### PR TITLE
Automatically Reschedule Cron Events

### DIFF
--- a/includes/class-convertkit-setup.php
+++ b/includes/class-convertkit-setup.php
@@ -23,17 +23,19 @@ class ConvertKit_Setup {
 	public function activate() {
 
 		// Call any functions to e.g. schedule WordPress Cron events now.
-		$posts = new ConvertKit_Resource_Posts( 'cron' );
-		$posts->schedule_cron_event();
+		$this->schedule_cron_events();
 
 	}
 
 	/**
-	 * Runs routines when the Plugin version has been updated.
+	 * Runs routines if the Plugin version has been updated.
 	 *
 	 * @since   1.9.7.4
 	 */
 	public function update() {
+
+		// Call any functions to always run every time the Plugin loads e.g. ensuring WordPress Cron events are scheduled.
+		$this->schedule_cron_events();
 
 		// Get installed Plugin version.
 		$current_version = get_option( 'convertkit_version' );
@@ -523,6 +525,29 @@ class ConvertKit_Setup {
 	public function deactivate() {
 
 		// Call any functions to e.g. unschedule WordPress Cron events now.
+		$this->unschedule_cron_events();
+
+	}
+
+	/**
+	 * Schedules any Plugin specific CRON events, if they do not already exist.
+	 * 
+	 * @since 	2.6.6
+	 */
+	private function schedule_cron_events() {
+
+		$posts = new ConvertKit_Resource_Posts( 'cron' );
+		$posts->schedule_cron_event();
+
+	}
+
+	/**
+	 * Unschedules any Plugin specific CRON events, if they exist.
+	 * 
+	 * @since 	2.6.6
+	 */
+	private function unschedule_cron_events() {
+		
 		$posts = new ConvertKit_Resource_Posts( 'cron' );
 		$posts->unschedule_cron_event();
 

--- a/includes/class-convertkit-setup.php
+++ b/includes/class-convertkit-setup.php
@@ -28,14 +28,24 @@ class ConvertKit_Setup {
 	}
 
 	/**
+	 * Runs routines on every Plugin request e.g.
+	 * ensuring WordPress Cron events are scheduled.
+	 *
+	 * @since   2.6.6
+	 */
+	public function initialize() {
+
+		// Call any functions to e.g. schedule WordPress Cron events now.
+		$this->schedule_cron_events();
+
+	}
+
+	/**
 	 * Runs routines if the Plugin version has been updated.
 	 *
 	 * @since   1.9.7.4
 	 */
 	public function update() {
-
-		// Call any functions to always run every time the Plugin loads e.g. ensuring WordPress Cron events are scheduled.
-		$this->schedule_cron_events();
 
 		// Get installed Plugin version.
 		$current_version = get_option( 'convertkit_version' );

--- a/includes/class-convertkit-setup.php
+++ b/includes/class-convertkit-setup.php
@@ -541,8 +541,8 @@ class ConvertKit_Setup {
 
 	/**
 	 * Schedules any Plugin specific CRON events, if they do not already exist.
-	 * 
-	 * @since 	2.6.6
+	 *
+	 * @since   2.6.6
 	 */
 	private function schedule_cron_events() {
 
@@ -553,11 +553,11 @@ class ConvertKit_Setup {
 
 	/**
 	 * Unschedules any Plugin specific CRON events, if they exist.
-	 * 
-	 * @since 	2.6.6
+	 *
+	 * @since   2.6.6
 	 */
 	private function unschedule_cron_events() {
-		
+
 		$posts = new ConvertKit_Resource_Posts( 'cron' );
 		$posts->unschedule_cron_event();
 

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -188,7 +188,7 @@ class WP_ConvertKit {
 		// Run the setup's update process on WordPress' init hook.
 		// Doing this sooner may result in errors with WordPress functions that are not yet
 		// available to the update routine.
-		add_action( 'init', array( $this, 'update' ) );
+		add_action( 'init', array( $this, 'init' ) );
 
 		/**
 		 * Initialize integration classes for the frontend web site.
@@ -200,14 +200,15 @@ class WP_ConvertKit {
 	}
 
 	/**
-	 * Runs the Plugin's update routine, which checks if
+	 * Runs the Plugin's initialization and update routines, which checks if
 	 * the Plugin has just been updated to a newer version,
 	 * and if so runs any specific processes that might be needed.
 	 *
 	 * @since   1.9.7.4
 	 */
-	public function update() {
+	public function init() {
 
+		$this->get_class( 'setup' )->initialize();
 		$this->get_class( 'setup' )->update();
 
 	}

--- a/tests/_support/Helper/Acceptance/WPCron.php
+++ b/tests/_support/Helper/Acceptance/WPCron.php
@@ -62,6 +62,31 @@ class WPCron extends \Codeception\Module
 	}
 
 	/**
+	 * Deletes the given event name using WordPress' Cron.
+	 *
+	 * Requires the WP-Crontrol Plugin to be installed and activated.
+	 *
+	 * @since   2.6.6
+	 *
+	 * @param   AcceptanceTester $I     AcceptanceTester.
+	 * @param   string           $name  Event Name.
+	 */
+	public function deleteCronEvent($I, $name)
+	{
+		// List cron event in WP-Crontrol Plugin.
+		$I->amOnAdminPage('tools.php?page=crontrol_admin_manage_page&s=' . $name);
+
+		// Hover mouse over event's name.
+		$I->moveMouseOver('#the-list tr');
+
+		// Delete the event.
+		$I->click('Delete');
+
+		// Confirm the event was deleted.
+		$I->see('Deleted the cron event ' . $name );
+	}
+
+	/**
 	 * Returns whether the given event name is scheduled in WordPress' Cron.
 	 *
 	 * @since   2.2.8

--- a/tests/acceptance/broadcasts/import-export/BroadcastsToPostsCest.php
+++ b/tests/acceptance/broadcasts/import-export/BroadcastsToPostsCest.php
@@ -59,9 +59,9 @@ class BroadcastsToPostsCest
 	/**
 	 * Tests that the Broadcasts to Posts Cron Event is recreated when it is deleted
 	 * by e.g. a third party Plugin.
-	 * 
-	 * @since 	2.6.6
-	 * 
+	 *
+	 * @since   2.6.6
+	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsCronEventRecreatedWhenDeleted(AcceptanceTester $I)

--- a/tests/acceptance/broadcasts/import-export/BroadcastsToPostsCest.php
+++ b/tests/acceptance/broadcasts/import-export/BroadcastsToPostsCest.php
@@ -57,6 +57,29 @@ class BroadcastsToPostsCest
 	}
 
 	/**
+	 * Tests that the Broadcasts to Posts Cron Event is recreated when it is deleted
+	 * by e.g. a third party Plugin.
+	 * 
+	 * @since 	2.6.6
+	 * 
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsCronEventRecreatedWhenDeleted(AcceptanceTester $I)
+	{
+		// Confirm Cron event exists.
+		$I->seeCronEvent($I, $this->cronEventName);
+
+		// Delete Cron event.
+		$I->deleteCronEvent($I, $this->cronEventName);
+
+		// Make a request.
+		$I->amOnAdminPage('edit.php');
+
+		// Confirm Cron event was recreated.
+		$I->seeCronEvent($I, $this->cronEventName);
+	}
+
+	/**
 	 * Tests that Broadcasts do not import when disabled in the Plugin's settings.
 	 *
 	 * @since   2.2.9
@@ -65,7 +88,7 @@ class BroadcastsToPostsCest
 	 */
 	public function testBroadcastsImportWhenDisabled(AcceptanceTester $I)
 	{
-		// Enable Broadcasts to Posts.
+		// Disable Broadcasts to Posts.
 		$I->setupConvertKitPluginBroadcasts(
 			$I,
 			[

--- a/tests/acceptance/broadcasts/import-export/BroadcastsToPostsCest.php
+++ b/tests/acceptance/broadcasts/import-export/BroadcastsToPostsCest.php
@@ -69,14 +69,25 @@ class BroadcastsToPostsCest
 		// Confirm Cron event exists.
 		$I->seeCronEvent($I, $this->cronEventName);
 
+		// Enable Broadcasts to Posts.
+		$I->setupConvertKitPluginBroadcasts(
+			$I,
+			[
+				'enabled' => true,
+			]
+		);
+
 		// Delete Cron event.
 		$I->deleteCronEvent($I, $this->cronEventName);
 
 		// Make a request.
-		$I->amOnAdminPage('edit.php');
+		$I->loadConvertKitSettingsBroadcastsScreen($I);
 
 		// Confirm Cron event was recreated.
 		$I->seeCronEvent($I, $this->cronEventName);
+
+		// Confirm Import Now button displays.
+		$I->see('Import now');
 	}
 
 	/**

--- a/tests/wpunit/ResourcePostsTest.php
+++ b/tests/wpunit/ResourcePostsTest.php
@@ -116,7 +116,7 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 
 		// Run the update action as WordPress would when updating the Plugin to a newer version.
 		$convertkit = WP_ConvertKit();
-		$convertkit->update();
+		$convertkit->init();
 
 		// Confirm the Plugin version number matches the current version.
 		$this->assertEquals(get_option('convertkit_version'), CONVERTKIT_PLUGIN_VERSION);

--- a/tests/wpunit/ResourcePostsTest.php
+++ b/tests/wpunit/ResourcePostsTest.php
@@ -129,6 +129,35 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
+	 * Test that the WordPress Cron event for this resource was reinstated with the expected name,
+	 * matching the expected schedule as defined in the Resource's class, when it is deleted
+	 * by e.g. a third party Plugin.
+	 *
+	 * @since   2.6.6
+	 */
+	public function testCronEventRecreatedAfterDeleted()
+	{
+		// Confirm the event was scheduled.
+		$this->assertEquals(
+			wp_get_schedule('convertkit_resource_refresh_' . $this->resource->type),
+			$this->resource->wp_cron_schedule
+		);
+
+		// Delete scheduled event.
+		$this->resource->unschedule_cron_event();
+
+		// Initialize Plugin, as if a request was made.
+		$convertkit = WP_ConvertKit();
+		$convertkit->init();
+
+		// Confirm event was scheduled.
+		$this->assertEquals(
+			wp_get_schedule('convertkit_resource_refresh_' . $this->resource->type),
+			$this->resource->wp_cron_schedule
+		);
+	}
+
+	/**
 	 * Test that the WordPress Cron event for this resource works when valid API credentials
 	 * are specified in the Plugin's settings.
 	 *


### PR DESCRIPTION
## Summary

Fixes the below reported issues, by ensuring that the Broadcast to Posts WordPress Cron Event exists, should it be deleted by a third party Plugin.

https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263836210039?view=List
https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263835305931?view=List
https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263835371174?view=List
https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263835396821?view=List

In turn, the 'Import Now' button will be displayed, and Broadcasts will import to WordPress Posts )if the functionality is enabled in the Plugin's settings).

## Testing

- `testBroadcastsCronEventRecreatedWhenDeleted`: Acceptance test to confirm the Cron event is recreated when deleted.
- `testCronEventRecreatedAfterDeleted`: Unit test to confirm Cron event is recreated when deleted.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)