### PR TITLE
Categories: Forms: Change 'Default' value from -1 to 0

### DIFF
--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -652,9 +652,15 @@ class ConvertKit_Output {
 			if ( $term_settings->has_form() ) {
 				return $term_settings->get_form();
 			}
+
+			// If the Term specifies that no Form should be used, return false.
+			if ( $term_settings->uses_no_form() ) {
+				return false;
+			}
 		}
 
-		// If here, use the Plugin's Default Form.
+		// If here, all Terms were set to display the Default Form.
+		// Therefore use the Plugin's Default Form.
 		return $this->settings->get_default_form( get_post_type( $post_id ) );
 
 	}

--- a/includes/class-convertkit-setup.php
+++ b/includes/class-convertkit-setup.php
@@ -161,8 +161,8 @@ class ConvertKit_Setup {
 		foreach ( $query->terms as $term_id ) {
 			$term_settings = new ConvertKit_Term( $term_id );
 
-			// If the Form setting is 0, change it to -1.
-			if ( $term_settings->get_form() === 0 ) {
+			// If the Form setting is Default i.e. it does not have a formchange it from 0 to -1.
+			if ( ! $term_settings->has_form() ) {
 				$term_settings->save(
 					array(
 						'form' => -1,

--- a/includes/class-convertkit-term.php
+++ b/includes/class-convertkit-term.php
@@ -154,7 +154,7 @@ class ConvertKit_Term {
 		$result = update_term_meta( $this->term_id, self::TERM_META_KEY, array_merge( $this->get(), $meta ) );
 
 		// Reload meta in class, to reflect changes.
-		$this->settings = get_term_meta( $term_id, self::TERM_META_KEY, true );
+		$this->settings = get_term_meta( $this->term_id, self::TERM_META_KEY, true );
 
 		return $result;
 

--- a/includes/class-convertkit-term.php
+++ b/includes/class-convertkit-term.php
@@ -101,6 +101,19 @@ class ConvertKit_Term {
 	}
 
 	/**
+	 * Whether the Term is set to use the Plugin's Default Form Setting.
+	 *
+	 * @since   2.6.6
+	 *
+	 * @return  bool
+	 */
+	public function uses_default_form() {
+
+		return ( $this->settings['form'] === -1 );
+
+	}
+
+	/**
 	 * Returns the form position setting for the Term
 	 * on the Term archive.
 	 *
@@ -138,7 +151,12 @@ class ConvertKit_Term {
 	 */
 	public function save( $meta ) {
 
-		return update_term_meta( $this->term_id, self::TERM_META_KEY, $meta );
+		$result = update_term_meta( $this->term_id, self::TERM_META_KEY, array_merge( $this->get(), $meta ) );
+
+		// Reload meta in class, to reflect changes.
+		$this->settings = get_term_meta( $term_id, self::TERM_META_KEY, true );
+
+		return $result;
 
 	}
 

--- a/includes/class-convertkit-term.php
+++ b/includes/class-convertkit-term.php
@@ -114,6 +114,19 @@ class ConvertKit_Term {
 	}
 
 	/**
+	 * Whether the Post's Form setting is set to 'None'
+	 *
+	 * @since   2.6.6
+	 *
+	 * @return  bool
+	 */
+	public function uses_no_form() {
+
+		return ( $this->settings['form'] === 0 );
+
+	}
+
+	/**
 	 * Returns the form position setting for the Term
 	 * on the Term archive.
 	 *

--- a/tests/acceptance/forms/general/CategoryFormCest.php
+++ b/tests/acceptance/forms/general/CategoryFormCest.php
@@ -573,9 +573,9 @@ class CategoryFormCest
 			[
 				'meta' => [
 					'_wp_convertkit_term_meta' => array(
-						'form' => 0,
+						'form'          => 0,
 						'form_position' => '',
-					)
+					),
 				],
 			]
 		);

--- a/tests/acceptance/forms/general/CategoryFormCest.php
+++ b/tests/acceptance/forms/general/CategoryFormCest.php
@@ -48,6 +48,7 @@ class CategoryFormCest
 			'#wp-convertkit-form',
 			[
 				'Default',
+				'None',
 			]
 		);
 
@@ -80,6 +81,67 @@ class CategoryFormCest
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
 		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
+	}
+
+	/**
+	 * Test that no Form is displayed when the user:
+	 * - Creates a Category in WordPress, selecting 'None' as the ConvertKit Form to display,
+	 * - Creates a WordPress Post assigned to the created Category.
+	 *
+	 * @since   2.6.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddCategoryWithNoneFormSetting(AcceptanceTester $I)
+	{
+		// Navigate to Posts > Categories.
+		$I->amOnAdminPage('edit-tags.php?taxonomy=category');
+
+		// Confirm that settings have label[for] attributes.
+		$I->seeInSource('<label for="wp-convertkit-form">');
+
+		// Create Category.
+		$I->fillField('tag-name', 'Kit: Create Category: None');
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None');
+
+		// Check the order of the Form resources are alphabetical, with the Default option prepending the Forms.
+		$I->checkSelectFormOptionOrder(
+			$I,
+			'#wp-convertkit-form',
+			[
+				'Default',
+				'None',
+			]
+		);
+
+		// Save.
+		$I->click('Add New Category');
+
+		// Confirm Category saved.
+		$I->waitForElementVisible('.notice-success');
+
+		// Get the Category ID from the table.
+		$termID = (int) str_replace( 'tag-', '', $I->grabAttributeFrom('#the-list tr:first-child', 'id') );
+
+		// Create Post, assigned to ConvertKit Category.
+		$postID = $I->havePostInDatabase(
+			[
+				'post_type'  => 'post',
+				'post_title' => 'Kit: Inherit None Form from Add Category',
+				'tax_input'  => [
+					[ 'category' => (int) $termID ],
+				],
+			]
+		);
+
+		// Load the Post on the frontend site.
+		$I->amOnPage('/?p=' . $postID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that no ConvertKit Form is displayed.
+		$I->dontSeeElementInDOM('form[data-sv-form]');
 	}
 
 	/**
@@ -123,6 +185,7 @@ class CategoryFormCest
 			'#wp-convertkit-form',
 			[
 				'Default',
+				'None',
 			]
 		);
 
@@ -150,6 +213,76 @@ class CategoryFormCest
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
 		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
+	}
+
+	/**
+	 * Test that no Form is displayed when the user:
+	 * - Edits an existing Category in WordPress, selecting the 'None' ConvertKit Form option,
+	 * - Creates a WordPress Post assigned to the edited Category.
+	 *
+	 * @since   2.6.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testEditCategoryWithNoneFormSetting(AcceptanceTester $I)
+	{
+		// Create Category.
+		$termID = $I->haveTermInDatabase( 'Kit: Edit Category: None', 'category' );
+		$termID = $termID[0];
+
+		// Create Post, assigned to ConvertKit Category.
+		$postID = $I->havePostInDatabase(
+			[
+				'post_type'  => 'post',
+				'post_title' => 'Kit: Inherit No Form from Edit Category',
+				'tax_input'  => [
+					[ 'category' => (int) $termID ],
+				],
+			]
+		);
+
+		// Edit the Term, defining a Form.
+		$I->amOnAdminPage('term.php?taxonomy=category&tag_ID=' . $termID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that settings have label[for] attributes.
+		$I->seeInSource('<label for="wp-convertkit-form">');
+
+		// Check the order of the Form resources are alphabetical, with the Default option prepending the Forms.
+		$I->checkSelectFormOptionOrder(
+			$I,
+			'#wp-convertkit-form',
+			[
+				'Default',
+				'None',
+			]
+		);
+
+		// Change Form to None.
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None');
+
+		// Click Update.
+		$I->click('Update');
+
+		// Wait for the page to load.
+		$I->waitForElementVisible('#wpfooter');
+
+		// Check that the update succeeded.
+		$I->seeElementInDOM('div.notice-success');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Load the Post on the frontend site.
+		$I->amOnPage('/?p=' . $postID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that no ConvertKit Form is displayed.
+		$I->dontSeeElementInDOM('form[data-sv-form]');
 	}
 
 	/**
@@ -310,6 +443,7 @@ class CategoryFormCest
 			'#wp-convertkit-form',
 			[
 				'Default',
+				'None',
 			]
 		);
 
@@ -390,6 +524,7 @@ class CategoryFormCest
 			'#wp-convertkit-form',
 			[
 				'Default',
+				'None',
 			]
 		);
 

--- a/tests/acceptance/forms/general/CategoryFormCest.php
+++ b/tests/acceptance/forms/general/CategoryFormCest.php
@@ -486,14 +486,14 @@ class CategoryFormCest
 	}
 
 	/**
-	 * Tests that existing Category settings stored in the Term Meta key [] are
-	 * automatically migrated when updating the Plugin to 2.4.9.1 or higher.
+	 * Tests that existing Category settings stored in the Term Meta key `ck_default_form` are
+	 * automatically migrated to the new key `_wp_convertkit_term_meta` when updating the Plugin to 2.4.9.1 or higher.
 	 *
 	 * @since   2.4.9.1
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testCategorySettingsMigratedOnUpgrade(AcceptanceTester $I)
+	public function testCategorySettingsMigratedToNewTermKeyOnUpgrade(AcceptanceTester $I)
 	{
 		// Create Category as if it were created / edited when the ConvertKit Plugin < 2.4.9.1
 		// was active.
@@ -550,6 +550,73 @@ class CategoryFormCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that one ConvertKit Form is output in the DOM.
+		// This confirms that there is only one script on the page for this form, which renders the form,
+		// and that the Category settings were correctly mapped.
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
+	}
+
+	/**
+	 * Tests that existing Category settings set to 'Default' have their values automatically migrated
+	 * from 0 to -1, to match how Post settings are stored, when updating the Plugin to 2.6.6 or higher.
+	 *
+	 * @since   2.6.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testCategoryDefaultSettingsMigratedToNewValueOnUpgrade(AcceptanceTester $I)
+	{
+		// Create Category as if it were created / edited when the ConvertKit Plugin < 2.6.6
+		// was active.
+		$termID = $I->haveTermInDatabase(
+			'Kit 2.6.6 and earlier',
+			'category',
+			[
+				'meta' => [
+					'_wp_convertkit_term_meta' => array(
+						'form' => 0,
+						'form_position' => '',
+					)
+				],
+			]
+		);
+		$termID = $termID[0];
+
+		// Create Post, assigned to Category.
+		$postID = $I->havePostInDatabase(
+			[
+				'post_type'  => 'post',
+				'post_title' => 'Kit: Default Form: Category Created before 2.6.6',
+				'tax_input'  => [
+					[ 'category' => $termID ],
+				],
+			]
+		);
+
+		// Downgrade the Plugin version to simulate an upgrade.
+		$I->haveOptionInDatabase('convertkit_version', '2.6.5');
+
+		// Load admin screen.
+		$I->amOnAdminPage('index.php');
+
+		// Check Category settings structure has been updated to the new meta key.
+		$I->seeTermMetaInDatabase(
+			[
+				'term_id'    => $termID,
+				'meta_key'   => '_wp_convertkit_term_meta',
+				'meta_value' => [
+					'form'          => -1,
+					'form_position' => '',
+				],
+			]
+		);
+
+		// Load the Post on the frontend site.
+		$I->amOnPage('/?p=' . $postID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the default ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form,
 		// and that the Category settings were correctly mapped.
 		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);

--- a/tests/acceptance/general/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/general/RefreshResourcesButtonCest.php
@@ -300,6 +300,7 @@ class RefreshResourcesButtonCest
 			'#wp-convertkit-form',
 			[
 				'Default',
+				'None',
 			]
 		);
 
@@ -339,6 +340,7 @@ class RefreshResourcesButtonCest
 			'#wp-convertkit-form',
 			[
 				'Default',
+				'None',
 			]
 		);
 

--- a/views/backend/term/fields-add.php
+++ b/views/backend/term/fields-add.php
@@ -21,6 +21,7 @@
 			'-1',
 			array(
 				'-1' => esc_html__( 'Default', 'convertkit' ),
+				'0'  => esc_html__( 'None', 'convertkit' ),
 			)
 		);
 		?>
@@ -32,6 +33,9 @@
 			<code><?php esc_html_e( 'Default', 'convertkit' ); ?></code>
 			<?php esc_html_e( ': Display a form based on the Post\'s settings.', 'convertkit' ); ?>
 			<br />
+				<code><?php esc_html_e( 'None', 'convertkit' ); ?></code>
+				<?php esc_html_e( ': do not display a form.', 'convertkit' ); ?>
+				<br />
 			<?php
 			printf(
 				/* translators: Taxonomy Name */

--- a/views/backend/term/fields-add.php
+++ b/views/backend/term/fields-add.php
@@ -18,9 +18,9 @@
 			array(
 				'convertkit-select2',
 			),
-			'0',
+			'-1',
 			array(
-				'0' => esc_html__( 'Default', 'convertkit' ),
+				'-1' => esc_html__( 'Default', 'convertkit' ),
 			)
 		);
 		?>

--- a/views/backend/term/fields-edit.php
+++ b/views/backend/term/fields-edit.php
@@ -23,6 +23,7 @@
 				esc_attr( $convertkit_term->get_form() ),
 				array(
 					'-1' => esc_html__( 'Default', 'convertkit' ),
+					'0'  => esc_html__( 'None', 'convertkit' ),
 				)
 			);
 			?>
@@ -33,6 +34,9 @@
 			<p class="description">
 				<code><?php esc_html_e( 'Default', 'convertkit' ); ?></code>
 				<?php esc_html_e( ': Display a form based on the Post\'s settings.', 'convertkit' ); ?>
+				<br />
+				<code><?php esc_html_e( 'None', 'convertkit' ); ?></code>
+				<?php esc_html_e( ': do not display a form.', 'convertkit' ); ?>
 				<br />
 				<?php
 				printf(

--- a/views/backend/term/fields-edit.php
+++ b/views/backend/term/fields-edit.php
@@ -22,7 +22,7 @@
 				),
 				esc_attr( $convertkit_term->get_form() ),
 				array(
-					'0' => esc_html__( 'Default', 'convertkit' ),
+					'-1' => esc_html__( 'Default', 'convertkit' ),
 				)
 			);
 			?>

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -9,7 +9,7 @@
  * Plugin Name: Kit (formerly ConvertKit)
  * Plugin URI: https://kit.com/
  * Description: Display Kit (formerly ConvertKit) email subscription forms, landing pages, products, broadcasts and more.
- * Version: 2.6.5
+ * Version: 2.6.6
  * Author: Kit
  * Author URI: https://kit.com/
  * Text Domain: convertkit
@@ -25,7 +25,7 @@ define( 'CONVERTKIT_PLUGIN_NAME', 'ConvertKit' ); // Used for user-agent in API 
 define( 'CONVERTKIT_PLUGIN_FILE', plugin_basename( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_PATH', __DIR__ );
-define( 'CONVERTKIT_PLUGIN_VERSION', '2.6.5' );
+define( 'CONVERTKIT_PLUGIN_VERSION', '2.6.6' );
 define( 'CONVERTKIT_OAUTH_CLIENT_ID', 'HXZlOCj-K5r0ufuWCtyoyo3f688VmMAYSsKg1eGvw0Y' );
 define( 'CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI', 'https://app.kit.com/wordpress/redirect' );
 


### PR DESCRIPTION
## Summary

When defining the Form setting on Pages or Posts, key/value pairs have always been:

| Value  | Setting Label |
| ------------- | ------------- |
| -1  | Default (i.e. inherit from Plugin Settings)  |
| 0  | None (i.e. don't display a Form)  |
| Form ID (integer)  | Form Names (i.e. display the specified Form) |

When defining the Form setting on a Category, key/value pairs were:

| Value  | Setting Label |
| ------------- | ------------- |
| default  | None  |
| Form ID (integer)  | Form Names (i.e. display the specified Form) |

The 'None' label was misleading, because selecting this choice would display the Form specified at Post or Plugin level.  [This PR](https://github.com/ConvertKit/convertkit-wordpress/pull/295) changed the Form setting value and its label on a Category to better reflect this:

| Value  | Setting Label |
| ------------- | ------------- |
| **0**  | **Default (i.e. inherit from Post Settings)**  |
| Form ID (integer)  | Form Names (i.e. display the specified Form) |

However, this still isn't in line with Form settings on Pages and Posts, where Default is `-1`.

This PR resolves by matching the Category Form settings with the Post Form settings:

| Value  | Setting Label |
| ------------- | ------------- |
| -1  | **Default (i.e. inherit from Post Settings)**  |
| Form ID (integer)  | Form Names (i.e. display the specified Form) |

Automatic upgrade routines are included to change existing Category settings to reflect this underlying change.

## Testing

- `testCategoryDefaultSettingsMigratedToNewValueOnUpgrade`: Test that Category Form Settings = Default have their underlying value changed from `0` to `-1`

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)