### PR TITLE
Categories: Forms: Add `None` Option

### DIFF
--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -652,9 +652,15 @@ class ConvertKit_Output {
 			if ( $term_settings->has_form() ) {
 				return $term_settings->get_form();
 			}
+
+			// If the Term specifies that no Form should be used, return false.
+			if ( $term_settings->uses_no_form() ) {
+				return false;
+			}
 		}
 
-		// If here, use the Plugin's Default Form.
+		// If here, all Terms were set to display the Default Form.
+		// Therefore use the Plugin's Default Form.
 		return $this->settings->get_default_form( get_post_type( $post_id ) );
 
 	}

--- a/includes/class-convertkit-term.php
+++ b/includes/class-convertkit-term.php
@@ -114,6 +114,19 @@ class ConvertKit_Term {
 	}
 
 	/**
+	 * Whether the Post's Form setting is set to 'None'
+	 *
+	 * @since   2.6.6
+	 *
+	 * @return  bool
+	 */
+	public function uses_no_form() {
+
+		return ( $this->settings['form'] === 0 );
+
+	}
+
+	/**
 	 * Returns the form position setting for the Term
 	 * on the Term archive.
 	 *

--- a/tests/acceptance/forms/general/CategoryFormCest.php
+++ b/tests/acceptance/forms/general/CategoryFormCest.php
@@ -48,6 +48,7 @@ class CategoryFormCest
 			'#wp-convertkit-form',
 			[
 				'Default',
+				'None',
 			]
 		);
 
@@ -184,6 +185,7 @@ class CategoryFormCest
 			'#wp-convertkit-form',
 			[
 				'Default',
+				'None',
 			]
 		);
 
@@ -441,6 +443,7 @@ class CategoryFormCest
 			'#wp-convertkit-form',
 			[
 				'Default',
+				'None',
 			]
 		);
 
@@ -521,6 +524,7 @@ class CategoryFormCest
 			'#wp-convertkit-form',
 			[
 				'Default',
+				'None',
 			]
 		);
 

--- a/tests/acceptance/forms/general/CategoryFormCest.php
+++ b/tests/acceptance/forms/general/CategoryFormCest.php
@@ -83,6 +83,67 @@ class CategoryFormCest
 	}
 
 	/**
+	 * Test that no Form is displayed when the user:
+	 * - Creates a Category in WordPress, selecting 'None' as the ConvertKit Form to display,
+	 * - Creates a WordPress Post assigned to the created Category.
+	 *
+	 * @since   2.6.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddCategoryWithNoFormSetting(AcceptanceTester $I)
+	{
+		// Navigate to Posts > Categories.
+		$I->amOnAdminPage('edit-tags.php?taxonomy=category');
+
+		// Confirm that settings have label[for] attributes.
+		$I->seeInSource('<label for="wp-convertkit-form">');
+
+		// Create Category.
+		$I->fillField('tag-name', 'Kit: Create Category: None');
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None');
+
+		// Check the order of the Form resources are alphabetical, with the Default option prepending the Forms.
+		$I->checkSelectFormOptionOrder(
+			$I,
+			'#wp-convertkit-form',
+			[
+				'Default',
+				'None',
+			]
+		);
+
+		// Save.
+		$I->click('Add New Category');
+
+		// Confirm Category saved.
+		$I->waitForElementVisible('.notice-success');
+
+		// Get the Category ID from the table.
+		$termID = (int) str_replace( 'tag-', '', $I->grabAttributeFrom('#the-list tr:first-child', 'id') );
+
+		// Create Post, assigned to ConvertKit Category.
+		$postID = $I->havePostInDatabase(
+			[
+				'post_type'  => 'post',
+				'post_title' => 'Kit: Inherit None Form from Add Category',
+				'tax_input'  => [
+					[ 'category' => (int) $termID ],
+				],
+			]
+		);
+
+		// Load the Post on the frontend site.
+		$I->amOnPage('/?p=' . $postID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that no ConvertKit Form is displayed.
+		$I->dontSeeElementInDOM('form[data-sv-form]');
+	}
+
+	/**
 	 * Test that the expected Form is displayed when the user:
 	 * - Edits an existing Category in WordPress, selecting the ConvertKit Form to display,
 	 * - Creates a WordPress Post assigned to the edited Category.
@@ -150,6 +211,76 @@ class CategoryFormCest
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
 		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
+	}
+
+	/**
+	 * Test that no Form is displayed when the user:
+	 * - Edits an existing Category in WordPress, selecting the 'None' ConvertKit Form option,
+	 * - Creates a WordPress Post assigned to the edited Category.
+	 *
+	 * @since   2.6.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testEditCategoryWithNoFormSetting(AcceptanceTester $I)
+	{
+		// Create Category.
+		$termID = $I->haveTermInDatabase( 'Kit: Edit Category: None', 'category' );
+		$termID = $termID[0];
+
+		// Create Post, assigned to ConvertKit Category.
+		$postID = $I->havePostInDatabase(
+			[
+				'post_type'  => 'post',
+				'post_title' => 'Kit: Inherit No Form from Edit Category',
+				'tax_input'  => [
+					[ 'category' => (int) $termID ],
+				],
+			]
+		);
+
+		// Edit the Term, defining a Form.
+		$I->amOnAdminPage('term.php?taxonomy=category&tag_ID=' . $termID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that settings have label[for] attributes.
+		$I->seeInSource('<label for="wp-convertkit-form">');
+
+		// Check the order of the Form resources are alphabetical, with the Default option prepending the Forms.
+		$I->checkSelectFormOptionOrder(
+			$I,
+			'#wp-convertkit-form',
+			[
+				'Default',
+				'None',
+			]
+		);
+
+		// Change Form to None.
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None');
+
+		// Click Update.
+		$I->click('Update');
+
+		// Wait for the page to load.
+		$I->waitForElementVisible('#wpfooter');
+
+		// Check that the update succeeded.
+		$I->seeElementInDOM('div.notice-success');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Load the Post on the frontend site.
+		$I->amOnPage('/?p=' . $postID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that no ConvertKit Form is displayed.
+		$I->dontSeeElementInDOM('form[data-sv-form]');
 	}
 
 	/**

--- a/tests/acceptance/forms/general/CategoryFormCest.php
+++ b/tests/acceptance/forms/general/CategoryFormCest.php
@@ -91,7 +91,7 @@ class CategoryFormCest
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testAddCategoryWithNoFormSetting(AcceptanceTester $I)
+	public function testAddCategoryWithNoneFormSetting(AcceptanceTester $I)
 	{
 		// Navigate to Posts > Categories.
 		$I->amOnAdminPage('edit-tags.php?taxonomy=category');
@@ -222,7 +222,7 @@ class CategoryFormCest
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testEditCategoryWithNoFormSetting(AcceptanceTester $I)
+	public function testEditCategoryWithNoneFormSetting(AcceptanceTester $I)
 	{
 		// Create Category.
 		$termID = $I->haveTermInDatabase( 'Kit: Edit Category: None', 'category' );

--- a/tests/acceptance/general/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/general/RefreshResourcesButtonCest.php
@@ -300,6 +300,7 @@ class RefreshResourcesButtonCest
 			'#wp-convertkit-form',
 			[
 				'Default',
+				'None',
 			]
 		);
 
@@ -339,6 +340,7 @@ class RefreshResourcesButtonCest
 			'#wp-convertkit-form',
 			[
 				'Default',
+				'None',
 			]
 		);
 

--- a/views/backend/term/fields-add.php
+++ b/views/backend/term/fields-add.php
@@ -21,7 +21,7 @@
 			'-1',
 			array(
 				'-1' => esc_html__( 'Default', 'convertkit' ),
-				'0' => esc_html__( 'None', 'convertkit' ),
+				'0'  => esc_html__( 'None', 'convertkit' ),
 			)
 		);
 		?>

--- a/views/backend/term/fields-add.php
+++ b/views/backend/term/fields-add.php
@@ -21,6 +21,7 @@
 			'-1',
 			array(
 				'-1' => esc_html__( 'Default', 'convertkit' ),
+				'0' => esc_html__( 'None', 'convertkit' ),
 			)
 		);
 		?>
@@ -32,6 +33,9 @@
 			<code><?php esc_html_e( 'Default', 'convertkit' ); ?></code>
 			<?php esc_html_e( ': Display a form based on the Post\'s settings.', 'convertkit' ); ?>
 			<br />
+				<code><?php esc_html_e( 'None', 'convertkit' ); ?></code>
+				<?php esc_html_e( ': do not display a form.', 'convertkit' ); ?>
+				<br />
 			<?php
 			printf(
 				/* translators: Taxonomy Name */

--- a/views/backend/term/fields-edit.php
+++ b/views/backend/term/fields-edit.php
@@ -23,7 +23,7 @@
 				esc_attr( $convertkit_term->get_form() ),
 				array(
 					'-1' => esc_html__( 'Default', 'convertkit' ),
-					'0' => esc_html__( 'None', 'convertkit' ),
+					'0'  => esc_html__( 'None', 'convertkit' ),
 				)
 			);
 			?>

--- a/views/backend/term/fields-edit.php
+++ b/views/backend/term/fields-edit.php
@@ -23,6 +23,7 @@
 				esc_attr( $convertkit_term->get_form() ),
 				array(
 					'-1' => esc_html__( 'Default', 'convertkit' ),
+					'0' => esc_html__( 'None', 'convertkit' ),
 				)
 			);
 			?>
@@ -33,6 +34,9 @@
 			<p class="description">
 				<code><?php esc_html_e( 'Default', 'convertkit' ); ?></code>
 				<?php esc_html_e( ': Display a form based on the Post\'s settings.', 'convertkit' ); ?>
+				<br />
+				<code><?php esc_html_e( 'None', 'convertkit' ); ?></code>
+				<?php esc_html_e( ': do not display a form.', 'convertkit' ); ?>
 				<br />
 				<?php
 				printf(


### PR DESCRIPTION
## Summary

Adds a `None` option [as requested here](https://n7studios-workspace.slack.com/archives/C02KFR6N1GF/p1732020639109099), matching how Post and Plugin level settings operate, to not display a Form should a Post be assigned to the given Category.

<img width="791" alt="Screenshot 2024-11-21 at 09 38 23" src="https://github.com/user-attachments/assets/4f777784-da4b-47ec-b0f6-3bb470bb4ea3">

## Testing

- `testAddCategoryWithNoneFormSetting`: Test that adding a Category with the Form setting = `None` results in no Form being displayed when viewing a Post.
- `testEditCategoryWithNoneFormSetting`: Test that editing a Category with the Form setting = `None` results in no Form being displayed when viewing a Post.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)