### PR TITLE
Tests: Update WP Crontrol URL for 1.17.1

### DIFF
--- a/tests/_support/Helper/Acceptance/WPCron.php
+++ b/tests/_support/Helper/Acceptance/WPCron.php
@@ -10,6 +10,15 @@ namespace Helper\Acceptance;
 class WPCron extends \Codeception\Module
 {
 	/**
+	 * Holds the admin UI URL for WP Crontrol.
+	 *
+	 * @since   2.6.6
+	 *
+	 * @var     string
+	 */
+	private $adminURL = 'tools.php?page=wp-crontrol';
+
+	/**
 	 * Asserts if the given event name is scheduled in WordPress' Cron.
 	 *
 	 * @since   2.2.8
@@ -49,7 +58,7 @@ class WPCron extends \Codeception\Module
 	public function runCronEvent($I, $name)
 	{
 		// List cron event in WP-Crontrol Plugin.
-		$I->amOnAdminPage('tools.php?page=crontrol_admin_manage_page&s=' . $name);
+		$I->amOnAdminPage($this->adminURL . '&s=' . $name);
 
 		// Hover mouse over event's name.
 		$I->moveMouseOver('#the-list tr');
@@ -74,7 +83,7 @@ class WPCron extends \Codeception\Module
 	public function deleteCronEvent($I, $name)
 	{
 		// List cron event in WP-Crontrol Plugin.
-		$I->amOnAdminPage('tools.php?page=crontrol_admin_manage_page&s=' . $name);
+		$I->amOnAdminPage($this->adminURL . '&s=' . $name);
 
 		// Hover mouse over event's name.
 		$I->moveMouseOver('#the-list tr');


### PR DESCRIPTION
## Summary

Fixes cron tests failing due to a change in the admin UI URL in [WP Crontrol 1.17.1](https://wordpress.org/plugins/wp-crontrol/), released November 23rd. 

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)