### PR TITLE
Tests: Fix `_load_textdomain_just_in_time` PHP Notice

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,7 +142,7 @@ jobs:
       # party Plugins.
       - name: Activate "Disable `_load_textdomain_just_in_time` `doing_it_wrong` notice Plugin"
         working-directory: ${{ env.ROOT_DIR }}
-        run: wp-cli-list && wp-cli plugin listwp-cli plugin activate disable-doing-it-wrong-notices
+        run: wp-cli plugin list && wp-cli plugin activate disable-doing-it-wrong-notices
 
       # These should be stored as a separated list of URLs in the repository Settings > Secrets > Repository Secret > CONVERTKIT_PAID_PLUGIN_URLS.
       # We cannot include the URLs in this file, as they're not Plugins we are permitted to distribute.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,13 +137,6 @@ jobs:
         working-directory: ${{ env.ROOT_DIR }}
         run: wp-cli plugin install ${{ env.INSTALL_PLUGINS_URLS }}
 
-      # Activates the Disable `_load_textdomain_just_in_time` `doing_it_wrong` notice Plugin,
-      # to prevent _load_textdomain_just_in_time PHP notices in WordPress 6.7+ due to third
-      # party Plugins.
-      - name: Activate "Disable `_load_textdomain_just_in_time` `doing_it_wrong` notice Plugin"
-        working-directory: ${{ env.ROOT_DIR }}
-        run: wp-cli plugin list && wp-cli plugin activate disable-doing-it-wrong-notices
-
       # These should be stored as a separated list of URLs in the repository Settings > Secrets > Repository Secret > CONVERTKIT_PAID_PLUGIN_URLS.
       # We cannot include the URLs in this file, as they're not Plugins we are permitted to distribute.
       - name: Install Paid Third Party WordPress Plugins

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,6 +137,13 @@ jobs:
         working-directory: ${{ env.ROOT_DIR }}
         run: wp-cli plugin install ${{ env.INSTALL_PLUGINS_URLS }}
 
+      # Activates the Disable `_load_textdomain_just_in_time` `doing_it_wrong` notice Plugin,
+      # to prevent _load_textdomain_just_in_time PHP notices in WordPress 6.7+ due to third
+      # party Plugins.
+      - name: Activate "Disable `_load_textdomain_just_in_time` `doing_it_wrong` notice Plugin"
+        working-directory: ${{ env.ROOT_DIR }}
+        run: wp-cli plugin activate disable-doing-it-wrong-notices.php
+
       # These should be stored as a separated list of URLs in the repository Settings > Secrets > Repository Secret > CONVERTKIT_PAID_PLUGIN_URLS.
       # We cannot include the URLs in this file, as they're not Plugins we are permitted to distribute.
       - name: Install Paid Third Party WordPress Plugins

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,7 +142,7 @@ jobs:
       # party Plugins.
       - name: Activate "Disable `_load_textdomain_just_in_time` `doing_it_wrong` notice Plugin"
         working-directory: ${{ env.ROOT_DIR }}
-        run: wp-cli plugin activate disable-doing-it-wrong-notices
+        run: wp-cli-list && wp-cli plugin listwp-cli plugin activate disable-doing-it-wrong-notices
 
       # These should be stored as a separated list of URLs in the repository Settings > Secrets > Repository Secret > CONVERTKIT_PAID_PLUGIN_URLS.
       # We cannot include the URLs in this file, as they're not Plugins we are permitted to distribute.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       DB_USER: root
       DB_PASS: root
       DB_HOST: localhost
-      INSTALL_PLUGINS: "admin-menu-editor autoptimize beaver-builder-lite-version contact-form-7 classic-editor custom-post-type-ui elementor forminator jetpack-boost woocommerce wordpress-seo wpforms-lite litespeed-cache wp-crontrol wp-super-cache w3-total-cache wp-fastest-cache wp-optimize sg-cachepress" # Don't include this repository's Plugin here.
+      INSTALL_PLUGINS: "admin-menu-editor autoptimize beaver-builder-lite-version block-visibility contact-form-7 classic-editor custom-post-type-ui elementor forminator jetpack-boost woocommerce wordpress-seo wpforms-lite litespeed-cache wp-crontrol wp-super-cache w3-total-cache wp-fastest-cache wp-optimize sg-cachepress" # Don't include this repository's Plugin here.
       INSTALL_PLUGINS_URLS: "https://downloads.wordpress.org/plugin/convertkit-for-woocommerce.1.6.4.zip http://cktestplugins.wpengine.com/wp-content/uploads/2024/01/convertkit-action-filter-tests.zip http://cktestplugins.wpengine.com/wp-content/uploads/2024/11/disable-doing-it-wrong-notices.zip" # URLs to specific third party Plugins
       CONVERTKIT_API_KEY: ${{ secrets.CONVERTKIT_API_KEY }} # ConvertKit API Key, stored in the repository's Settings > Secrets
       CONVERTKIT_API_SECRET: ${{ secrets.CONVERTKIT_API_SECRET }} # ConvertKit API Secret, stored in the repository's Settings > Secrets

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
       DB_PASS: root
       DB_HOST: localhost
       INSTALL_PLUGINS: "admin-menu-editor autoptimize beaver-builder-lite-version contact-form-7 classic-editor custom-post-type-ui elementor forminator jetpack-boost woocommerce wordpress-seo wpforms-lite litespeed-cache wp-crontrol wp-super-cache w3-total-cache wp-fastest-cache wp-optimize sg-cachepress" # Don't include this repository's Plugin here.
-      INSTALL_PLUGINS_URLS: "https://downloads.wordpress.org/plugin/convertkit-for-woocommerce.1.6.4.zip http://cktestplugins.wpengine.com/wp-content/uploads/2024/01/convertkit-action-filter-tests.zip" # URLs to specific third party Plugins
+      INSTALL_PLUGINS_URLS: "https://downloads.wordpress.org/plugin/convertkit-for-woocommerce.1.6.4.zip http://cktestplugins.wpengine.com/wp-content/uploads/2024/01/convertkit-action-filter-tests.zip http://cktestplugins.wpengine.com/wp-content/uploads/2024/11/disable-doing-it-wrong-notices.zip" # URLs to specific third party Plugins
       CONVERTKIT_API_KEY: ${{ secrets.CONVERTKIT_API_KEY }} # ConvertKit API Key, stored in the repository's Settings > Secrets
       CONVERTKIT_API_SECRET: ${{ secrets.CONVERTKIT_API_SECRET }} # ConvertKit API Secret, stored in the repository's Settings > Secrets
       CONVERTKIT_API_KEY_NO_DATA: ${{ secrets.CONVERTKIT_API_KEY_NO_DATA }} # ConvertKit API Key for ConvertKit account with no data, stored in the repository's Settings > Secrets

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,7 +142,7 @@ jobs:
       # party Plugins.
       - name: Activate "Disable `_load_textdomain_just_in_time` `doing_it_wrong` notice Plugin"
         working-directory: ${{ env.ROOT_DIR }}
-        run: wp-cli plugin activate disable-doing-it-wrong-notices.php
+        run: wp-cli plugin activate disable-doing-it-wrong-notices
 
       # These should be stored as a separated list of URLs in the repository Settings > Secrets > Repository Secret > CONVERTKIT_PAID_PLUGIN_URLS.
       # We cannot include the URLs in this file, as they're not Plugins we are permitted to distribute.

--- a/includes/blocks/class-convertkit-block-form.php
+++ b/includes/blocks/class-convertkit-block-form.php
@@ -290,6 +290,13 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 	 */
 	public function render( $atts ) {
 
+		// Check if the Block Visibility Plugin permits displaying this block.
+		if ( ! $this->is_block_visible( $atts ) ) {
+			// Block should not be displayed due to Block Visibility Plugin conditions.
+			// Return a blank string now.
+			return '';
+		}
+
 		// Parse shortcode attributes, defining fallback defaults if required.
 		$atts = shortcode_atts(
 			$this->get_default_values(),

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -391,6 +391,15 @@ class ConvertKit_Output {
 	 */
 	private function inject_form_after_element( $content, $tag, $index, $form ) {
 
+		// Wrap content in <html>, <head> and <body> tags now, so we can inject the UTF-8 Content-Type meta tag.
+		$content = '<html><head></head><body>' . $content . '</body></html>';
+
+		// Forcibly tell DOMDocument that this HTML uses the UTF-8 charset.
+		// <meta charset="utf-8"> isn't enough, as DOMDocument still interprets the HTML as ISO-8859, which breaks character encoding
+		// Use of mb_convert_encoding() with HTML-ENTITIES is deprecated in PHP 8.2, so we have to use this method.
+		// If we don't, special characters render incorrectly.
+		$content = str_replace( '<head>', '<head>' . "\n" . '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">', $content );
+
 		// Load Page / Post content into DOMDocument.
 		libxml_use_internal_errors( true );
 		$html = new DOMDocument();

--- a/tests/_support/Helper/Acceptance/WPCron.php
+++ b/tests/_support/Helper/Acceptance/WPCron.php
@@ -10,6 +10,15 @@ namespace Helper\Acceptance;
 class WPCron extends \Codeception\Module
 {
 	/**
+	 * Holds the admin UI URL for WP Crontrol.
+	 *
+	 * @since   2.6.6
+	 *
+	 * @var     string
+	 */
+	private $adminURL = 'tools.php?page=wp-crontrol';
+	
+	/**
 	 * Asserts if the given event name is scheduled in WordPress' Cron.
 	 *
 	 * @since   2.2.8
@@ -49,7 +58,7 @@ class WPCron extends \Codeception\Module
 	public function runCronEvent($I, $name)
 	{
 		// List cron event in WP-Crontrol Plugin.
-		$I->amOnAdminPage('tools.php?page=crontrol_admin_manage_page&s=' . $name);
+		$I->amOnAdminPage($this->adminURL . '&s=' . $name);
 
 		// Hover mouse over event's name.
 		$I->moveMouseOver('#the-list tr');
@@ -74,7 +83,7 @@ class WPCron extends \Codeception\Module
 	public function deleteCronEvent($I, $name)
 	{
 		// List cron event in WP-Crontrol Plugin.
-		$I->amOnAdminPage('tools.php?page=crontrol_admin_manage_page&s=' . $name);
+		$I->amOnAdminPage($this->adminURL . '&s=' . $name);
 
 		// Hover mouse over event's name.
 		$I->moveMouseOver('#the-list tr');

--- a/tests/_support/Helper/Acceptance/WPCron.php
+++ b/tests/_support/Helper/Acceptance/WPCron.php
@@ -17,7 +17,7 @@ class WPCron extends \Codeception\Module
 	 * @var     string
 	 */
 	private $adminURL = 'tools.php?page=wp-crontrol';
-	
+
 	/**
 	 * Asserts if the given event name is scheduled in WordPress' Cron.
 	 *

--- a/tests/_support/Helper/Acceptance/WPGutenberg.php
+++ b/tests/_support/Helper/Acceptance/WPGutenberg.php
@@ -405,7 +405,7 @@ class WPGutenberg extends \Codeception\Module
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>Item #2</p>
+<p>Item #2: Adhaésionés altéram improbis mi pariendarum sit stulti triarium</p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column -->
 

--- a/tests/acceptance/forms/blocks-shortcodes/PageBlockFormCest.php
+++ b/tests/acceptance/forms/blocks-shortcodes/PageBlockFormCest.php
@@ -1027,6 +1027,55 @@ class PageBlockFormCest
 	}
 
 	/**
+	 * Test that a non-inline Form is not displayed when specified in the Form Block and the
+	 * Block Visibility Plugin sets the block to not display.
+	 *
+	 * @since   2.6.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFormBlockWithNonInlineFormAndBlockVisibilityPlugin(AcceptanceTester $I)
+	{
+		// Setup Plugin and Resources.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Activate Block Visibility Plugin.
+		$I->activateThirdPartyPlugin($I, 'block-visibility');
+
+		// Create a Page as if it were create in Gutenberg with the Form block
+		// set to display a non-inline Form, and the Block Visibility Plugin
+		// set to hide the block.
+		$pageID = $I->havePostInDatabase(
+			[
+				'post_type'    => 'page',
+				'post_title'   => 'Kit: Page: Form: Block: Block Visibility',
+				'post_content' => '<!-- wp:convertkit/form {"form":"' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_ID'] . '","blockVisibility":{"controlSets":[{"id":1,"enable":true,"controls":{"location":{"ruleSets":[{"enable":true,"rules":[{"field":"postType","operator":"any","value":["page"]}]}],"hideOnRuleSets":true}}}]}} /-->',
+				'meta_input'   => [
+					// Configure ConvertKit Plugin to not display a default Form.
+					'_wp_convertkit_post_meta' => [
+						'form'         => '0',
+						'landing_page' => '',
+						'tag'          => '',
+					],
+				],
+			]
+		);
+
+		// Load Page.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that no ConvertKit Form is displayed.
+		$I->dontSeeElementInDOM('form[data-sv-form]');
+
+		// Deactivate Block Visibility Plugin.
+		$I->deactivateThirdPartyPlugin($I, 'block-visibility');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/acceptance/forms/blocks-shortcodes/PageShortcodeFormCest.php
+++ b/tests/acceptance/forms/blocks-shortcodes/PageShortcodeFormCest.php
@@ -655,6 +655,7 @@ class PageShortcodeFormCest
 		$I->setupConvertKitPluginResources($I);
 
 		// Activate Perfmatters Plugin.
+		$I->activateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
 		$I->activateThirdPartyPlugin($I, 'perfmatters');
 
 		// Enable Defer and Delay JavaScript.
@@ -700,6 +701,7 @@ class PageShortcodeFormCest
 
 		// Deactivate Perfmatters Plugin.
 		$I->deactivateThirdPartyPlugin($I, 'perfmatters');
+		$I->deactivateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
 	}
 
 	/**
@@ -770,6 +772,7 @@ class PageShortcodeFormCest
 		$I->setupConvertKitPluginResources($I);
 
 		// Activate WP Rocket Plugin.
+		$I->activateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
 		$I->activateThirdPartyPlugin($I, 'wp-rocket');
 
 		// Configure WP Rocket.
@@ -806,6 +809,7 @@ class PageShortcodeFormCest
 
 		// Deactivate WP Rocket Plugin.
 		$I->deactivateThirdPartyPlugin($I, 'wp-rocket');
+		$I->deactivateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
 	}
 
 	/**

--- a/tests/acceptance/forms/post-types/CPTFormCest.php
+++ b/tests/acceptance/forms/post-types/CPTFormCest.php
@@ -314,6 +314,9 @@ class CPTFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM after the third paragraph.
 		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_element', 'p', 3);
+
+		// Confirm character encoding is not broken due to using DOMDocument.
+		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
 	}
 
 	/**
@@ -350,6 +353,9 @@ class CPTFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM after the second <h2> element.
 		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_element', 'h2', 2);
+
+		// Confirm character encoding is not broken due to using DOMDocument.
+		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
 	}
 
 	/**
@@ -386,6 +392,9 @@ class CPTFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM after the second <img> element.
 		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_element', 'img', 2);
+
+		// Confirm character encoding is not broken due to using DOMDocument.
+		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
 	}
 
 	/**
@@ -423,6 +432,9 @@ class CPTFormCest
 		// Confirm that one ConvertKit Form is output in the DOM after the content, as
 		// the number of paragraphs is less than the position.
 		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_content');
+
+		// Confirm character encoding is not broken due to using DOMDocument.
+		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
 	}
 
 	/**

--- a/tests/acceptance/forms/post-types/PageFormCest.php
+++ b/tests/acceptance/forms/post-types/PageFormCest.php
@@ -238,6 +238,48 @@ class PageFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM after the third paragraph.
 		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_element', 'p', 3);
+
+		// Confirm character encoding is not broken due to using DOMDocument.
+		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
+	}
+
+	/**
+	 * Test that the Default Form specified in the Plugin Settings works when
+	 * creating and viewing a new WordPress Page, and its position is set
+	 * to after the 2nd <h2> element.
+	 *
+	 * @since   2.6.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewPageUsingDefaultFormAfterHeadingElement(AcceptanceTester $I)
+	{
+		// Setup ConvertKit plugin with Default Form for Pages set to be output after the 2nd <h2> of content.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'page_form'                        => $_ENV['CONVERTKIT_API_FORM_ID'],
+				'page_form_position'               => 'after_element',
+				'page_form_position_element'       => 'h2',
+				'page_form_position_element_index' => 2,
+			]
+		);
+		$I->setupConvertKitPluginResources($I);
+
+		// Setup Page with placeholder content.
+		$pageID = $I->addGutenbergPageToDatabase($I, 'page', 'Kit: Page: Form: Default: After 2nd H2 Element');
+
+		// View the Page on the frontend site.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that one ConvertKit Form is output in the DOM after the second <h2> element.
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_element', 'h2', 2);
+
+		// Confirm character encoding is not broken due to using DOMDocument.
+		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
 	}
 
 	/**
@@ -274,6 +316,9 @@ class PageFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM after the second <img> element.
 		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_element', 'img', 2);
+
+		// Confirm character encoding is not broken due to using DOMDocument.
+		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
 	}
 
 	/**
@@ -311,6 +356,9 @@ class PageFormCest
 		// Confirm that one ConvertKit Form is output in the DOM after the content, as
 		// the number of paragraphs is less than the position.
 		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_content');
+
+		// Confirm character encoding is not broken due to using DOMDocument.
+		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
 	}
 
 	/**

--- a/tests/acceptance/forms/post-types/PostFormCest.php
+++ b/tests/acceptance/forms/post-types/PostFormCest.php
@@ -237,6 +237,9 @@ class PostFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM after the third paragraph.
 		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_element', 'p', 3);
+
+		// Confirm character encoding is not broken due to using DOMDocument.
+		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
 	}
 
 	/**
@@ -273,6 +276,9 @@ class PostFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM after the second <h2> element.
 		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_element', 'h2', 2);
+
+		// Confirm character encoding is not broken due to using DOMDocument.
+		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
 	}
 
 	/**
@@ -309,6 +315,9 @@ class PostFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM after the second <img> element.
 		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_element', 'img', 2);
+
+		// Confirm character encoding is not broken due to using DOMDocument.
+		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
 	}
 
 	/**
@@ -346,6 +355,9 @@ class PostFormCest
 		// Confirm that one ConvertKit Form is output in the DOM after the content, as
 		// the number of paragraphs is less than the position.
 		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_content');
+
+		// Confirm character encoding is not broken due to using DOMDocument.
+		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
 	}
 
 	/**

--- a/tests/acceptance/integrations/other/DiviBroadcastsCest.php
+++ b/tests/acceptance/integrations/other/DiviBroadcastsCest.php
@@ -16,6 +16,7 @@ class DiviBroadcastsCest
 	public function _before(AcceptanceTester $I)
 	{
 		$I->activateConvertKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
 		$I->activateThirdPartyPlugin($I, 'divi-builder');
 	}
 
@@ -173,6 +174,7 @@ class DiviBroadcastsCest
 	public function _passed(AcceptanceTester $I)
 	{
 		$I->deactivateThirdPartyPlugin($I, 'divi-builder');
+		$I->deactivateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
 		$I->deactivateConvertKitPlugin($I);
 		$I->resetConvertKitPlugin($I);
 	}

--- a/tests/acceptance/integrations/other/DiviFormCest.php
+++ b/tests/acceptance/integrations/other/DiviFormCest.php
@@ -16,6 +16,7 @@ class DiviFormCest
 	public function _before(AcceptanceTester $I)
 	{
 		$I->activateConvertKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
 		$I->activateThirdPartyPlugin($I, 'divi-builder');
 	}
 
@@ -228,6 +229,7 @@ class DiviFormCest
 	public function _passed(AcceptanceTester $I)
 	{
 		$I->deactivateThirdPartyPlugin($I, 'divi-builder');
+		$I->deactivateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
 		$I->deactivateConvertKitPlugin($I);
 		$I->resetConvertKitPlugin($I);
 	}

--- a/tests/acceptance/integrations/other/DiviFormTriggerCest.php
+++ b/tests/acceptance/integrations/other/DiviFormTriggerCest.php
@@ -16,6 +16,7 @@ class DiviFormTriggerCest
 	public function _before(AcceptanceTester $I)
 	{
 		$I->activateConvertKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
 		$I->activateThirdPartyPlugin($I, 'divi-builder');
 	}
 
@@ -193,6 +194,7 @@ class DiviFormTriggerCest
 	public function _passed(AcceptanceTester $I)
 	{
 		$I->deactivateThirdPartyPlugin($I, 'divi-builder');
+		$I->deactivateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
 		$I->deactivateConvertKitPlugin($I);
 		$I->resetConvertKitPlugin($I);
 	}

--- a/tests/acceptance/integrations/other/DiviProductCest.php
+++ b/tests/acceptance/integrations/other/DiviProductCest.php
@@ -16,6 +16,7 @@ class DiviProductCest
 	public function _before(AcceptanceTester $I)
 	{
 		$I->activateConvertKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
 		$I->activateThirdPartyPlugin($I, 'divi-builder');
 	}
 
@@ -186,6 +187,7 @@ class DiviProductCest
 	public function _passed(AcceptanceTester $I)
 	{
 		$I->deactivateThirdPartyPlugin($I, 'divi-builder');
+		$I->deactivateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
 		$I->deactivateConvertKitPlugin($I);
 		$I->resetConvertKitPlugin($I);
 	}

--- a/tests/acceptance/landing-pages/PageLandingPageCest.php
+++ b/tests/acceptance/landing-pages/PageLandingPageCest.php
@@ -328,6 +328,7 @@ class PageLandingPageCest
 		$I->setupConvertKitPluginResources($I);
 
 		// Activate Perfmatters Plugin.
+		$I->activateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
 		$I->activateThirdPartyPlugin($I, 'perfmatters');
 
 		// Enable Lazy Loading.
@@ -373,6 +374,7 @@ class PageLandingPageCest
 
 		// Deactivate Perfmatters Plugin.
 		$I->deactivateThirdPartyPlugin($I, 'perfmatters');
+		$I->deactivateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

WordPress 6.7 displays a PHP notice if a Theme or Plugin calls `load_plugin_textdomain` too early i.e. before the WordPress `init` hook and WP_DEBUG is enabled.

This Plugin's tests run with WP_DEBUG enabled, and due to activating third party Plugins to run specific tests against, we get errors:
![Screenshot 2024-11-25 at 13 10 30](https://github.com/user-attachments/assets/cee71b47-2e35-406e-98ec-5f014b4b4541)

This PR resolves by suppressing the `_load_textdomain_just_in_time` PHP notice in our automated testing via [use of a Plugin](https://gist.github.com/n7studios/cec76acd6652ab1cc74f8ca6b8cbba0f), whilst allowing other notices to still display and be detected.

Also fixes cron tests failing due to a change in the admin UI URL in [WP Crontrol 1.17.1](https://wordpress.org/plugins/wp-crontrol/), released November 23rd.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)