### PR TITLE
Character Encoding: Remove `meta` tag after injecting Form

### DIFF
--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -391,6 +391,9 @@ class ConvertKit_Output {
 	 */
 	private function inject_form_after_element( $content, $tag, $index, $form ) {
 
+		// Define the meta tag.
+		$meta_tag = '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">';
+
 		// Wrap content in <html>, <head> and <body> tags now, so we can inject the UTF-8 Content-Type meta tag.
 		$content = '<html><head></head><body>' . $content . '</body></html>';
 
@@ -398,7 +401,7 @@ class ConvertKit_Output {
 		// <meta charset="utf-8"> isn't enough, as DOMDocument still interprets the HTML as ISO-8859, which breaks character encoding
 		// Use of mb_convert_encoding() with HTML-ENTITIES is deprecated in PHP 8.2, so we have to use this method.
 		// If we don't, special characters render incorrectly.
-		$content = str_replace( '<head>', '<head>' . "\n" . '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">', $content );
+		$content = str_replace( '<head>', '<head>' . "\n" . $meta_tag, $content );
 
 		// Load Page / Post content into DOMDocument.
 		libxml_use_internal_errors( true );
@@ -435,6 +438,7 @@ class ConvertKit_Output {
 		$content = str_replace( '</head>', '', $content );
 		$content = str_replace( '<body>', '', $content );
 		$content = str_replace( '</body>', '', $content );
+		$content = str_replace( $meta_tag, '', $content );
 
 		return $content;
 

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -395,18 +395,18 @@ class ConvertKit_Output {
 		$meta_tag = '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">';
 
 		// Wrap content in <html>, <head> and <body> tags now, so we can inject the UTF-8 Content-Type meta tag.
-		$content = '<html><head></head><body>' . $content . '</body></html>';
+		$modified_content = '<html><head></head><body>' . $content . '</body></html>';
 
 		// Forcibly tell DOMDocument that this HTML uses the UTF-8 charset.
 		// <meta charset="utf-8"> isn't enough, as DOMDocument still interprets the HTML as ISO-8859, which breaks character encoding
 		// Use of mb_convert_encoding() with HTML-ENTITIES is deprecated in PHP 8.2, so we have to use this method.
 		// If we don't, special characters render incorrectly.
-		$content = str_replace( '<head>', '<head>' . "\n" . $meta_tag, $content );
+		$modified_content = str_replace( '<head>', '<head>' . "\n" . $meta_tag, $modified_content );
 
 		// Load Page / Post content into DOMDocument.
 		libxml_use_internal_errors( true );
 		$html = new DOMDocument();
-		$html->loadHTML( $content, LIBXML_HTML_NODEFDTD );
+		$html->loadHTML( $modified_content, LIBXML_HTML_NODEFDTD );
 
 		// Find the element to append the form to.
 		// item() is a zero based index.
@@ -414,7 +414,7 @@ class ConvertKit_Output {
 
 		// If the element could not be found, either the number of elements by tag name is less
 		// than the requested position the form be inserted in, or no element exists.
-		// Append the form to the content and return.
+		// Append the form to the original content and return.
 		if ( is_null( $element_node ) ) {
 			return $content . $form;
 		}
@@ -427,20 +427,20 @@ class ConvertKit_Output {
 		$element_node->parentNode->insertBefore( $html->importNode( $form_node->documentElement, true ), $element_node->nextSibling ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 		// Fetch HTML string.
-		$content = $html->saveHTML();
+		$modified_content = $html->saveHTML();
 
 		// Remove some HTML tags that DOMDocument adds, returning the output.
 		// We do this instead of using LIBXML_HTML_NOIMPLIED in loadHTML(), because Legacy Forms are not always contained in
 		// a single root / outer element, which is required for LIBXML_HTML_NOIMPLIED to correctly work.
-		$content = str_replace( '<html>', '', $content );
-		$content = str_replace( '</html>', '', $content );
-		$content = str_replace( '<head>', '', $content );
-		$content = str_replace( '</head>', '', $content );
-		$content = str_replace( '<body>', '', $content );
-		$content = str_replace( '</body>', '', $content );
-		$content = str_replace( $meta_tag, '', $content );
+		$modified_content = str_replace( '<html>', '', $modified_content );
+		$modified_content = str_replace( '</html>', '', $modified_content );
+		$modified_content = str_replace( '<head>', '', $modified_content );
+		$modified_content = str_replace( '</head>', '', $modified_content );
+		$modified_content = str_replace( '<body>', '', $modified_content );
+		$modified_content = str_replace( '</body>', '', $modified_content );
+		$modified_content = str_replace( $meta_tag, '', $modified_content );
 
-		return $content;
+		return $modified_content;
 
 	}
 

--- a/tests/acceptance/forms/post-types/CPTFormCest.php
+++ b/tests/acceptance/forms/post-types/CPTFormCest.php
@@ -317,6 +317,9 @@ class CPTFormCest
 
 		// Confirm character encoding is not broken due to using DOMDocument.
 		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
+
+		// Confirm no meta tag exists within the content.
+		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
 	}
 
 	/**
@@ -356,6 +359,9 @@ class CPTFormCest
 
 		// Confirm character encoding is not broken due to using DOMDocument.
 		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
+
+		// Confirm no meta tag exists within the content.
+		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
 	}
 
 	/**
@@ -395,6 +401,9 @@ class CPTFormCest
 
 		// Confirm character encoding is not broken due to using DOMDocument.
 		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
+
+		// Confirm no meta tag exists within the content.
+		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
 	}
 
 	/**
@@ -435,6 +444,9 @@ class CPTFormCest
 
 		// Confirm character encoding is not broken due to using DOMDocument.
 		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
+
+		// Confirm no meta tag exists within the content.
+		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
 	}
 
 	/**

--- a/tests/acceptance/forms/post-types/PageFormCest.php
+++ b/tests/acceptance/forms/post-types/PageFormCest.php
@@ -280,6 +280,9 @@ class PageFormCest
 
 		// Confirm character encoding is not broken due to using DOMDocument.
 		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
+
+		// Confirm no meta tag exists within the content.
+		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
 	}
 
 	/**

--- a/tests/acceptance/forms/post-types/PageFormCest.php
+++ b/tests/acceptance/forms/post-types/PageFormCest.php
@@ -241,6 +241,9 @@ class PageFormCest
 
 		// Confirm character encoding is not broken due to using DOMDocument.
 		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
+
+		// Confirm no meta tag exists within the content.
+		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
 	}
 
 	/**
@@ -322,6 +325,12 @@ class PageFormCest
 
 		// Confirm character encoding is not broken due to using DOMDocument.
 		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
+
+		// Confirm no meta tag exists within the content.
+		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
+
+		// Confirm no meta tag exists within the content.
+		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
 	}
 
 	/**
@@ -362,6 +371,9 @@ class PageFormCest
 
 		// Confirm character encoding is not broken due to using DOMDocument.
 		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
+
+		// Confirm no meta tag exists within the content.
+		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
 	}
 
 	/**

--- a/tests/acceptance/forms/post-types/PostFormCest.php
+++ b/tests/acceptance/forms/post-types/PostFormCest.php
@@ -240,6 +240,9 @@ class PostFormCest
 
 		// Confirm character encoding is not broken due to using DOMDocument.
 		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
+
+		// Confirm no meta tag exists within the content.
+		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
 	}
 
 	/**
@@ -279,6 +282,9 @@ class PostFormCest
 
 		// Confirm character encoding is not broken due to using DOMDocument.
 		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
+
+		// Confirm no meta tag exists within the content.
+		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
 	}
 
 	/**
@@ -318,6 +324,9 @@ class PostFormCest
 
 		// Confirm character encoding is not broken due to using DOMDocument.
 		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
+
+		// Confirm no meta tag exists within the content.
+		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
 	}
 
 	/**
@@ -358,6 +367,9 @@ class PostFormCest
 
 		// Confirm character encoding is not broken due to using DOMDocument.
 		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
+
+		// Confirm no meta tag exists within the content.
+		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This [previous PR](https://github.com/Kit/convertkit-wordpress/pull/745) resolved an issue with character encoding when injecting a Form after the nth element (heading, paragraph, image etc).

This resulted in an errant `meta` tag being left behind in the Post's content:
![Screenshot 2024-11-27 at 09 57 34](https://github.com/user-attachments/assets/2953db4f-bf06-45e7-95a5-02a9271c2baf)

This PR resolves by removing the `meta` tag.

## Testing

Updated tests to confirm meta tag removal when injecting a Form after an element.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)