### PR TITLE
Remove JS `convertStoreSubscriberIDInCookie` function

### DIFF
--- a/resources/frontend/js/convertkit.js
+++ b/resources/frontend/js/convertkit.js
@@ -18,72 +18,6 @@
  *
  * @since   1.9.6
  *
- * @param   int  id   Subscriber ID
- */
-function convertStoreSubscriberIDInCookie( subscriber_id ) {
-
-	if ( convertkit.debug ) {
-		console.log( 'convertStoreSubscriberIDInCookie' );
-		console.log( subscriber_id );
-	}
-
-	fetch(
-		convertkit.ajaxurl,
-		{
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/x-www-form-urlencoded',
-			},
-			body: new URLSearchParams(
-				{
-					action: 'convertkit_store_subscriber_id_in_cookie',
-					convertkit_nonce: convertkit.nonce,
-					subscriber_id: subscriber_id
-				}
-			)
-		}
-	)
-	.then(
-		function ( response ) {
-			if ( convertkit.debug ) {
-				console.log( response );
-			}
-
-			return response.json();
-		}
-	)
-	.then(
-		function ( result ) {
-			if ( convertkit.debug ) {
-				console.log( result );
-			}
-
-			convertKitRemoveSubscriberIDFromURL( window.location.href );
-		}
-	)
-	.catch(
-		function ( error ) {
-			if ( convertkit.debug ) {
-				console.error( error );
-			}
-
-			convertKitRemoveSubscriberIDFromURL( window.location.href );
-		}
-	);
-
-}
-
-/**
- * Gets the subscriber ID for the given email address, storing
- * it in the `ck_subscriber_id` cookie if it exists.
- *
- * Typically called when the user completes a ConvertKit Form
- * that has either "Auto-confirm new subscribers" or
- * "Send subscriber to thank you page" enabled (both scenarios
- * include a ck_subscriber_id).
- *
- * @since   1.9.6
- *
  * @param   string  emailAddress   Email Address
  */
 function convertStoreSubscriberEmailAsIDInCookie( emailAddress ) {
@@ -217,11 +151,8 @@ document.addEventListener(
 	'DOMContentLoaded',
 	function () {
 
-		if ( convertkit.subscriber_id > 0 ) {
-			// If the user can be detected as a ConvertKit Subscriber (i.e. their Subscriber ID is in a cookie or the URL),
-			// update the cookie now.
-			convertStoreSubscriberIDInCookie( convertkit.subscriber_id );
-		}
+		// Removes `ck_subscriber_id` from the URI.
+		convertKitRemoveSubscriberIDFromURL( window.location.href );
 
 		// Store subscriber ID as a cookie from the email address used when a ConvertKit Form is submitted.
 		document.addEventListener(


### PR DESCRIPTION
## Summary

Prior to `1.9.6`, JS functionality existed to set a cookie if:
1. A `ck_subscriber_id` query parameter was included in the URL (i.e. a subscriber clicked a link in a Broadcast), and
2. The WordPress Page had the `Add a tag` setting configured to assign the subscriber to a tag.

Since then, several updates have moved this functionality to the server side:

- #371: Server side validation and storing of a subscriber ID as a cookie
- #408: Moves the logic above to an earlier point in the request cycle
- #675: Moves JS client side tagging logic to server side, resolving a reported security issue

As a result, the JS client-side function `convertStoreSubscriberIDInCookie` is still being called, triggering the `convertkit_store_subscriber_id_in_cookie` AJAX endpoint whenever a subscriber ID exists.

A user report ([see Linear issue](https://linear.app/kit/issue/WP-6/creator-reporting-convertkit-store-subscriber-id-in-cookie-causing)) indicates this endpoint is receiving significant traffic (10–20 requests per second), likely from a high-traffic site. This suggests the JS-based logic is unnecessary, as all relevant subscriber ID checks and cookie operations are now handled server-side.

This PR removes the redundant JS client-side call to `convertStoreSubscriberIDInCookie`, reducing unnecessary AJAX requests and improving performance for high-traffic sites.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)