### PR TITLE
Tests: Use PHPStan 2.0

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -129,6 +129,5 @@ jobs:
 
       # Run PHPStan for static analysis.
       - name: Run PHPStan Static Analysis
-        if: ${{ matrix.php-versions != '7.2' && matrix.php-versions != '7.3' }}
         working-directory: ${{ env.PLUGIN_DIR }}
         run: php vendor/bin/phpstan analyse --memory-limit=1250M

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -129,5 +129,6 @@ jobs:
 
       # Run PHPStan for static analysis.
       - name: Run PHPStan Static Analysis
+        if: ${{ matrix.php-versions != '7.2' && matrix.php-versions != '7.3' }}
         working-directory: ${{ env.PLUGIN_DIR }}
         run: php vendor/bin/phpstan analyse --memory-limit=1250M

--- a/admin/class-convertkit-admin-cache-plugins.php
+++ b/admin/class-convertkit-admin-cache-plugins.php
@@ -266,11 +266,6 @@ class ConvertKit_Admin_Cache_Plugins {
 		$config   = new WPO_Cache_Config();
 		$settings = $config->get();
 
-		// Check that we received an array of settings.
-		if ( ! is_array( $settings ) ) {
-			return;
-		}
-
 		// Check the exception cookies array key exists in the settings.
 		if ( ! array_key_exists( 'cache_exception_cookies', $settings ) ) {
 			$settings['cache_exception_cookies'] = array();

--- a/admin/class-convertkit-admin-tinymce.php
+++ b/admin/class-convertkit-admin-tinymce.php
@@ -97,7 +97,7 @@ class ConvertKit_Admin_TinyMCE {
 		$shortcodes = convertkit_get_shortcodes();
 
 		// Bail if no shortcode are available.
-		if ( ! is_array( $shortcodes ) || ! count( $shortcodes ) ) {
+		if ( ! count( $shortcodes ) ) {
 			return;
 		}
 
@@ -139,7 +139,7 @@ class ConvertKit_Admin_TinyMCE {
 		$shortcodes = convertkit_get_shortcodes();
 
 		// Bail if no shortcodes are available.
-		if ( ! is_array( $shortcodes ) || ! count( $shortcodes ) ) {
+		if ( ! count( $shortcodes ) ) {
 			return $plugins;
 		}
 
@@ -184,7 +184,7 @@ class ConvertKit_Admin_TinyMCE {
 		$shortcodes = convertkit_get_shortcodes();
 
 		// Bail if no shortcodes are available.
-		if ( ! is_array( $shortcodes ) || ! count( $shortcodes ) ) {
+		if ( ! count( $shortcodes ) ) {
 			return $buttons;
 		}
 

--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -342,7 +342,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 
 		// If the DISABLE_WP_CRON constant exists and is true, display a warning that this functionality
 		// may not work.
-		if ( defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON === true ) {
+		if ( defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON === true ) { // @phpstan-ignore-line Constant is not always true.
 			?>
 			<div class="notice notice-info">
 				<p>

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -37,7 +37,7 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @var     bool|ConvertKit_Resource_Forms;
+	 * @var     bool|ConvertKit_Resource_Forms
 	 */
 	private $forms = false;
 

--- a/admin/section/class-convertkit-settings-tools.php
+++ b/admin/section/class-convertkit-settings-tools.php
@@ -228,9 +228,6 @@ class ConvertKit_Settings_Tools extends ConvertKit_Settings_Base {
 		}
 
 		// Bail if no configuration file was supplied.
-		if ( ! is_array( $_FILES ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
-			$this->redirect();
-		}
 		if ( $_FILES['import']['error'] !== 0 ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			$this->redirect_with_error_notice( 'import_configuration_upload_error' );
 		}

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
         "codeception/util-universalframework": "^1.0",
         "php-webdriver/webdriver": "^1.0",
         "wp-coding-standards/wpcs": "^3.0.0",
-        "phpstan/phpstan": "^1.7",
-        "szepeviktor/phpstan-wordpress": "^1.0",
-        "wp-cli/wp-cli": "2.8.1",
+        "phpstan/phpstan": "^2.0",
+        "szepeviktor/phpstan-wordpress": "^2.0",
+        "wp-cli/wp-cli": "2.11",
         "gumlet/php-image-resize": "^1.6"
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
         "codeception/util-universalframework": "^1.0",
         "php-webdriver/webdriver": "^1.0",
         "wp-coding-standards/wpcs": "^3.0.0",
-        "phpstan/phpstan": "^2.0",
-        "szepeviktor/phpstan-wordpress": "^2.0",
+        "phpstan/phpstan": "^1.0 || ^2.0",
+        "szepeviktor/phpstan-wordpress": "^1.0 || ^2.0",
         "wp-cli/wp-cli": "2.11",
         "gumlet/php-image-resize": "^1.6"
     },

--- a/includes/blocks/class-convertkit-block.php
+++ b/includes/blocks/class-convertkit-block.php
@@ -299,10 +299,6 @@ class ConvertKit_Block {
 	 */
 	public function sanitize_atts( $atts ) {
 
-		if ( ! is_array( $atts ) ) {
-			return $atts;
-		}
-
 		foreach ( $atts as $key => $value ) {
 			if ( is_array( $value ) ) {
 				continue;

--- a/includes/class-convertkit-broadcasts-importer.php
+++ b/includes/class-convertkit-broadcasts-importer.php
@@ -157,7 +157,7 @@ class ConvertKit_Broadcasts_Importer {
 		// Check that we're using the ConvertKit WordPress Libraries 1.3.8 or higher.
 		// If another ConvertKit Plugin is active and out of date, its libraries might
 		// be loaded that don't have this method.
-		if ( ! method_exists( $api, 'get_post' ) ) {
+		if ( ! method_exists( $api, 'get_post' ) ) { // @phpstan-ignore-line Older WordPress Libraries won't have this function.
 			return new WP_Error(
 				'convertkit_broadcasts_importer_error',
 				__( 'Kit WordPress Libraries 1.3.7 or older detected, missing the `get_post` method.', 'convertkit' )

--- a/includes/class-convertkit-gutenberg.php
+++ b/includes/class-convertkit-gutenberg.php
@@ -87,7 +87,7 @@ class ConvertKit_Gutenberg {
 		$blocks = convertkit_get_blocks();
 
 		// Bail if no blocks are available.
-		if ( ! is_array( $blocks ) || ! count( $blocks ) ) {
+		if ( ! count( $blocks ) ) {
 			return;
 		}
 
@@ -98,7 +98,7 @@ class ConvertKit_Gutenberg {
 		foreach ( $blocks as $block => $properties ) {
 
 			// Skip if this block has already been registered.
-			if ( is_array( $registered_blocks ) && in_array( 'convertkit/' . $block, $registered_blocks, true ) ) {
+			if ( in_array( 'convertkit/' . $block, $registered_blocks, true ) ) {
 				continue;
 			}
 

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -68,7 +68,7 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource_V4 {
 		// addon), or a WordPress site updates this Plugin before other ConvertKit Plugins,
 		// get_by() won't be available and will cause an E_ERROR, crashing the site.
 		// @see https://wordpress.org/support/topic/error-1795/.
-		if ( ! method_exists( $this, 'get_by' ) ) {
+		if ( ! method_exists( $this, 'get_by' ) ) { // @phpstan-ignore-line Older WordPress Libraries won't have this function.
 			return false;
 		}
 

--- a/includes/class-convertkit-shortcodes.php
+++ b/includes/class-convertkit-shortcodes.php
@@ -36,13 +36,12 @@ class ConvertKit_Shortcodes {
 		$shortcodes = convertkit_get_shortcodes();
 
 		// Bail if no shortcodes are available.
-		if ( ! is_array( $shortcodes ) || ! count( $shortcodes ) ) {
+		if ( ! count( $shortcodes ) ) {
 			return;
 		}
 
 		// Iterate through shortcodes, registering them as shortcodes.
 		foreach ( $shortcodes as $shortcode => $properties ) {
-
 			// Register shortcode.
 			add_shortcode(
 				'convertkit_' . $shortcode,

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -116,7 +116,7 @@ function convertkit_get_supported_post_types() {
 	// If public Custom Post Types can be fetched, include them now.
 	if ( function_exists( 'get_post_types' ) ) {
 		// Get public Custom Post Types.
-		$custom_post_types = get_post_types(
+		$custom_post_types = (array) get_post_types(
 			array(
 				'public'   => true,
 
@@ -125,13 +125,10 @@ function convertkit_get_supported_post_types() {
 			)
 		);
 
-		// Sanity check an array was returned.
-		if ( is_array( $custom_post_types ) ) {
-			$post_types = array_merge(
-				$post_types,
-				array_keys( $custom_post_types )
-			);
-		}
+		$post_types = array_merge(
+			$post_types,
+			array_keys( $custom_post_types )
+		);
 	}
 
 	/**

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
@@ -201,9 +201,6 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 			)
 		);
 
-		if ( ! is_array( $result->posts ) ) {
-			return false;
-		}
 		if ( ! count( $result->posts ) ) {
 			return false;
 		}

--- a/includes/integrations/divi/class-convertkit-divi-module.php
+++ b/includes/integrations/divi/class-convertkit-divi-module.php
@@ -70,7 +70,7 @@ class ConvertKit_Divi_Module extends ET_Builder_Module {
 		$blocks = convertkit_get_blocks();
 
 		// Bail if no blocks are available.
-		if ( ! is_array( $blocks ) || ! count( $blocks ) ) {
+		if ( ! count( $blocks ) ) {
 			return;
 		}
 

--- a/includes/integrations/elementor/class-convertkit-elementor-widget.php
+++ b/includes/integrations/elementor/class-convertkit-elementor-widget.php
@@ -278,7 +278,7 @@ class ConvertKit_Elementor_Widget extends Elementor\Widget_Base {
 		$blocks = convertkit_get_blocks();
 
 		// Bail if no blocks are available.
-		if ( ! is_array( $blocks ) || ! count( $blocks ) ) {
+		if ( ! count( $blocks ) ) {
 			return new WP_Error( 'convertkit_elementor_widget_get_block_error', __( 'No blocks are registered. Register blocks using the `convertkit_blocks` filter.', 'convertkit' ) );
 		}
 

--- a/includes/integrations/elementor/class-convertkit-elementor.php
+++ b/includes/integrations/elementor/class-convertkit-elementor.php
@@ -87,7 +87,7 @@ class ConvertKit_Elementor {
 		$blocks = convertkit_get_blocks();
 
 		// Bail if no blocks are available.
-		if ( ! is_array( $blocks ) || ! count( $blocks ) ) {
+		if ( ! count( $blocks ) ) {
 			return;
 		}
 
@@ -106,7 +106,7 @@ class ConvertKit_Elementor {
 			$class_name = 'ConvertKit_Elementor_Widget_' . str_replace( '-', '_', $block );
 
 			// Register Widget, using applicable function depending on the Elementor version.
-			if ( method_exists( $widgets_manager, 'register' ) ) {
+			if ( method_exists( $widgets_manager, 'register' ) ) { // @phpstan-ignore-line - older versions of Elementor don't have this method.
 				// Use register() function, available in Elementor 3.5.0.
 				// Required per https://developers.elementor.com/docs/managers/registering-widgets/.
 				$widgets_manager->register( new $class_name() );

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -21,6 +21,10 @@ parameters:
     scanDirectories:
         - /home/runner/work/convertkit-wordpress/convertkit-wordpress/wordpress/wp-content/plugins
 
+    # Location of constants for PHPStan to scan, building symbols.
+    scanFiles:
+        - /home/runner/work/convertkit-wordpress/convertkit-wordpress/wordpress/wp-config.php
+
     # Should not need to edit anything below here
     # Rule Level: https://phpstan.org/user-guide/rule-levels
     level: 5

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -21,6 +21,15 @@ parameters:
     scanDirectories:
         - /home/runner/work/convertkit-wordpress/convertkit-wordpress/wordpress/wp-content/plugins
 
+    # Location of constants for PHPStan to scan, building symbols.
+    scanFiles:
+        - /home/runner/work/convertkit-wordpress/convertkit-wordpress/wordpress/wp-config.php
+
+    # Ignore the following errors, as PHPStan and PHPStan for WordPress haven't correctly registered symbols,
+    # so they're false positives.
+    ignoreErrors:
+        - '#Function __ invoked with 2 parameters, 1 required.#'
+
     # Should not need to edit anything below here
     # Rule Level: https://phpstan.org/user-guide/rule-levels
     level: 5

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -25,6 +25,9 @@ parameters:
     scanFiles:
         - /home/runner/work/convertkit-wordpress/convertkit-wordpress/wordpress/wp-config.php
 
+    # Don't report unmatched ignored errors on older PHP versions (7.2, 7.3)
+    reportUnmatchedIgnoredErrors: false
+
     # Should not need to edit anything below here
     # Rule Level: https://phpstan.org/user-guide/rule-levels
     level: 5

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -21,15 +21,6 @@ parameters:
     scanDirectories:
         - /home/runner/work/convertkit-wordpress/convertkit-wordpress/wordpress/wp-content/plugins
 
-    # Location of constants for PHPStan to scan, building symbols.
-    scanFiles:
-        - /home/runner/work/convertkit-wordpress/convertkit-wordpress/wordpress/wp-config.php
-
-    # Ignore the following errors, as PHPStan and PHPStan for WordPress haven't correctly registered symbols,
-    # so they're false positives.
-    ignoreErrors:
-        - '#Function __ invoked with 2 parameters, 1 required.#'
-
     # Should not need to edit anything below here
     # Rule Level: https://phpstan.org/user-guide/rule-levels
     level: 5

--- a/phpstan.neon.example
+++ b/phpstan.neon.example
@@ -21,6 +21,10 @@ parameters:
     scanDirectories:
         - /home/runner/work/convertkit-wordpress/convertkit-wordpress/wordpress/wp-content/plugins
 
+    # Location of constants for PHPStan to scan, building symbols.
+    scanFiles:
+        - /home/runner/work/convertkit-wordpress/convertkit-wordpress/wordpress/wp-config.php
+
     # Should not need to edit anything below here
     # Rule Level: https://phpstan.org/user-guide/rule-levels
     level: 5

--- a/phpstan.neon.example
+++ b/phpstan.neon.example
@@ -1,4 +1,4 @@
-# PHPStan configuration for local static analysis.
+# PHPStan configuration for GitHub Actions.
 
 # Include PHPStan for WordPress configuration.
 includes:
@@ -19,15 +19,17 @@ parameters:
 
     # Location of WordPress Plugins for PHPStan to scan, building symbols.
     scanDirectories:
-        - /Users/tim/Local Sites/convertkit-github/app/public/wp-content/plugins
+        - /home/runner/work/convertkit-wordpress/convertkit-wordpress/wordpress/wp-content/plugins
+
+    # Location of constants for PHPStan to scan, building symbols.
+    scanFiles:
+        - /home/runner/work/convertkit-wordpress/convertkit-wordpress/wordpress/wp-config.php
+
+    # Ignore the following errors, as PHPStan and PHPStan for WordPress haven't correctly registered symbols,
+    # so they're false positives.
+    ignoreErrors:
+        - '#Function __ invoked with 2 parameters, 1 required.#'
 
     # Should not need to edit anything below here
     # Rule Level: https://phpstan.org/user-guide/rule-levels
     level: 5
-
-    # Ignore the following errors, as PHPStan and PHPStan for WordPress haven't registered symbols for them yet,
-    # so they're false positives.
-    ignoreErrors:
-        - '#Access to an undefined property WP_Theme::#'
-        - '#Constant WP_MEMORY_LIMIT not found.#'
-        - '#Function apply_filters invoked with#' # apply_filters() accepted a variable number of parameters, which PHPStan fails to detect

--- a/phpstan.neon.example
+++ b/phpstan.neon.example
@@ -25,6 +25,9 @@ parameters:
     scanFiles:
         - /home/runner/work/convertkit-wordpress/convertkit-wordpress/wordpress/wp-config.php
 
+    # Don't report unmatched ignored errors on older PHP versions (7.2, 7.3)
+    reportUnmatchedIgnoredErrors: false
+
     # Should not need to edit anything below here
     # Rule Level: https://phpstan.org/user-guide/rule-levels
     level: 5

--- a/phpstan.neon.example
+++ b/phpstan.neon.example
@@ -21,15 +21,6 @@ parameters:
     scanDirectories:
         - /home/runner/work/convertkit-wordpress/convertkit-wordpress/wordpress/wp-content/plugins
 
-    # Location of constants for PHPStan to scan, building symbols.
-    scanFiles:
-        - /home/runner/work/convertkit-wordpress/convertkit-wordpress/wordpress/wp-config.php
-
-    # Ignore the following errors, as PHPStan and PHPStan for WordPress haven't correctly registered symbols,
-    # so they're false positives.
-    ignoreErrors:
-        - '#Function __ invoked with 2 parameters, 1 required.#'
-
     # Should not need to edit anything below here
     # Rule Level: https://phpstan.org/user-guide/rule-levels
     level: 5


### PR DESCRIPTION
## Summary

Runs static analysis using the latest [2.0](https://github.com/phpstan/phpstan/blob/2.0.x/UPGRADING.md) version of PHPStan when tests are performed on PHP 7.4 and higher, which is the minimum supported version.

PHPStan 1.x will run on tests using PHP < 7.4.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)