### PR TITLE
Fix `DOMDocument` Fatal Error when non-inline Form specified

### DIFF
--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -326,9 +326,24 @@ class ConvertKit_Output {
 			}
 		}
 
+		// If the Form HTML is empty, it's a modal form that has been set to load in the footer of the site.
+		// We don't need to append anything to the content.
+		if ( empty( $form ) ) {
+			if ( $this->settings->debug_enabled() ) {
+				$content .= '<!-- Kit append_form_to_content(): Form is non-inline, appended to footer. -->';
+			}
+
+			return $content;
+		}
+
 		// If here, we have a ConvertKit Form.
 		// Append form to Post's Content, based on the position setting.
 		$form_position = $this->settings->get_default_form_position( get_post_type( $post_id ) );
+
+		if ( $this->settings->debug_enabled() ) {
+			$content .= '<!-- Kit append_form_to_content(): Form Position: ' . esc_html( $form_position ) . ' -->';
+		}
+
 		switch ( $form_position ) {
 			case 'before_after_content':
 				$content = $form . $content . $form;
@@ -390,6 +405,11 @@ class ConvertKit_Output {
 	 * @return  string
 	 */
 	private function inject_form_after_element( $content, $tag, $index, $form ) {
+
+		// If the form is empty, don't inject anything.
+		if ( empty( $form ) ) {
+			return $content;
+		}
 
 		// Define the meta tag.
 		$meta_tag = '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">';
@@ -458,6 +478,11 @@ class ConvertKit_Output {
 	 * @return  string
 	 */
 	private function inject_form_after_element_fallback( $content, $tag, $index, $form ) {
+
+		// If the form is empty, don't inject anything.
+		if ( empty( $form ) ) {
+			return $content;
+		}
 
 		// Calculate tag length.
 		$tag_length = ( strlen( $tag ) + 3 );

--- a/tests/acceptance/forms/post-types/CPTFormCest.php
+++ b/tests/acceptance/forms/post-types/CPTFormCest.php
@@ -324,7 +324,7 @@ class CPTFormCest
 
 	/**
 	 * Test that specifying a non-inline Form specified in the Plugin Settings does not
-	 * result in a fatal error when creating and viewing a new WordPress Post, and its position is set
+	 * result in a fatal error when creating and viewing a new WordPress CPT, and its position is set
 	 * to after the 3rd paragraph.
 	 *
 	 * @since   2.6.8

--- a/tests/acceptance/forms/post-types/CPTFormCest.php
+++ b/tests/acceptance/forms/post-types/CPTFormCest.php
@@ -323,6 +323,49 @@ class CPTFormCest
 	}
 
 	/**
+	 * Test that specifying a non-inline Form specified in the Plugin Settings does not
+	 * result in a fatal error when creating and viewing a new WordPress Post, and its position is set
+	 * to after the 3rd paragraph.
+	 *
+	 * @since   2.6.8
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewCPTUsingDefaultNonInlineFormAfterParagraphElement(AcceptanceTester $I)
+	{
+		// Setup ConvertKit plugin with Default Form for CPTs set to be output after the 3rd paragraph of content.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'article_form'                        => $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'],
+				'article_form_position'               => 'after_element',
+				'article_form_position_element'       => 'p',
+				'article_form_position_element_index' => 3,
+			]
+		);
+		$I->setupConvertKitPluginResources($I);
+
+		// Setup CPT with placeholder content.
+		$pageID = $I->addGutenbergPageToDatabase($I, 'article', 'Kit: CPT: Non-Inline Form: Default: After 3rd Paragraph Element');
+
+		// View the Page on the frontend site.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that one ConvertKit Form is output in the DOM.
+		// This confirms that there is only one script on the page for this form, which renders the form.
+		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '"]', 1);
+
+		// Confirm character encoding is not broken due to using DOMDocument.
+		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
+
+		// Confirm no meta tag exists within the content.
+		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
+	}
+
+	/**
 	 * Test that the Default Form specified in the Plugin Settings works when
 	 * creating and viewing a new WordPress CPT, and its position is set
 	 * to after the 2nd <h2> element.

--- a/tests/acceptance/forms/post-types/PageFormCest.php
+++ b/tests/acceptance/forms/post-types/PageFormCest.php
@@ -247,6 +247,49 @@ class PageFormCest
 	}
 
 	/**
+	 * Test that specifying a non-inline Form specified in the Plugin Settings does not
+	 * result in a fatal error when creating and viewing a new WordPress Page, and its position is set
+	 * to after the 3rd paragraph.
+	 *
+	 * @since   2.6.8
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewPageUsingDefaultNonInlineFormAfterParagraphElement(AcceptanceTester $I)
+	{
+		// Setup ConvertKit plugin with Default Form for Pages set to be output after the 3rd paragraph of content.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'page_form'                        => $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'],
+				'page_form_position'               => 'after_element',
+				'page_form_position_element'       => 'p',
+				'page_form_position_element_index' => 3,
+			]
+		);
+		$I->setupConvertKitPluginResources($I);
+
+		// Setup Page with placeholder content.
+		$pageID = $I->addGutenbergPageToDatabase($I, 'page', 'Kit: Page: Non-Inline Form: Default: After 3rd Paragraph Element');
+
+		// View the Page on the frontend site.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that one ConvertKit Form is output in the DOM.
+		// This confirms that there is only one script on the page for this form, which renders the form.
+		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '"]', 1);
+
+		// Confirm character encoding is not broken due to using DOMDocument.
+		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
+
+		// Confirm no meta tag exists within the content.
+		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
+	}
+
+	/**
 	 * Test that the Default Form specified in the Plugin Settings works when
 	 * creating and viewing a new WordPress Page, and its position is set
 	 * to after the 2nd <h2> element.

--- a/tests/acceptance/forms/post-types/PostFormCest.php
+++ b/tests/acceptance/forms/post-types/PostFormCest.php
@@ -246,6 +246,49 @@ class PostFormCest
 	}
 
 	/**
+	 * Test that specifying a non-inline Form specified in the Plugin Settings does not
+	 * result in a fatal error when creating and viewing a new WordPress Post, and its position is set
+	 * to after the 3rd paragraph.
+	 *
+	 * @since   2.6.8
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewPostUsingDefaultNonInlineFormAfterParagraphElement(AcceptanceTester $I)
+	{
+		// Setup ConvertKit plugin with Default Form for Posts set to be output after the 3rd paragraph of content.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'post_form'                        => $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'],
+				'post_form_position'               => 'after_element',
+				'post_form_position_element'       => 'p',
+				'post_form_position_element_index' => 3,
+			]
+		);
+		$I->setupConvertKitPluginResources($I);
+
+		// Setup Post with placeholder content.
+		$pageID = $I->addGutenbergPageToDatabase($I, 'post', 'Kit: Post: Non-Inline Form: Default: After 3rd Paragraph Element');
+
+		// View the Page on the frontend site.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that one ConvertKit Form is output in the DOM.
+		// This confirms that there is only one script on the page for this form, which renders the form.
+		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '"]', 1);
+
+		// Confirm character encoding is not broken due to using DOMDocument.
+		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
+
+		// Confirm no meta tag exists within the content.
+		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
+	}
+
+	/**
 	 * Test that the Default Form specified in the Plugin Settings works when
 	 * creating and viewing a new WordPress Post, and its position is set
 	 * to after the 2nd <h2> element.


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://linear.app/kit/issue/WP-7/bcdc-wordpress-p3-critical-error-message-when-modal-form-set-on) when:
- a non-inline Form is specified at Plugin, Post or Category level, and
- the `Form Position` setting = `After element`

This was caused due to the `$form` variable being empty (due to the Plugin correctly deferring non-inline Forms to the footer of the site), and DOMDocument attempting to load a blank string as a result.

```
Warning: DOMDocument::loadHTML(): Empty string supplied as input in /home/thevanab/public_html/wp-content/plugins/convertkit/includes/class-convertkit-output.php on line 424

Fatal error: Uncaught TypeError: Argument 1 passed to DOMDocument::importNode() must be an instance of DOMNode, null given in /home/thevanab/public_html/wp-content/plugins/convertkit/includes/class-convertkit-output.php:427
Stack trace:
#0 /home/thevanab/public_html/wp-content/plugins/convertkit/includes/class-convertkit-output.php(427): DOMDocument->importNode(NULL, true)
#1 /home/thevanab/public_html/wp-content/plugins/convertkit/includes/class-convertkit-output.php(354): ConvertKit_Output->inject_form_after_element('\n<p>This is a k...', 'p', 4, '')
#2 /home/thevanab/public_html/wp-includes/class-wp-hook.php(324): ConvertKit_Output->append_form_to_content('\n<p>This is a k...')
#3 /home/thevanab/public_html/wp-includes/plugin.php(205): WP_Hook->apply_filters('\n<p>This is a k...', Array)
#4 /home/thevanab/public_html/wp-includes/post-template.php(256): apply_filters('the_content', '<!-- wp:paragra...')
#5 /home/thevanab/public_html/wp-content/themes/kadence/template-parts/content/entry_content.php(27): the_content('Con in /home/thevanab/public_html/wp-content/plugins/convertkit/includes/class-convertkit-output.php
```

## Testing

- `testAddNewCPTUsingDefaultNonInlineFormAfterParagraphElement`: Test that specifying a non-inline Form specified in the Plugin Settings does not result in a fatal error when creating and viewing a new WordPress CPT, and its position is set to after the 3rd paragraph.
- `testAddNewPageUsingDefaultNonInlineFormAfterParagraphElement`: Test that specifying a non-inline Form specified in the Plugin Settings does not result in a fatal error when creating and viewing a new WordPress Page, and its position is set to after the 3rd paragraph.
- `testAddNewPostUsingDefaultNonInlineFormAfterParagraphElement`: Test that specifying a non-inline Form specified in the Plugin Settings does not result in a fatal error when creating and viewing a new WordPress Post, and its position is set to after the 3rd paragraph.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)