### PR TITLE
Tests: Update Legacy Form action URL from `convertkit.com` to `kit.com`

### DIFF
--- a/tests/acceptance/forms/blocks-shortcodes/PageShortcodeFormCest.php
+++ b/tests/acceptance/forms/blocks-shortcodes/PageShortcodeFormCest.php
@@ -362,7 +362,7 @@ class PageShortcodeFormCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the ConvertKit Default Legacy Form displays.
-		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
+		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.kit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Looks like legacy forms HTML now returns a form action of `api.kit.com`, instead of `api.convertkit.com`.

![Screenshot 2024-12-09 at 14 57 23](https://github.com/user-attachments/assets/6ad3cf36-dc05-4861-b306-5363d215bf7a)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)