### PR TITLE
Update `ck_subscriber_id` Notice

### DIFF
--- a/admin/class-convertkit-admin-cache-plugins.php
+++ b/admin/class-convertkit-admin-cache-plugins.php
@@ -58,6 +58,7 @@ class ConvertKit_Admin_Cache_Plugins {
 		$this->w3_total_cache();
 		$this->wp_fastest_cache();
 		$this->wp_optimize();
+		$this->wp_rocket();
 		$this->wp_super_cache();
 
 	}
@@ -281,6 +282,40 @@ class ConvertKit_Admin_Cache_Plugins {
 
 		// Update configuration to include excluding caching for the ck_subscriber_id cookie.
 		return $config->update( $settings );
+
+	}
+
+	/**
+	 * Add a rule to WP Rocket to prevent caching when
+	 * the ck_subscriber_id cookie is present.
+	 *
+	 * @since   2.7.0
+	 */
+	public function wp_rocket() {
+
+		// Bail if the WP Rocket plugin is not active.
+		if ( ! is_plugin_active( 'wp-rocket/wp-rocket.php' ) ) {
+			return;
+		}
+
+		// Sanity check that we can access WP-Optimize's configuration class.
+		if ( ! function_exists( 'update_rocket_option' ) ) {
+			return;
+		}
+
+		// Fetch settings.
+		$settings = get_rocket_option( 'cache_reject_cookies', array() );
+
+		// If the cookie exception exists, no need to modify anything.
+		if ( in_array( $this->key, $settings, true ) ) {
+			return;
+		}
+
+		// Add cookie to exceptions.
+		$settings[] = $this->key;
+
+		// Update configuration to include excluding caching for the ck_subscriber_id cookie.
+		return update_rocket_option( 'cache_reject_cookies', $settings );
 
 	}
 

--- a/admin/class-convertkit-admin-cache-plugins.php
+++ b/admin/class-convertkit-admin-cache-plugins.php
@@ -315,7 +315,7 @@ class ConvertKit_Admin_Cache_Plugins {
 		$settings[] = $this->key;
 
 		// Update configuration to include excluding caching for the ck_subscriber_id cookie.
-		return update_rocket_option( 'cache_reject_cookies', $settings );
+		update_rocket_option( 'cache_reject_cookies', $settings );
 
 	}
 

--- a/admin/class-convertkit-admin-settings-restrict-content.php
+++ b/admin/class-convertkit-admin-settings-restrict-content.php
@@ -321,18 +321,6 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 
 		?>
 		<p class="description"><?php esc_html_e( 'Defines the text and button labels to display when a Page, Post or Custom Post has its Member Content setting defined.', 'convertkit' ); ?></p>
-		<div class="notice notice-warning">
-			<p>
-				<?php
-				printf(
-					'%s %s %s',
-					esc_html__( 'If your web host has caching configured (or you are using a caching plugin), you must configure it to disable caching when the', 'convertkit' ),
-					'<code>ck_subscriber_id</code>',
-					esc_html__( 'cookie is present. Failing to do so will result in errors.', 'convertkit' )
-				);
-				?>
-			</p>
-		</div>
 		<?php
 
 	}

--- a/includes/class-convertkit-cache-plugins.php
+++ b/includes/class-convertkit-cache-plugins.php
@@ -79,6 +79,9 @@ class ConvertKit_Cache_Plugins {
 		add_filter( 'convertkit_output_script_footer', array( $this, 'wp_rocket_exclude_delay_js_execution' ) );
 		add_filter( 'convertkit_resource_forms_output_script', array( $this, 'wp_rocket_exclude_delay_js_execution' ) );
 
+		// WP Rocket: Add `ck_subscriber_id` to "Never Cache Cookies" setting.
+		add_filter( 'rocket_cache_reject_cookies', array( $this, 'wp_rocket_add_never_cache_cookies' ) );
+
 	}
 
 	/**
@@ -258,6 +261,22 @@ class ConvertKit_Cache_Plugins {
 				'nowprocket' => '',
 			)
 		);
+
+	}
+
+	/**
+	 * WP Rocket: Register `ck_subscriber_id` as a cookie that, when set, prevents
+	 * caching.
+	 * 
+	 * @since 	2.7.0
+	 * 
+	 * @param 	array 	$cookies 	Cookies.
+	 * @return  array
+	 */
+	public function wp_rocket_add_never_cache_cookies( $cookies ) {
+
+		$cookies[] = 'ck_subscriber_id';
+		return $cookies;
 
 	}
 

--- a/includes/class-convertkit-cache-plugins.php
+++ b/includes/class-convertkit-cache-plugins.php
@@ -79,9 +79,6 @@ class ConvertKit_Cache_Plugins {
 		add_filter( 'convertkit_output_script_footer', array( $this, 'wp_rocket_exclude_delay_js_execution' ) );
 		add_filter( 'convertkit_resource_forms_output_script', array( $this, 'wp_rocket_exclude_delay_js_execution' ) );
 
-		// WP Rocket: Add `ck_subscriber_id` to "Never Cache Cookies" setting.
-		add_filter( 'rocket_cache_reject_cookies', array( $this, 'wp_rocket_add_never_cache_cookies' ) );
-
 	}
 
 	/**
@@ -261,22 +258,6 @@ class ConvertKit_Cache_Plugins {
 				'nowprocket' => '',
 			)
 		);
-
-	}
-
-	/**
-	 * WP Rocket: Register `ck_subscriber_id` as a cookie that, when set, prevents
-	 * caching.
-	 * 
-	 * @since 	2.7.0
-	 * 
-	 * @param 	array 	$cookies 	Cookies.
-	 * @return  array
-	 */
-	public function wp_rocket_add_never_cache_cookies( $cookies ) {
-
-		$cookies[] = 'ck_subscriber_id';
-		return $cookies;
 
 	}
 

--- a/tests/acceptance/restrict-content/general/RestrictContentCacheCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentCacheCest.php
@@ -260,6 +260,46 @@ class RestrictContentCacheCest
 	}
 
 	/**
+	 * Tests that the WP RocketPlugin does not interfere with Restrict Content
+	 * output when a ck_subscriber_id cookie is present.
+	 *
+	 * @since   2.7.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentWPRocketCache(AcceptanceTester $I)
+	{
+		// Activate WP Rocket Plugin.
+		$I->activateThirdPartyPlugin($I, 'wp-rocket');
+
+		// Create Restricted Content Page.
+		$pageID = $I->createRestrictedContentPage(
+			$I,
+			[
+				'post_title'               => 'Kit: Restrict Content: Product: WP Rocket',
+				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+			]
+		);
+
+		// Log out, so that caching is honored.
+		$I->logOut();
+
+		// Navigate to the page.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Test that the restricted content CTA displays when no valid signed subscriber ID is used,
+		// to confirm caching does not show member-only content.
+		$I->testRestrictContentByProductHidesContentWithCTA($I);
+
+		// Test that the restricted content displays when a valid signed subscriber ID is used,
+		// to confirm caching does not show the incorrect content.
+		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID);
+
+		// Deactivate WP Super Cache Plugin.
+		$I->deactivateThirdPartyPlugin($I, 'wp-rocket');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.


### PR DESCRIPTION
## Summary

The notice added by [this PR](https://github.com/Kit/convertkit-wordpress/pull/465) is a bit confusing for some creators, who think they still need to configure something when looking at other issues, such as form display - even if their caching Plugin is configured.

We already have conditional notices displayed on steps to take should a creator use a caching Plugin that we cannot automatically configure ([this PR](https://github.com/Kit/convertkit-wordpress/pull/469)).

This PR also includes automatic configuration for WP Rocket.

## Testing

`testRestrictContentWPRocketCache`: Test that Member Content is excluded from caching when WP Rocket is active and the subscriber logs in.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)