### PR TITLE
Form Subscribe: Add `referrer` support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "2.0.5"
+        "convertkit/convertkit-wordpress-libraries": "dev-add-form-referrer-support"
     },
     "require-dev": {
         "lucatume/wp-browser": "<3.5",

--- a/includes/integrations/contactform7/class-convertkit-contactform7.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7.php
@@ -163,7 +163,7 @@ class ConvertKit_ContactForm7 {
 				}
 
 				// Add subscriber to form.
-				return $api->add_subscriber_to_form( $resource_id, $subscriber['subscriber']['id'] );
+				return $api->add_subscriber_to_form( $resource_id, $subscriber['subscriber']['id'], $this->get_referrer_url() );
 
 			/**
 			 * Sequence
@@ -196,6 +196,29 @@ class ConvertKit_ContactForm7 {
 				return $api->tag_subscriber( $resource_id, $subscriber['subscriber']['id'] );
 
 		}
+
+	}
+
+	/**
+	 * Gets the referrer URL to send to the `form_subscribe` API method.
+	 *
+	 * Falls back to the action's AJAX URL if the Post ID the form was
+	 * embedded in cannot be determined.
+	 *
+	 * @since   2.7.1
+	 *
+	 * @return  string
+	 */
+	private function get_referrer_url() {
+
+		// If the request includes the Post ID the form was embedded in,
+		// return that URL.
+		if ( array_key_exists( '_wpcf7_container_post', $_REQUEST ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return get_permalink( absint( $_REQUEST['_wpcf7_container_post'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		}
+
+		// Return the AJAX URL.
+		return home_url( add_query_arg( null, null ) );
 
 	}
 

--- a/includes/integrations/forminator/class-convertkit-forminator.php
+++ b/includes/integrations/forminator/class-convertkit-forminator.php
@@ -161,7 +161,7 @@ class ConvertKit_Forminator {
 				}
 
 				// Add subscriber to form.
-				return $api->add_subscriber_to_form( $resource_id, $subscriber['subscriber']['id'] );
+				return $api->add_subscriber_to_form( $resource_id, $subscriber['subscriber']['id'], $this->get_referrer_url() );
 
 			/**
 			 * Sequence
@@ -194,6 +194,36 @@ class ConvertKit_Forminator {
 				return $api->tag_subscriber( $resource_id, $subscriber['subscriber']['id'] );
 
 		}
+
+	}
+
+	/**
+	 * Gets the referrer URL to send to the `form_subscribe` API method.
+	 *
+	 * Falls back to the action's AJAX URL if the Post ID the form was
+	 * embedded in cannot be determined.
+	 *
+	 * @since   2.7.1
+	 *
+	 * @return  string
+	 */
+	private function get_referrer_url() {
+
+		// If the request includes the HTTP referrer, return that URL
+		// as it will include any UTM parameters.
+		if ( array_key_exists( '_wp_http_referer', $_REQUEST ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			// referrer is a relative path, so use home_url() to return a fully qualified URL.
+			return esc_url( home_url( $_REQUEST['_wp_http_referer'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		}
+
+		// If the request includes the current_url, return that URL.
+		// It won't include any UTM parameters, but is still an accurate URL.
+		if ( array_key_exists( 'current_url', $_REQUEST ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return esc_url( $_REQUEST['current_url'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		}
+
+		// Return the AJAX URL.
+		return home_url( add_query_arg( null, null ) );
 
 	}
 

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -69,6 +69,46 @@ class ConvertKitAPI extends \Codeception\Module
 	}
 
 	/**
+	 * Check the given subscriber ID has been assigned to the given form ID.
+	 *
+	 * @since   2.7.1
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 * @param   int              $subscriberID  Subscriber ID.
+	 * @param   int              $formID        Form ID.
+	 * @param   string           $referrer      Referrer.
+	 */
+	public function apiCheckSubscriberHasForm($I, $subscriberID, $formID, $referrer = false)
+	{
+		// Run request.
+		$results = $this->apiRequest(
+			'forms/' . $formID . '/subscribers',
+			'GET',
+			[
+				// Check all subscriber states.
+				'status' => 'all',
+			]
+		);
+
+		// Iterate through subscribers.
+		$subscriberHasForm = false;
+		foreach ($results['subscribers'] as $subscriber) {
+			if ($subscriber['id'] === $subscriberID) {
+				$subscriberHasForm = true;
+				break;
+			}
+		}
+
+		// Assert if the subscriber has the form.
+		$this->assertTrue($subscriberHasForm);
+
+		// If a referrer is specified, assert it matches the subscriber's referrer now.
+		if ($referrer) {
+			$I->assertEquals($subscriber['referrer'], $referrer);
+		}
+	}
+
+	/**
 	 * Check the given subscriber ID has been assigned to the given sequence ID.
 	 *
 	 * @since   2.5.2

--- a/tests/acceptance/integrations/other/ContactForm7FormCest.php
+++ b/tests/acceptance/integrations/other/ContactForm7FormCest.php
@@ -62,7 +62,15 @@ class ContactForm7FormCest
 		);
 
 		// Confirm that the email address was added to ConvertKit.
-		$I->apiCheckSubscriberExists($I, $emailAddress);
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriberID,
+			$_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL'] . $I->grabFromCurrentUrl()
+		);
 	}
 
 	/**

--- a/tests/acceptance/integrations/other/ForminatorCest.php
+++ b/tests/acceptance/integrations/other/ForminatorCest.php
@@ -62,7 +62,15 @@ class ForminatorCest
 		);
 
 		// Confirm that the email address was added to ConvertKit.
-		$I->apiCheckSubscriberExists($I, $emailAddress);
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriberID,
+			$_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL'] . $I->grabFromCurrentUrl()
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Specifies the URL a Contact Form 7 or Forminator Form is embedded as the `referrer` parameter, when configured to subscribe the email address to a Kit Form.

![Screenshot 2025-01-02 at 10 31 20](https://github.com/user-attachments/assets/3158b93b-cb41-454b-a1e6-f12ddf9f0221)

![Screenshot 2025-01-02 at 10 31 11](https://github.com/user-attachments/assets/ff8ab486-7c3f-4989-9498-86a0910f8a92)

## Testing

- `testSettingsContactForm7ToConvertKitFormMapping`: Updated test to confirm the subscriber is subscribed to the Kit Form, and has the expected referrer URL.
- `testSettingsForminatorFormToConvertKitFormMapping`: Updated test to confirm the subscriber is subscribed to the Kit Form, and has the expected referrer URL.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)