### PR TITLE
Fix reCAPTCHA Test

### DIFF
--- a/tests/acceptance/restrict-content/general/RestrictContentTagCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentTagCest.php
@@ -100,7 +100,7 @@ class RestrictContentTagCest
 			[
 				'recaptcha_site_key'      => $_ENV['CONVERTKIT_API_RECAPTCHA_SITE_KEY'],
 				'recaptcha_secret_key'    => $_ENV['CONVERTKIT_API_RECAPTCHA_SECRET_KEY'],
-				'recaptcha_minimum_score' => '0.5',
+				'recaptcha_minimum_score' => '0.01', // Set a low score to ensure reCAPTCHA passes the subscriber.
 			]
 		);
 


### PR DESCRIPTION
## Summary

This test fails as it's been run many times through GitHub actions, and Google rightly thinks the test email addresses are spammy.

Fixes the test by deliberately lowering the minimum score setting.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)