### PR TITLE
Add Refresh Resource Button to Blocks and Shortcode UI

### DIFF
--- a/includes/blocks/class-convertkit-block-form-trigger.php
+++ b/includes/blocks/class-convertkit-block-form-trigger.php
@@ -270,7 +270,8 @@ class ConvertKit_Block_Form_Trigger extends ConvertKit_Block {
 		return array(
 			'form'             => array(
 				'label'       => __( 'Form', 'convertkit' ),
-				'type'        => 'select',
+				'type'        => 'resource',
+				'resource'    => 'forms',
 				'values'      => $forms,
 				'description' => __( 'The modal, sticky bar or slide in form to display when the button is pressed. To embed a form, use the Kit Form block instead.', 'convertkit' ),
 			),

--- a/includes/blocks/class-convertkit-block-form.php
+++ b/includes/blocks/class-convertkit-block-form.php
@@ -225,10 +225,11 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 
 		return array(
 			'form' => array(
-				'label'  => __( 'Form', 'convertkit' ),
-				'type'   => 'select',
-				'values' => $forms,
-				'data'   => array(
+				'label'    => __( 'Form', 'convertkit' ),
+				'type'     => 'resource',
+				'resource' => 'forms',
+				'values'   => $forms,
+				'data'     => array(
 					// Used by resources/backend/js/gutenberg-block-form.js to determine the selected form's format
 					// (modal, slide in, sticky bar) and output a message in the block editor for the preview to explain
 					// why some formats cannot be previewed.

--- a/includes/blocks/class-convertkit-block-product.php
+++ b/includes/blocks/class-convertkit-block-product.php
@@ -300,9 +300,10 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 		// automatically by Gutenberg.
 		return array(
 			'product'                 => array(
-				'label'  => __( 'Product', 'convertkit' ),
-				'type'   => 'select',
-				'values' => $products,
+				'label'    => __( 'Product', 'convertkit' ),
+				'type'     => 'resource',
+				'resource' => 'products',
+				'values'   => $products,
 			),
 			'text'                    => array(
 				'label'       => __( 'Button Text', 'convertkit' ),

--- a/includes/integrations/divi/class-convertkit-divi-module.php
+++ b/includes/integrations/divi/class-convertkit-divi-module.php
@@ -144,6 +144,7 @@ class ConvertKit_Divi_Module extends ET_Builder_Module {
 					// Divi won't pass the underlying value, resulting in no output.
 					// Forcing a 'None' option as the first ensures the user must select an <option>, therefore
 					// ensuring output is correct.
+					$fields[ $field_name ]['type']    = 'select';
 					$fields[ $field_name ]['options'] = array( 0 => __( '(None)', 'convertkit' ) ) + $field['values'];
 					break;
 

--- a/includes/integrations/divi/class-convertkit-divi-module.php
+++ b/includes/integrations/divi/class-convertkit-divi-module.php
@@ -138,6 +138,7 @@ class ConvertKit_Divi_Module extends ET_Builder_Module {
 				/**
 				 * Select
 				 */
+				case 'resource':
 				case 'select':
 					// For select dropdowns, Divi treats the first <option> as the default. If it's selected,
 					// Divi won't pass the underlying value, resulting in no output.

--- a/includes/integrations/elementor/class-convertkit-elementor-widget.php
+++ b/includes/integrations/elementor/class-convertkit-elementor-widget.php
@@ -183,6 +183,7 @@ class ConvertKit_Elementor_Widget extends Elementor\Widget_Base {
 			/**
 			 * Select
 			 */
+			case 'resource':
 			case 'select':
 				$control = array_merge(
 					$control,

--- a/resources/backend/css/gutenberg.css
+++ b/resources/backend/css/gutenberg.css
@@ -1,3 +1,4 @@
+/* Block editor */
 .wp-block .convertkit-no-content {
 	padding: 90px 20px 20px 20px;
 	background: url(../images/kit-logo.svg) 50% 25px no-repeat;
@@ -31,4 +32,14 @@
 .convertkit-popover .components-popover__content {
 	width: 300px;
 	padding: 15px;
+}
+
+/* Sidebar */
+.components-flex-item button.convertkit-block-refresh {
+	margin: 24px 0 0 0;
+	padding: 0;
+	height: 32px;
+}
+.components-flex-item button.convertkit-block-refresh span.dashicons {
+	vertical-align: sub;
 }

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -366,7 +366,6 @@ function convertKitGutenbergRegisterBlock( block ) {
 			}
 
 			if ( typeof block.gutenberg_preview_render_callback !== 'undefined' ) {
-				console.log( 'custom preview ' + block.name );
 				// Use a custom callback function to render this block's preview in the Gutenberg Editor.
 				// This doesn't affect the output for this block on the frontend site, which will always
 				// use the block's PHP's render() function.

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -50,6 +50,9 @@ function convertKitGutenbergRegisterBlock( block ) {
 			TextControl,
 			SelectControl,
 			ToggleControl,
+			Flex,
+			FlexItem,
+			FlexBlock,
 			Panel,
 			PanelBody,
 			PanelRow
@@ -172,12 +175,29 @@ function convertKitGutenbergRegisterBlock( block ) {
 					];
 
 					// If select field type is for resources (forms, products etc),
-					// include a refresh button.
+					// include a refresh button in a flex layout.
 					if ( field.type === 'resource' ) {
-						selectField.push( refreshButton( props, buttonDisabled, setButtonDisabled ) );
+						return el(
+							Flex,
+							{
+								align: 'start',
+							},
+							[
+								el(
+									FlexItem,
+									{},
+									selectField
+								),
+								el(
+									FlexItem,
+									{},
+									refreshButton( props, buttonDisabled, setButtonDisabled, false )
+								)
+							]
+						);
 					}
 
-					// Return field element.
+					// Just return the select field element.
 					return selectField;
 					break;
 
@@ -313,6 +333,9 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 */
 		const editBlock = function ( props ) {
 
+			// useState to toggle the refresh button's disabled state.
+			const [ buttonDisabled, setButtonDisabled ] = useState( false );
+
 			// If requesting an example of how this block looks (which is requested
 			// when the user adds a new block and hovers over this block's icon),
 			// show the preview image.
@@ -328,9 +351,6 @@ function convertKitGutenbergRegisterBlock( block ) {
 					)
 				);
 			}
-
-			// useState to toggle the refresh button's disabled state.
-			const [ buttonDisabled, setButtonDisabled ] = useState( false );
 
 			// Build Inspector Control Panels, which will appear in the Sidebar when editing the Block.
 			let panels = getPanels( props, buttonDisabled, setButtonDisabled );
@@ -391,14 +411,14 @@ function convertKitGutenbergRegisterBlock( block ) {
 				// Refresh button disabled; display a spinner and the button.
 				elements = [
 					spinner( props ),
-					refreshButton( props, buttonDisabled, setButtonDisabled )
+					refreshButton( props, buttonDisabled, setButtonDisabled, true )
 				];
 			} else {
 				// Refresh button enabled; display the notice, link and button.
 				elements = [
 					( ! block.has_access_token ? block.no_access_token.notice : block.no_resources.notice ),
 					noticeLink( props, setButtonDisabled ),
-					refreshButton( props, buttonDisabled, setButtonDisabled )
+					refreshButton( props, buttonDisabled, setButtonDisabled, true )
 				];
 			}
 
@@ -497,9 +517,10 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 * @param 	object 	props 				Block properties.
 		 * @param 	bool 	buttonDisabled 		Whether the refresh button is disabled (true) or enabled (false)/
 		 * @param 	object 	setButtonDisabled 	Function to enable or disable the refresh button.
+		 * @param 	bool 	displayText 		Display text in button.
 		 * @return 	object 						Button.
 		 */
-		const refreshButton = function ( props, buttonDisabled, setButtonDisabled ) {
+		const refreshButton = function ( props, buttonDisabled, setButtonDisabled, displayText ) {
 
 			return el(
 				Button,
@@ -507,7 +528,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 					key: props.clientId + '-refresh-button',
 					className: 'button button-secondary convertkit-block-refresh',
 					disabled: buttonDisabled,
-					text: 'Refresh',
+					text: ( displayText === true ? 'Refresh' : '' ),
 					icon: dashIcon( 'update' ),
 					onClick: function () {
 

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -133,6 +133,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 			// Define additional Field Properties and the Field Element,
 			// depending on the Field Type (select, textarea, text etc).
 			switch ( field.type ) {
+
 				case 'select':
 					// Build options for <select> input.
 					fieldOptions.push(
@@ -164,7 +165,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 					// Assign options to field.
 					fieldProperties.options = fieldOptions;
 
-					// Define select field.
+					// Return field element.
 					return el(
 						SelectControl,
 						fieldProperties
@@ -562,6 +563,14 @@ function convertKitGutenbergRegisterBlock( block ) {
 
 		}
 
+		/**
+		 * Returns an inline refresh button, used to refresh a block's resources.
+		 *
+		 * @since 	2.7.1
+		 *
+		 * @param 	object 	props 				Block properties.
+		 * @return 	object 						Button.
+		 */
 		const inlineRefreshButton = function ( props ) {
 
 			return el(

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -573,17 +573,33 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 */
 		const inlineRefreshButton = function ( props ) {
 
+			return el( blockInlineRefreshButton, props );
+
+		}
+
+		/**
+		 * Returns a refresh button.
+		 *
+		 * @since 	2.7.1
+		 *
+		 * @param 	object 	props 	Block properties.
+		 * @return 	object 	Button.
+		 */
+		const blockInlineRefreshButton = function ( props ) {
+
+			const [ buttonDisabled, setButtonDisabled ] = useState( false );
+
 			return el(
 				Button,
 				{
 					key: props.clientId + '-refresh-button',
 					className: 'button button-secondary convertkit-block-refresh',
-					disabled: false,
+					disabled: buttonDisabled,
 					icon: dashIcon( 'update' ),
 					onClick: function () {
 
 						// Refresh block definitions.
-						refreshBlocksDefinitions( props );
+						refreshBlocksDefinitions( props, setButtonDisabled );
 
 					}
 				}

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -142,7 +142,10 @@ function convertKitGutenbergRegisterBlock( block ) {
 							value: '',
 						}
 					);
-					for ( let value in field.values ) {
+					for ( const value of Object.keys( field.values ) ) {
+						console.log( field.values[ value ] );
+						console.log( value );
+
 						fieldOptions.push(
 							{
 								label: field.values[ value ],
@@ -180,7 +183,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 							value: '',
 						}
 					);
-					for ( let value in field.values ) {
+					for ( const value of Object.keys( field.values ) ) {
 						fieldOptions.push(
 							{
 								label: field.values[ value ],

--- a/resources/backend/js/modal.js
+++ b/resources/backend/js/modal.js
@@ -18,6 +18,9 @@ document.addEventListener(
 
 				// Check if a cancel button was clicked.
 				if ( e.target.matches( '#convertkit-modal-body div.mce-cancel button, #convertkit-modal-body div.mce-cancel button *, #convertkit-quicktags-modal .media-toolbar .media-toolbar-secondary button.cancel' ) ) {
+
+					console.log( 'cancel' );
+
 					// TinyMCE.
 					if ( typeof tinyMCE !== 'undefined' && tinyMCE.activeEditor && ! tinyMCE.activeEditor.isHidden() ) {
 						tinymce.activeEditor.windowManager.close();
@@ -37,9 +40,16 @@ document.addEventListener(
 			function ( e ) {
 
 				// Check if an insert button was clicked.
-				if ( e.target.matches( '#convertkit-modal-body div.mce-insert button, #convertkit-modal-body div.mce-insert button *, #convertkit-quicktags-modal .media-toolbar .media-toolbar-primary button.button-primary' ) ) {
+				if ( e.target.matches( '#convertkit-modal-body div.mce-insert button, #convertkit-modal-body div.mce-insert button *, #convertkit-quicktags-modal .media-toolbar .media-toolbar-primary button.button-primary' ) ||
+					e.target.matches( 'button.wp-convertkit-refresh-resources, span.dashicons-update' ) ) {
+
 					// Prevent default action.
 					e.preventDefault();
+
+					// Don't close the modal if the refresh button was clicked.
+					if ( e.target.matches( 'button.wp-convertkit-refresh-resources, span.dashicons-update' ) ) {
+						return;
+					}
 
 					// Get containing form.
 					const form = document.querySelector( 'form.convertkit-tinymce-popup' );

--- a/resources/backend/js/modal.js
+++ b/resources/backend/js/modal.js
@@ -19,8 +19,6 @@ document.addEventListener(
 				// Check if a cancel button was clicked.
 				if ( e.target.matches( '#convertkit-modal-body div.mce-cancel button, #convertkit-modal-body div.mce-cancel button *, #convertkit-quicktags-modal .media-toolbar .media-toolbar-secondary button.cancel' ) ) {
 
-					console.log( 'cancel' );
-
 					// TinyMCE.
 					if ( typeof tinyMCE !== 'undefined' && tinyMCE.activeEditor && ! tinyMCE.activeEditor.isHidden() ) {
 						tinymce.activeEditor.windowManager.close();
@@ -63,7 +61,7 @@ document.addEventListener(
 						function ( element ) {
 							// Skip if no data-shortcode attribute.
 							if ( ! element.dataset.shortcode ) {
-									return;
+								return;
 							}
 
 							let val = '';

--- a/resources/backend/js/quicktags.js
+++ b/resources/backend/js/quicktags.js
@@ -76,6 +76,9 @@ function convertKitQuickTagRegister( block ) {
 
 					// Listen for color input changes.
 					convertKitColorInputInit();
+
+					// Bind refresh resource event listeners.
+					convertKitRefreshResourcesInitEventListeners();
 				}
 			)
 			.catch(

--- a/resources/backend/js/tinymce.js
+++ b/resources/backend/js/tinymce.js
@@ -97,6 +97,9 @@ function convertKitTinyMCERegisterPlugin( block ) {
 
 							// Listen for color input changes.
 							convertKitColorInputInit();
+
+							// Bind refresh resource event listeners.
+							convertKitRefreshResourcesInitEventListeners();
 						}
 					)
 					.catch(

--- a/tests/_support/Helper/Acceptance/ConvertKitPlugin.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitPlugin.php
@@ -794,7 +794,7 @@ class ConvertKitPlugin extends \Codeception\Module
 
 		// Wait for the refresh button to disappear, confirming that the block refresh completed
 		// and that resources now exist.
-		$I->waitForElementNotVisible('button.convertkit-block-refresh');
+		$I->waitForElementNotVisible('div.convertkit-no-content button.convertkit-block-refresh');
 
 		// Confirm that the block displays the expected message.
 		if ($expectedMessage) {

--- a/tests/acceptance/broadcasts/blocks-shortcodes/PageBlockBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/blocks-shortcodes/PageBlockBroadcastsCest.php
@@ -131,10 +131,10 @@ class PageBlockBroadcastsCest
 		$I->setupConvertKitPluginResources($I);
 
 		// Click the refresh button.
-		$I->click('button.convertkit-block-refresh');
+		$I->click('div.convertkit-no-content button.convertkit-block-refresh');
 
 		// Wait for the refresh button to disappear, confirming that an API Key and resources now exist.
-		$I->waitForElementNotVisible('button.convertkit-block-refresh');
+		$I->waitForElementNotVisible('div.convertkit-no-content button.convertkit-block-refresh');
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);

--- a/tests/acceptance/forms/blocks-shortcodes/PageBlockFormCest.php
+++ b/tests/acceptance/forms/blocks-shortcodes/PageBlockFormCest.php
@@ -597,7 +597,7 @@ class PageBlockFormCest
 	 */
 	public function testFormBlockRefreshButton(AcceptanceTester $I)
 	{
-		// Setup Plugin with ConvertKit Account that has no Broadcasts.
+		// Setup Plugin with ConvertKit Account that has no Forms.
 		$I->setupConvertKitPluginCredentialsNoData($I);
 		$I->setupConvertKitPluginResourcesNoData($I);
 
@@ -613,10 +613,10 @@ class PageBlockFormCest
 		$I->setupConvertKitPluginResources($I);
 
 		// Click the refresh button.
-		$I->click('button.convertkit-block-refresh');
+		$I->click('div.convertkit-no-content button.convertkit-block-refresh');
 
 		// Wait for the refresh button to disappear, confirming that an API Key and resources now exist.
-		$I->waitForElementNotVisible('button.convertkit-block-refresh');
+		$I->waitForElementNotVisible('div.convertkit-no-content button.convertkit-block-refresh');
 
 		// Confirm that the Form block displays instructions to the user on how to select a Form.
 		$I->see(

--- a/tests/acceptance/forms/blocks-shortcodes/PageBlockFormTriggerCest.php
+++ b/tests/acceptance/forms/blocks-shortcodes/PageBlockFormTriggerCest.php
@@ -438,7 +438,7 @@ class PageBlockFormTriggerCest
 	 */
 	public function testFormTriggerBlockRefreshButton(AcceptanceTester $I)
 	{
-		// Setup Plugin with ConvertKit Account that has no Broadcasts.
+		// Setup Plugin with ConvertKit Account that has no Forms.
 		$I->setupConvertKitPluginCredentialsNoData($I);
 		$I->setupConvertKitPluginResourcesNoData($I);
 
@@ -454,10 +454,10 @@ class PageBlockFormTriggerCest
 		$I->setupConvertKitPluginResources($I);
 
 		// Click the refresh button.
-		$I->click('button.convertkit-block-refresh');
+		$I->click('div.convertkit-no-content button.convertkit-block-refresh');
 
 		// Wait for the refresh button to disappear, confirming that an API Key and resources now exist.
-		$I->waitForElementNotVisible('button.convertkit-block-refresh');
+		$I->waitForElementNotVisible('div.convertkit-no-content button.convertkit-block-refresh');
 
 		// Confirm that the Form Trigger block displays instructions to the user on how to select a Form.
 		$I->see(

--- a/tests/acceptance/general/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/general/RefreshResourcesButtonCest.php
@@ -404,14 +404,124 @@ class RefreshResourcesButtonCest
 		$I->publishAndViewGutenbergPage($I);
 	}
 
+	/**
+	 * Test that the refresh button for Forms works when using the Form shortcode in the
+	 * TinyMCE Editor.
+	 *
+	 * @since   2.7.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
 	public function testRefreshResourcesOnFormShortcodeUsingTinyMCE(AcceptanceTester $I)
 	{
-		
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Define one cached Form, as if the Forms resource class populated them from the API.
+		$I->haveOptionInDatabase(
+			'convertkit_forms',
+			[
+				3003590 => [
+					'id'         => 3003590,
+					'name'       => 'Third Party Integrations Form',
+					'created_at' => '2022-02-17T15:05:31.000Z',
+					'type'       => 'embed',
+					'format'     => 'inline',
+					'embed_js'   => 'https://cheerful-architect-3237.kit.com/71cbcc4042/index.js',
+					'embed_url'  => 'https://cheerful-architect-3237.kit.com/71cbcc4042',
+					'archived'   => false,
+					'uid'        => '71cbcc4042',
+				],
+			]
+		);
+
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form: Shortcode: Visual Editor: Refresh Button');
+
+		// Open Visual Editor shortcode modal.
+		$I->openVisualEditorShortcodeModal($I, 'Kit Form');
+
+		// Wait for the modal's form to load.
+		$I->waitForElementVisible('#convertkit-modal-body form.convertkit-tinymce-popup');
+
+		// Click the Forms refresh button.
+		$I->click('#convertkit-modal-body-body button.wp-convertkit-refresh-resources[data-resource="forms"]');
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible('#convertkit-modal-body-body  button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
+
+		// Confirm that the Form option contains all Forms by selecting a Form that wasn't in the cache
+		// and was fetched via the API.
+		$I->selectOption('form', $_ENV['CONVERTKIT_API_FORM_NAME']);
+
+		// Click the Insert button.
+		$I->click('#convertkit-modal-body div.mce-insert button');
+
+		// Confirm the modal closes.
+		$I->waitForElementNotVisible('#convertkit-modal-body');
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage($I);
 	}
 
+	/**
+	 * Test that the refresh button for Forms works when using the Form shortcode in the
+	 * Text Editor.
+	 *
+	 * @since   2.7.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
 	public function testRefreshResourcesOnFormShortcodeUsingTextEditor(AcceptanceTester $I)
 	{
-		
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Define one cached Form, as if the Forms resource class populated them from the API.
+		$I->haveOptionInDatabase(
+			'convertkit_forms',
+			[
+				3003590 => [
+					'id'         => 3003590,
+					'name'       => 'Third Party Integrations Form',
+					'created_at' => '2022-02-17T15:05:31.000Z',
+					'type'       => 'embed',
+					'format'     => 'inline',
+					'embed_js'   => 'https://cheerful-architect-3237.kit.com/71cbcc4042/index.js',
+					'embed_url'  => 'https://cheerful-architect-3237.kit.com/71cbcc4042',
+					'archived'   => false,
+					'uid'        => '71cbcc4042',
+				],
+			]
+		);
+
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form: Shortcode: Text Editor: Refresh Button');
+
+		// Open Text Editor shortcode modal.
+		$I->openTextEditorShortcodeModal($I, 'convertkit-form');
+
+		// Wait for the modal's form to load.
+		$I->waitForElementVisible('#convertkit-quicktags-modal form.convertkit-tinymce-popup');
+
+		// Click the Forms refresh button.
+		$I->click('#convertkit-quicktags-modal button.wp-convertkit-refresh-resources[data-resource="forms"]');
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible('#convertkit-quicktags-modal button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
+
+		// Confirm that the Form option contains all Forms by selecting a Form that wasn't in the cache
+		// and was fetched via the API.
+		$I->selectOption('form', $_ENV['CONVERTKIT_API_FORM_NAME']);
+
+		// Click the Insert button.
+		$I->click('#convertkit-quicktags-modal button.button-primary');
+
+		// Confirm the modal closes.
+		$I->waitForElementNotVisible('#convertkit-quicktags-modal');
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage($I);
 	}
 
 	/**
@@ -468,7 +578,127 @@ class RefreshResourcesButtonCest
 		$I->publishAndViewGutenbergPage($I);
 	}
 
-/**
+	/**
+	 * Test that the refresh button for Forms works when using the Form Trigger shortcode in the
+	 * TinyMCE Editor.
+	 *
+	 * @since   2.7.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRefreshResourcesOnFormTriggerShortcodeUsingTinyMCE(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Define one cached non-inline Form, as if the Forms resource class populated them from the API.
+		$I->haveOptionInDatabase(
+			'convertkit_forms',
+			[
+				2780979 => [
+					'id'         => 2780979,
+					'name'       => 'Slide In Form',
+					'created_at' => '2021-11-17T04:22:24.000Z',
+					'type'       => 'embed',
+					'format'     => 'slide in',
+					'embed_js'   => 'https://cheerful-architect-3237.kit.com/e0d65bed9d/index.js',
+					'embed_url'  => 'https://cheerful-architect-3237.kit.com/e0d65bed9d',
+					'archived'   => false,
+					'uid'        => 'e0d65bed9d',
+				],
+			]
+		);
+
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form Trigger: Shortcode: Visual Editor: Refresh Button');
+
+		// Open Visual Editor shortcode modal.
+		$I->openVisualEditorShortcodeModal($I, 'Kit Form Trigger');
+
+		// Wait for the modal's form to load.
+		$I->waitForElementVisible('#convertkit-modal-body form.convertkit-tinymce-popup');
+
+		// Click the Forms refresh button.
+		$I->click('#convertkit-modal-body-body button.wp-convertkit-refresh-resources[data-resource="forms"]');
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible('#convertkit-modal-body-body  button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
+
+		// Confirm that the Form option contains all Forms by selecting a Form that wasn't in the cache
+		// and was fetched via the API.
+		$I->selectOption('form', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME']);
+
+		// Click the Insert button.
+		$I->click('#convertkit-modal-body div.mce-insert button');
+
+		// Confirm the modal closes.
+		$I->waitForElementNotVisible('#convertkit-modal-body');
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage($I);
+	}
+
+	/**
+	 * Test that the refresh button for Forms works when using the Form Trigger shortcode in the
+	 * Text Editor.
+	 *
+	 * @since   2.7.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRefreshResourcesOnFormTriggerShortcodeUsingTextEditor(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Define one cached non-inline Form, as if the Forms resource class populated them from the API.
+		$I->haveOptionInDatabase(
+			'convertkit_forms',
+			[
+				2780979 => [
+					'id'         => 2780979,
+					'name'       => 'Slide In Form',
+					'created_at' => '2021-11-17T04:22:24.000Z',
+					'type'       => 'embed',
+					'format'     => 'slide in',
+					'embed_js'   => 'https://cheerful-architect-3237.kit.com/e0d65bed9d/index.js',
+					'embed_url'  => 'https://cheerful-architect-3237.kit.com/e0d65bed9d',
+					'archived'   => false,
+					'uid'        => 'e0d65bed9d',
+				],
+			]
+		);
+
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form Trigger: Shortcode: Text Editor: Refresh Button');
+
+		// Open Text Editor shortcode modal.
+		$I->openTextEditorShortcodeModal($I, 'convertkit-formtrigger');
+
+		// Wait for the modal's form to load.
+		$I->waitForElementVisible('#convertkit-quicktags-modal form.convertkit-tinymce-popup');
+
+		// Click the Forms refresh button.
+		$I->click('#convertkit-quicktags-modal button.wp-convertkit-refresh-resources[data-resource="forms"]');
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible('#convertkit-quicktags-modal button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
+
+		// Confirm that the Form option contains all Forms by selecting a Form that wasn't in the cache
+		// and was fetched via the API.
+		$I->selectOption('form', $_ENV['CONVERTKIT_API_FORM_NAME']);
+
+		// Click the Insert button.
+		$I->click('#convertkit-quicktags-modal button.button-primary');
+
+		// Confirm the modal closes.
+		$I->waitForElementNotVisible('#convertkit-quicktags-modal');
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage($I);
+	}
+
+	/**
 	 * Test that the refresh button for Products works when using the Product block.
 	 *
 	 * @since   2.7.1
@@ -515,6 +745,61 @@ class RefreshResourcesButtonCest
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
+	}
+
+	/**
+	 * Test that the refresh button for Products works when using the Products shortcode in the
+	 * TinyMCE Editor.
+	 *
+	 * @since   2.7.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRefreshResourcesOnProductShortcodeUsingTinyMCE(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Define one cached Product, as if the Products resource class populated them from the API.
+		$I->haveOptionInDatabase(
+			'convertkit_products',
+			[
+				42847 => [
+					'id'        => 42847,
+					'name'      => 'Example Tip Jar',
+					'url'       => 'https://cheerful-architect-3237.kit.com/products/example-tip-jar',
+					'published' => true,
+				],
+			]
+		);
+
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Product: Shortcode: Visual Editor: Refresh Button');
+
+		// Open Visual Editor shortcode modal.
+		$I->openVisualEditorShortcodeModal($I, 'Kit Product');
+
+		// Wait for the modal's form to load.
+		$I->waitForElementVisible('#convertkit-modal-body form.convertkit-tinymce-popup');
+
+		// Click the Forms refresh button.
+		$I->click('#convertkit-modal-body-body button.wp-convertkit-refresh-resources[data-resource="forms"]');
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible('#convertkit-modal-body-body  button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
+
+		// Confirm that the Form option contains all Forms by selecting a Form that wasn't in the cache
+		// and was fetched via the API.
+		$I->selectOption('form', $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
+
+		// Click the Insert button.
+		$I->click('#convertkit-modal-body div.mce-insert button');
+
+		// Confirm the modal closes.
+		$I->waitForElementNotVisible('#convertkit-modal-body');
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage($I);
 	}
 
 	/**

--- a/tests/acceptance/general/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/general/RefreshResourcesButtonCest.php
@@ -916,6 +916,7 @@ class RefreshResourcesButtonCest
 		$I->see('Kit: The access token is invalid');
 
 		// Confirm that the notice is dismissible.
+		$I->scrollTo('#wpbody');
 		$I->click('div.convertkit-error button.notice-dismiss');
 		$I->wait(1);
 		$I->dontSeeElementInDOM('div.convertkit-error');
@@ -956,6 +957,7 @@ class RefreshResourcesButtonCest
 		$I->see('Kit: The access token is invalid');
 
 		// Confirm that the notice is dismissible.
+		$I->scrollTo('#wpbody');
 		$I->click('div.convertkit-error button.notice-dismiss');
 		$I->wait(1);
 		$I->dontSeeElementInDOM('div.convertkit-error');
@@ -1004,6 +1006,7 @@ class RefreshResourcesButtonCest
 		$I->see('Kit: The access token is invalid');
 
 		// Confirm that the notice is dismissible.
+		$I->scrollTo('#wpbody');
 		$I->click('div.convertkit-error button.notice-dismiss');
 		$I->wait(1);
 		$I->dontSeeElementInDOM('div.convertkit-error');
@@ -1036,6 +1039,7 @@ class RefreshResourcesButtonCest
 		$I->see('Kit: The access token is invalid');
 
 		// Confirm that the notice is dismissible.
+		$I->scrollTo('#wpbody');
 		$I->click('div.convertkit-error button.notice-dismiss');
 		$I->wait(1);
 		$I->dontSeeElementInDOM('div.convertkit-error');
@@ -1072,6 +1076,7 @@ class RefreshResourcesButtonCest
 		$I->see('Kit: The access token is invalid');
 
 		// Confirm that the notice is dismissible.
+		$I->scrollTo('#wpbody');
 		$I->click('div.convertkit-error button.notice-dismiss');
 		$I->wait(1);
 		$I->dontSeeElementInDOM('div.convertkit-error');

--- a/tests/acceptance/general/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/general/RefreshResourcesButtonCest.php
@@ -1,7 +1,8 @@
 <?php
 /**
  * Tests Refresh Resource buttons, which are displayed next to settings fields
- * across Page/Post editing, Bulk/Quick edit and Category editing.
+ * across Page/Post editing, Bulk/Quick edit, Category editing, shortcodes
+ * and blocks.
  *
  * @since   1.9.8.0
  */
@@ -347,6 +348,173 @@ class RefreshResourcesButtonCest
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist in the Select2 field, this will fail the test.
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+	}
+
+	/**
+	 * Test that the refresh button for Forms works when using the Form block.
+	 *
+	 * @since   2.7.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRefreshResourcesOnFormBlock(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Define one cached Form, as if the Forms resource class populated them from the API.
+		$I->haveOptionInDatabase(
+			'convertkit_forms',
+			[
+				3003590 => [
+					'id'         => 3003590,
+					'name'       => 'Third Party Integrations Form',
+					'created_at' => '2022-02-17T15:05:31.000Z',
+					'type'       => 'embed',
+					'format'     => 'inline',
+					'embed_js'   => 'https://cheerful-architect-3237.kit.com/71cbcc4042/index.js',
+					'embed_url'  => 'https://cheerful-architect-3237.kit.com/71cbcc4042',
+					'archived'   => false,
+					'uid'        => '71cbcc4042',
+				],
+			]
+		);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'Kit: Page: Forms: Block: Refresh Button');
+
+		// Add block to Page.
+		$I->addGutenbergBlock(
+			$I,
+			'Kit Form',
+			'convertkit-form'
+		);
+
+		// Click the refresh button.
+		$I->click('div.components-flex-item button.convertkit-block-refresh');
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible('div.components-flex-item button.convertkit-block-refresh:not(:disabled)');
+
+		// Confirm that the Form option contains all Forms by selecting a Form that wasn't in the cache
+		// and was fetched via the API.
+		$I->selectOption('#convertkit_form_form', $_ENV['CONVERTKIT_API_FORM_NAME']);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+	}
+
+	public function testRefreshResourcesOnFormShortcodeUsingTinyMCE(AcceptanceTester $I)
+	{
+		
+	}
+
+	public function testRefreshResourcesOnFormShortcodeUsingTextEditor(AcceptanceTester $I)
+	{
+		
+	}
+
+	/**
+	 * Test that the refresh button for Forms works when using the Form Trigger block.
+	 *
+	 * @since   2.7.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRefreshResourcesOnFormTriggerBlock(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Define one cached non-inline Form, as if the Forms resource class populated them from the API.
+		$I->haveOptionInDatabase(
+			'convertkit_forms',
+			[
+				2780979 => [
+					'id'         => 2780979,
+					'name'       => 'Slide In Form',
+					'created_at' => '2021-11-17T04:22:24.000Z',
+					'type'       => 'embed',
+					'format'     => 'slide in',
+					'embed_js'   => 'https://cheerful-architect-3237.kit.com/e0d65bed9d/index.js',
+					'embed_url'  => 'https://cheerful-architect-3237.kit.com/e0d65bed9d',
+					'archived'   => false,
+					'uid'        => 'e0d65bed9d',
+				],
+			]
+		);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form Trigger: Block: Refresh Button');
+
+		// Add block to Page.
+		$I->addGutenbergBlock(
+			$I,
+			'Kit Form Trigger',
+			'convertkit-formtrigger'
+		);
+
+		// Click the refresh button.
+		$I->click('div.components-flex-item button.convertkit-block-refresh');
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible('div.components-flex-item button.convertkit-block-refresh:not(:disabled)');
+
+		// Confirm that the Form option contains all Forms by selecting a Form that wasn't in the cache
+		// and was fetched via the API.
+		$I->selectOption('#convertkit_formtrigger_form', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME']);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+	}
+
+/**
+	 * Test that the refresh button for Products works when using the Product block.
+	 *
+	 * @since   2.7.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRefreshResourcesOnProductBlock(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Define one cached Product, as if the Products resource class populated them from the API.
+		$I->haveOptionInDatabase(
+			'convertkit_products',
+			[
+				42847 => [
+					'id'        => 42847,
+					'name'      => 'Example Tip Jar',
+					'url'       => 'https://cheerful-architect-3237.kit.com/products/example-tip-jar',
+					'published' => true,
+				],
+			]
+		);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'Kit: Page: Product: Block: Refresh Button');
+
+		// Add block to Page.
+		$I->addGutenbergBlock(
+			$I,
+			'Kit Product',
+			'convertkit-product'
+		);
+
+		// Click the refresh button.
+		$I->click('div.components-flex-item button.convertkit-block-refresh');
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible('div.components-flex-item button.convertkit-block-refresh:not(:disabled)');
+
+		// Confirm that the Product option contains all Products by selecting a Product that wasn't in the cache
+		// and was fetched via the API.
+		$I->selectOption('#convertkit_product_product', $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
 	}
 
 	/**

--- a/tests/acceptance/general/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/general/RefreshResourcesButtonCest.php
@@ -782,21 +782,76 @@ class RefreshResourcesButtonCest
 		// Wait for the modal's form to load.
 		$I->waitForElementVisible('#convertkit-modal-body form.convertkit-tinymce-popup');
 
-		// Click the Forms refresh button.
-		$I->click('#convertkit-modal-body-body button.wp-convertkit-refresh-resources[data-resource="forms"]');
+		// Click the Products refresh button.
+		$I->click('#convertkit-modal-body-body button.wp-convertkit-refresh-resources[data-resource="products"]');
 
 		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible('#convertkit-modal-body-body  button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
+		$I->waitForElementVisible('#convertkit-modal-body-body  button.wp-convertkit-refresh-resources[data-resource="products"]:not(:disabled)');
 
-		// Confirm that the Form option contains all Forms by selecting a Form that wasn't in the cache
+		// Confirm that the Product option contains all Products by selecting a Product that wasn't in the cache
 		// and was fetched via the API.
-		$I->selectOption('form', $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
+		$I->selectOption('product', $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
 
 		// Click the Insert button.
 		$I->click('#convertkit-modal-body div.mce-insert button');
 
 		// Confirm the modal closes.
 		$I->waitForElementNotVisible('#convertkit-modal-body');
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage($I);
+	}
+
+	/**
+	 * Test that the refresh button for Products works when using the Product shortcode in the
+	 * Text Editor.
+	 *
+	 * @since   2.7.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRefreshResourcesOnProductShortcodeUsingTextEditor(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Define one cached Product, as if the Products resource class populated them from the API.
+		$I->haveOptionInDatabase(
+			'convertkit_products',
+			[
+				42847 => [
+					'id'        => 42847,
+					'name'      => 'Example Tip Jar',
+					'url'       => 'https://cheerful-architect-3237.kit.com/products/example-tip-jar',
+					'published' => true,
+				],
+			]
+		);
+
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Product: Shortcode: Text Editor: Refresh Button');
+
+		// Open Text Editor shortcode modal.
+		$I->openTextEditorShortcodeModal($I, 'convertkit-product');
+
+		// Wait for the modal's form to load.
+		$I->waitForElementVisible('#convertkit-quicktags-modal form.convertkit-tinymce-popup');
+
+		// Click the Products refresh button.
+		$I->click('#convertkit-quicktags-modal button.wp-convertkit-refresh-resources[data-resource="products"]');
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible('#convertkit-quicktags-modal button.wp-convertkit-refresh-resources[data-resource="products"]:not(:disabled)');
+
+		// Confirm that the Product option contains all Products by selecting a Product that wasn't in the cache
+		// and was fetched via the API.
+		$I->selectOption('product', $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
+
+		// Click the Insert button.
+		$I->click('#convertkit-quicktags-modal button.button-primary');
+
+		// Confirm the modal closes.
+		$I->waitForElementNotVisible('#convertkit-quicktags-modal');
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewClassicEditorPage($I);

--- a/tests/acceptance/products/PageBlockProductCest.php
+++ b/tests/acceptance/products/PageBlockProductCest.php
@@ -562,10 +562,10 @@ class PageBlockProductCest
 		$I->setupConvertKitPluginResources($I);
 
 		// Click the refresh button.
-		$I->click('button.convertkit-block-refresh');
+		$I->click('div.convertkit-no-content button.convertkit-block-refresh');
 
 		// Wait for the refresh button to disappear, confirming that an API Key and resources now exist.
-		$I->waitForElementNotVisible('button.convertkit-block-refresh');
+		$I->waitForElementNotVisible('div.convertkit-no-content button.convertkit-block-refresh');
 
 		// Confirm that the Product block displays instructions to the user on how to select a Product.
 		$I->see(

--- a/views/backend/tinymce/modal-field.php
+++ b/views/backend/tinymce/modal-field.php
@@ -43,6 +43,7 @@ switch ( $field['type'] ) {
 	/**
 	 * Select
 	 */
+	case 'resource':
 	case 'select':
 		?>
 		<select name="<?php echo esc_attr( $field_name ); ?>"
@@ -62,6 +63,22 @@ switch ( $field['type'] ) {
 			?>
 		</select>
 		<?php
+		// Display a refresh resource button if the field type is resource.
+		if ( $field['type'] === 'resource' ) {
+			$button_title = sprintf(
+				/* translators: Resource Type (Forms, Products, Tags etc). */
+				__( 'Refresh %s from Kit account', 'convertkit' ),
+				$field['resource']
+			);
+			?>
+			<button class="wp-convertkit-refresh-resources button button-secondary hide-if-no-js"
+					title="<?php echo esc_attr( $button_title ); ?>"
+					data-resource="<?php echo esc_attr( $field['resource'] ); ?>"
+					data-field="#tinymce_modal_<?php echo esc_attr( $field_name ); ?>">
+				<span class="dashicons dashicons-update"></span>
+			</button>
+			<?php
+		}
 		break;
 
 	/**


### PR DESCRIPTION
## Summary

Adds refresh buttons to the Form, Form Trigger and Product blocks and shortcodes, allowing creators to refresh the list of cached resources (forms, products) after adding them to Kit, without having to navigate to Settings > Kit ([example ticket](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263837351253?view=List)).

![Screenshot 2025-01-07 at 17 50 43](https://github.com/user-attachments/assets/00c34b63-2080-4b1c-8286-75f5398461ed)

## Testing

- `testRefreshResourcesOnFormBlock`: Test that refreshing resources works on the Form block
- `testRefreshResourcesOnFormShortcodeUsingTinyMCE`: Test that refreshing resources works on the Form shortcode in the TinyMCE editor
- `testRefreshResourcesOnFormShortcodeUsingTextEditor`: Test that refreshing resources works on the Form shortcode in the text editor
- `testRefreshResourcesOnFormTriggerBlock`: Test that refreshing resources works on the Form Trigger block
- `testRefreshResourcesOnFormTriggerShortcodeUsingTinyMCE`: Test that refreshing resources works on the Form Trigger shortcode in the TinyMCE editor
- `testRefreshResourcesOnFormTriggerShortcodeUsingTextEditor`: Test that refreshing resources works on the Form Trigger shortcode in the text editor
-`testRefreshResourcesOnProductBlock`: Test that refreshing resources works on the Product block
- `testRefreshResourcesOnProductShortcodeUsingTinyMCE`: Test that refreshing resources works on the Product shortcode in the TinyMCE editor
- `testRefreshResourcesOnProductShortcodeUsingTextEditor`: Test that refreshing resources works on the Product shortcode in the text editor

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)