### PR TITLE
Group Settings in UI

### DIFF
--- a/admin/class-convertkit-admin-settings-restrict-content.php
+++ b/admin/class-convertkit-admin-settings-restrict-content.php
@@ -37,14 +37,17 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			'general'  => array(
 				'title'    => $this->title,
 				'callback' => array( $this, 'print_section_info' ),
+				'wrap'	   => true,
 			),
 			'products' => array(
 				'title'    => __( 'Products', 'convertkit' ),
 				'callback' => array( $this, 'print_section_info_products' ),
+				'wrap'	   => true,
 			),
 			'tags'     => array(
 				'title'    => __( 'Tags', 'convertkit' ),
 				'callback' => array( $this, 'print_section_info_tags' ),
+				'wrap'	   => true,
 			),
 		);
 

--- a/admin/class-convertkit-admin-settings-restrict-content.php
+++ b/admin/class-convertkit-admin-settings-restrict-content.php
@@ -32,6 +32,22 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 		$this->title    = __( 'Member Content', 'convertkit' );
 		$this->tab_text = __( 'Member Content', 'convertkit' );
 
+		// Define settings sections.
+		$this->settings_sections = array(
+			'general' => array(
+				'title' => $this->title,
+				'callback' => array( $this, 'print_section_info' ),
+			),
+			'products' => array(
+				'title' => __( 'Products', 'convertkit' ),
+				'callback' => array( $this, 'print_section_info_products' ),
+			),
+			'tags' => array(
+				'title' => __( 'Tags', 'convertkit' ),
+				'callback' => array( $this, 'print_section_info_tags' ),
+			),
+		);
+
 		// Enqueue scripts.
 		add_action( 'convertkit_admin_settings_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 
@@ -86,12 +102,12 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			__( 'reCAPTCHA: Site Key', 'convertkit' ),
 			array( $this, 'text_callback' ),
 			$this->settings_key,
-			$this->name,
+			$this->name . '-tags',
 			array(
 				'name'        => 'recaptcha_site_key',
 				'label_for'   => 'recaptcha_site_key',
 				'description' => array(
-					__( 'Enter your Google reCAPTCHA v3 Site Key. When specified, this will be used in Member Content by Tag functionality to reduce spam signups.', 'convertkit' ),
+					__( 'Enter your Google reCAPTCHA v3 Site Key. When specified, this will be used to reduce spam signups.', 'convertkit' ),
 				),
 			)
 		);
@@ -100,12 +116,12 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			__( 'reCAPTCHA: Secret Key', 'convertkit' ),
 			array( $this, 'text_callback' ),
 			$this->settings_key,
-			$this->name,
+			$this->name . '-tags',
 			array(
 				'name'        => 'recaptcha_secret_key',
 				'label_for'   => 'recaptcha_secret_key',
 				'description' => array(
-					__( 'Enter your Google reCAPTCHA v3 Secret Key. When specified, this will be used in Member Content by Tag functionality to reduce spam signups.', 'convertkit' ),
+					__( 'Enter your Google reCAPTCHA v3 Secret Key. When specified, this will be used to reduce spam signups.', 'convertkit' ),
 				),
 			)
 		);
@@ -114,7 +130,7 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			__( 'reCAPTCHA: Minimum Score', 'convertkit' ),
 			array( $this, 'number_callback' ),
 			$this->settings_key,
-			$this->name,
+			$this->name . '-tags',
 			array(
 				'name'        => 'recaptcha_minimum_score',
 				'label_for'   => 'recaptcha_minimum_score',
@@ -127,64 +143,64 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			)
 		);
 
-		// Restrict by Product.
-		add_settings_field(
-			'subscribe_heading',
-			__( 'Product: Subscribe Heading', 'convertkit' ),
-			array( $this, 'text_callback' ),
-			$this->settings_key,
-			$this->name,
-			array(
-				'name'        => 'subscribe_heading',
-				'label_for'   => 'subscribe_heading',
-				'description' => array(
-					__( 'When a Page, Post or Custom Post\'s Member Content setting is set to a Kit Product, displays text in a heading explaining why the content is only available to subscribers.', 'convertkit' ),
-				),
-			)
-		);
-
-		add_settings_field(
-			'subscribe_text',
-			__( 'Product: Subscribe Text', 'convertkit' ),
-			array( $this, 'textarea_callback' ),
-			$this->settings_key,
-			$this->name,
-			array(
-				'name'        => 'subscribe_text',
-				'label_for'   => 'subscribe_text',
-				'description' => array(
-					__( 'When a Page, Post or Custom Post\'s Member Content setting is set to a Kit Product, displays text explaining why the content is only available to subscribers.', 'convertkit' ),
-				),
-			)
-		);
-
 		// Restrict by Tag.
 		add_settings_field(
 			'subscribe_heading_tag',
-			__( 'Tag: Subscribe Heading', 'convertkit' ),
+			__( 'Subscribe Heading', 'convertkit' ),
 			array( $this, 'text_callback' ),
 			$this->settings_key,
-			$this->name,
+			$this->name . '-tags',
 			array(
 				'name'        => 'subscribe_heading_tag',
 				'label_for'   => 'subscribe_heading_tag',
 				'description' => array(
-					__( 'When a Page, Post or Custom Post\'s Member Content setting is set to a Kit Tag, displays text in a heading explaining why the content is only available to subscribers.', 'convertkit' ),
+					__( 'Displays text in a heading explaining why the content is only available to subscribers.', 'convertkit' ),
 				),
 			)
 		);
 
 		add_settings_field(
 			'subscribe_text_tag',
-			__( 'Tag: Subscribe Text', 'convertkit' ),
+			__( 'Subscribe Text', 'convertkit' ),
 			array( $this, 'textarea_callback' ),
 			$this->settings_key,
-			$this->name,
+			$this->name . '-tags',
 			array(
 				'name'        => 'subscribe_text_tag',
 				'label_for'   => 'subscribe_text_tag',
 				'description' => array(
-					__( 'When a Page, Post or Custom Post\'s Member Content setting is set to a Kit Tag, displays text explaining why the content is only available to subscribers.', 'convertkit' ),
+					__( 'Displays text explaining why the content is only available to subscribers.', 'convertkit' ),
+				),
+			)
+		);
+
+		// Restrict by Product.
+		add_settings_field(
+			'subscribe_heading',
+			__( 'Subscribe Heading', 'convertkit' ),
+			array( $this, 'text_callback' ),
+			$this->settings_key,
+			$this->name . '-products',
+			array(
+				'name'        => 'subscribe_heading',
+				'label_for'   => 'subscribe_heading',
+				'description' => array(
+					__( 'Displays text in a heading explaining why the content is only available to subscribers.', 'convertkit' ),
+				),
+			)
+		);
+
+		add_settings_field(
+			'subscribe_text',
+			__( 'Subscribe Text', 'convertkit' ),
+			array( $this, 'textarea_callback' ),
+			$this->settings_key,
+			$this->name . '-products',
+			array(
+				'name'        => 'subscribe_text',
+				'label_for'   => 'subscribe_text',
+				'description' => array(
+					__( 'Displays text explaining why the content is only available to subscribers.', 'convertkit' ),
 				),
 			)
 		);
@@ -325,6 +341,31 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 
 	}
 
+	/**
+	 * Prints help info for the products section of the settings screen.
+	 *
+	 * @since   2.7.1
+	 */
+	public function print_section_info_products() {
+
+		?>
+		<p class="description"><?php esc_html_e( 'Defines settings when a Page, Post or Custom Post type has its member content setting set to a Kit product.', 'convertkit' ); ?></p>
+		<?php
+
+	}
+
+	/**
+	 * Prints help info for the tags section of the settings screen.
+	 *
+	 * @since   2.7.1
+	 */
+	public function print_section_info_tags() {
+
+		?>
+		<p class="description"><?php esc_html_e( 'Defines settings when a Page, Post or Custom Post type has its member content setting set to a Kit tag.', 'convertkit' ); ?></p>
+		<?php
+
+	}
 
 	/**
 	 * Returns the URL for the ConvertKit documentation for this setting section.

--- a/admin/class-convertkit-admin-settings-restrict-content.php
+++ b/admin/class-convertkit-admin-settings-restrict-content.php
@@ -177,6 +177,22 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			)
 		);
 
+		// All.
+		add_settings_field(
+			'subscribe_button_label',
+			__( 'Subscribe Button Label', 'convertkit' ),
+			array( $this, 'text_callback' ),
+			$this->settings_key,
+			$this->name,
+			array(
+				'name'        => 'subscribe_button_label',
+				'label_for'   => 'subscribe_button_label',
+				'description' => array(
+					__( 'The text to display for the call to action button to subscribe.', 'convertkit' ),
+				),
+			)
+		);
+
 		// Restrict by Product.
 		add_settings_field(
 			'subscribe_heading',
@@ -208,28 +224,12 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			)
 		);
 
-		// All.
-		add_settings_field(
-			'subscribe_button_label',
-			__( 'Subscribe Button Label', 'convertkit' ),
-			array( $this, 'text_callback' ),
-			$this->settings_key,
-			$this->name,
-			array(
-				'name'        => 'subscribe_button_label',
-				'label_for'   => 'subscribe_button_label',
-				'description' => array(
-					__( 'The text to display for the call to action button to subscribe.', 'convertkit' ),
-				),
-			)
-		);
-
 		add_settings_field(
 			'email_text',
 			__( 'Email Text', 'convertkit' ),
 			array( $this, 'text_callback' ),
 			$this->settings_key,
-			$this->name,
+			$this->name . '-products',
 			array(
 				'name'        => 'email_text',
 				'label_for'   => 'email_text',
@@ -244,7 +244,7 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			__( 'Email Heading', 'convertkit' ),
 			array( $this, 'text_callback' ),
 			$this->settings_key,
-			$this->name,
+			$this->name . '-products',
 			array(
 				'name'        => 'email_heading',
 				'label_for'   => 'email_heading',
@@ -259,7 +259,7 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			__( 'Email Field Description', 'convertkit' ),
 			array( $this, 'text_callback' ),
 			$this->settings_key,
-			$this->name,
+			$this->name . '-products',
 			array(
 				'name'        => 'email_description_text',
 				'label_for'   => 'email_description_text',
@@ -274,7 +274,7 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			__( 'Email Button Label', 'convertkit' ),
 			array( $this, 'text_callback' ),
 			$this->settings_key,
-			$this->name,
+			$this->name . '-products',
 			array(
 				'name'        => 'email_button_label',
 				'label_for'   => 'email_button_label',
@@ -289,7 +289,7 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			__( 'Email Check Heading', 'convertkit' ),
 			array( $this, 'text_callback' ),
 			$this->settings_key,
-			$this->name,
+			$this->name . '-products',
 			array(
 				'name'        => 'email_check_heading',
 				'label_for'   => 'email_check_heading',
@@ -304,7 +304,7 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			__( 'Email Check Text', 'convertkit' ),
 			array( $this, 'text_callback' ),
 			$this->settings_key,
-			$this->name,
+			$this->name . '-products',
 			array(
 				'name'        => 'email_check_text',
 				'label_for'   => 'email_check_text',
@@ -319,7 +319,7 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			__( 'No Access Text', 'convertkit' ),
 			array( $this, 'text_callback' ),
 			$this->settings_key,
-			$this->name,
+			$this->name . '-products',
 			array(
 				'name'        => 'no_access_text',
 				'label_for'   => 'no_access_text',

--- a/admin/class-convertkit-admin-settings-restrict-content.php
+++ b/admin/class-convertkit-admin-settings-restrict-content.php
@@ -37,17 +37,17 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			'general'  => array(
 				'title'    => $this->title,
 				'callback' => array( $this, 'print_section_info' ),
-				'wrap'	   => true,
+				'wrap'     => true,
 			),
 			'products' => array(
 				'title'    => __( 'Products', 'convertkit' ),
 				'callback' => array( $this, 'print_section_info_products' ),
-				'wrap'	   => true,
+				'wrap'     => true,
 			),
 			'tags'     => array(
 				'title'    => __( 'Tags', 'convertkit' ),
 				'callback' => array( $this, 'print_section_info_tags' ),
-				'wrap'	   => true,
+				'wrap'     => true,
 			),
 		);
 

--- a/admin/class-convertkit-admin-settings-restrict-content.php
+++ b/admin/class-convertkit-admin-settings-restrict-content.php
@@ -34,16 +34,16 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 
 		// Define settings sections.
 		$this->settings_sections = array(
-			'general' => array(
-				'title' => $this->title,
+			'general'  => array(
+				'title'    => $this->title,
 				'callback' => array( $this, 'print_section_info' ),
 			),
 			'products' => array(
-				'title' => __( 'Products', 'convertkit' ),
+				'title'    => __( 'Products', 'convertkit' ),
 				'callback' => array( $this, 'print_section_info_products' ),
 			),
-			'tags' => array(
-				'title' => __( 'Tags', 'convertkit' ),
+			'tags'     => array(
+				'title'    => __( 'Tags', 'convertkit' ),
 				'callback' => array( $this, 'print_section_info_tags' ),
 			),
 		);

--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -38,7 +38,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 		// Define settings sections.
 		$this->settings_sections = array(
 			'general' => array(
-				'title' => $this->title,
+				'title'    => $this->title,
 				'callback' => array( $this, 'print_section_info' ),
 			),
 		);

--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -40,7 +40,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 			'general' => array(
 				'title'    => $this->title,
 				'callback' => array( $this, 'print_section_info' ),
-				'wrap'	   => true,
+				'wrap'     => true,
 			),
 		);
 

--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -35,6 +35,14 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 		// Identify that this is beta functionality.
 		$this->is_beta = true;
 
+		// Define settings sections.
+		$this->settings_sections = array(
+			'general' => array(
+				'title' => $this->title,
+				'callback' => array( $this, 'print_section_info' ),
+			),
+		);
+
 		// Register and maybe output notices for this settings screen.
 		if ( $this->on_settings_screen( $this->name ) ) {
 			add_filter( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );

--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -40,6 +40,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 			'general' => array(
 				'title'    => $this->title,
 				'callback' => array( $this, 'print_section_info' ),
+				'wrap'	   => true,
 			),
 		);
 

--- a/admin/section/class-convertkit-settings-base.php
+++ b/admin/section/class-convertkit-settings-base.php
@@ -89,14 +89,6 @@ abstract class ConvertKit_Settings_Base {
 			$this->tab_text = $this->title;
 		}
 
-		// Define settings sections.
-		$this->settings_sections = array(
-			'general'  => array(
-				'title'    => $this->title,
-				'callback' => array( $this, 'print_section_info' ),
-			),
-		);
-
 		// Register the settings section.
 		$this->register_section();
 
@@ -140,15 +132,21 @@ abstract class ConvertKit_Settings_Base {
 
 		// Register settings sections.
 		foreach ( $this->settings_sections as $name => $settings_section ) {
+			// Determine if this settings section needs to be wrapped in its own container.
+			$wrap = array();
+			if ( $settings_section['wrap'] ) {
+				$wrap = array(
+					'before_section' => $this->get_render_container_start(),
+					'after_section'  => $this->get_render_container_end(),
+				);
+			}
+
 			add_settings_section(
 				( $name === 'general' ? $this->name : $this->name . '-' . $name ),
 				$settings_section['title'],
 				$settings_section['callback'],
 				$this->settings_key,
-				array(
-					'before_section' => $this->get_render_container_start(),
-					'after_section'  => $this->get_render_container_end(),
-				)
+				$wrap
 			);
 		}
 
@@ -238,7 +236,7 @@ abstract class ConvertKit_Settings_Base {
 		}
 
 		/**
-		 *  Performs actions after rendering of the settings form.
+		 * Performs actions after rendering of the settings form.
 		 *
 		 * @since   1.9.6
 		 */

--- a/admin/section/class-convertkit-settings-base.php
+++ b/admin/section/class-convertkit-settings-base.php
@@ -53,10 +53,10 @@ abstract class ConvertKit_Settings_Base {
 
 	/**
 	 * Holds the settings sections for a settings screen.
-	 * 
-	 * @since 	2.7.1
-	 * 
-	 * @var 	array
+	 *
+	 * @since   2.7.1
+	 *
+	 * @var     array
 	 */
 	public $settings_sections = array();
 
@@ -88,6 +88,14 @@ abstract class ConvertKit_Settings_Base {
 		if ( empty( $this->tab_text ) ) {
 			$this->tab_text = $this->title;
 		}
+
+		// Define settings sections.
+		$this->settings_sections = array(
+			'general'  => array(
+				'title'    => $this->title,
+				'callback' => array( $this, 'print_section_info' ),
+			),
+		);
 
 		// Register the settings section.
 		$this->register_section();
@@ -139,7 +147,7 @@ abstract class ConvertKit_Settings_Base {
 				$this->settings_key,
 				array(
 					'before_section' => $this->get_render_container_start(),
-					'after_section' => $this->get_render_container_end(),
+					'after_section'  => $this->get_render_container_end(),
 				)
 			);
 		}
@@ -159,7 +167,8 @@ abstract class ConvertKit_Settings_Base {
 	/**
 	 * Register fields for this section
 	 */
-	abstract public function register_fields();
+	public function register_fields() {
+	}
 
 	/**
 	 * Prints help info for this section
@@ -245,7 +254,7 @@ abstract class ConvertKit_Settings_Base {
 	 */
 	public function render_container_start() {
 
-		echo $this->get_render_container_start();
+		echo $this->get_render_container_start(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 	}
 
@@ -257,7 +266,7 @@ abstract class ConvertKit_Settings_Base {
 	 */
 	public function render_container_end() {
 
-		echo $this->get_render_container_end();
+		echo $this->get_render_container_end(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 	}
 

--- a/admin/section/class-convertkit-settings-base.php
+++ b/admin/section/class-convertkit-settings-base.php
@@ -52,6 +52,15 @@ abstract class ConvertKit_Settings_Base {
 	public $settings;
 
 	/**
+	 * Holds the settings sections for a settings screen.
+	 * 
+	 * @since 	2.7.1
+	 * 
+	 * @var 	array
+	 */
+	public $settings_sections = array();
+
+	/**
 	 * Holds whether this settings section is for beta functionality.
 	 *
 	 * @since   2.1.0
@@ -121,15 +130,24 @@ abstract class ConvertKit_Settings_Base {
 	 */
 	public function register_section() {
 
-		add_settings_section(
-			$this->name,
-			$this->title,
-			array( $this, 'print_section_info' ),
-			$this->settings_key
-		);
+		// Register settings sections.
+		foreach ( $this->settings_sections as $name => $settings_section ) {
+			add_settings_section(
+				( $name === 'general' ? $this->name : $this->name . '-' . $name ),
+				$settings_section['title'],
+				$settings_section['callback'],
+				$this->settings_key,
+				array(
+					'before_section' => $this->get_render_container_start(),
+					'after_section' => $this->get_render_container_end(),
+				)
+			);
+		}
 
+		// Register settings fields.
 		$this->register_fields();
 
+		// Register setting to store data in options table.
 		register_setting(
 			$this->settings_key,
 			$this->settings_key,
@@ -202,8 +220,6 @@ abstract class ConvertKit_Settings_Base {
 		 */
 		do_action( 'convertkit_settings_base_render_before' );
 
-		$this->render_container_start();
-
 		do_settings_sections( $this->settings_key );
 
 		settings_fields( $this->settings_key );
@@ -211,8 +227,6 @@ abstract class ConvertKit_Settings_Base {
 		if ( ! $this->save_disabled ) {
 			submit_button();
 		}
-
-		$this->render_container_end();
 
 		/**
 		 *  Performs actions after rendering of the settings form.
@@ -224,17 +238,14 @@ abstract class ConvertKit_Settings_Base {
 	}
 
 	/**
-	 * Outputs .metabox-holder and .postbox container div elements,
+	 * Outputs opening .metabox-holder and .postbox container div elements,
 	 * used before beginning a setting screen's output.
 	 *
 	 * @since   2.0.0
 	 */
 	public function render_container_start() {
 
-		?>
-		<div class="metabox-holder">
-			<div class="postbox <?php echo sanitize_html_class( $this->is_beta ? 'convertkit-beta' : '' ); ?>">
-		<?php
+		echo $this->get_render_container_start();
 
 	}
 
@@ -246,10 +257,31 @@ abstract class ConvertKit_Settings_Base {
 	 */
 	public function render_container_end() {
 
-		?>
-			</div>
-		</div>
-		<?php
+		echo $this->get_render_container_end();
+
+	}
+
+	/**
+	 * Returns opening .metabox-holder and .postbox container div elements,
+	 * used before beginning a section of a settings screen output.
+	 *
+	 * @since   2.7.1
+	 */
+	public function get_render_container_start() {
+
+		return '<div class="metabox-holder"><div class="postbox ' . sanitize_html_class( $this->is_beta ? 'convertkit-beta' : '' ) . '">';
+
+	}
+
+	/**
+	 * Returns closing .metabox-holder and .postbox container div elements,
+	 * used after finishing a section of a settings screen output.
+	 *
+	 * @since   2.7.1
+	 */
+	public function get_render_container_end() {
+
+		return '</div></div>';
 
 	}
 

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -57,6 +57,14 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 		$this->title    = __( 'General Settings', 'convertkit' );
 		$this->tab_text = __( 'General', 'convertkit' );
 
+		// Define settings sections.
+		$this->settings_sections = array(
+			'general' => array(
+				'title' => $this->title,
+				'callback' => array( $this, 'print_section_info' ),
+			),
+		);
+
 		// Register and maybe output notices for this settings screen.
 		if ( $this->on_settings_screen( $this->name ) ) {
 			add_filter( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -59,9 +59,13 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 
 		// Define settings sections.
 		$this->settings_sections = array(
-			'general' => array(
-				'title' => $this->title,
+			'general'  => array(
+				'title'    => $this->title,
 				'callback' => array( $this, 'print_section_info' ),
+			),
+			'advanced' => array(
+				'title'    => __( 'Advanced', 'convertkit' ),
+				'callback' => array( $this, 'print_section_info_advanced' ),
 			),
 		);
 
@@ -354,12 +358,13 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 			)
 		);
 
+		// Advanced.
 		add_settings_field(
 			'debug',
 			__( 'Debug', 'convertkit' ),
 			array( $this, 'debug_callback' ),
 			$this->settings_key,
-			$this->name,
+			$this->name . '-advanced',
 			array(
 				'label_for' => 'debug',
 			)
@@ -370,7 +375,7 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 			__( 'Disable JavaScript', 'convertkit' ),
 			array( $this, 'no_scripts_callback' ),
 			$this->settings_key,
-			$this->name,
+			$this->name . '-advanced',
 			array(
 				'label_for' => 'no_scripts',
 			)
@@ -381,7 +386,7 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 			__( 'Disable CSS', 'convertkit' ),
 			array( $this, 'no_css_callback' ),
 			$this->settings_key,
-			$this->name,
+			$this->name . '-advanced',
 			array(
 				'label_for' => 'no_css',
 			)
@@ -395,17 +400,30 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 	public function print_section_info() {
 
 		?>
-		<p><?php esc_html_e( 'Choosing a default form will embed it at the bottom of every post or page (in single view only) across your site.', 'convertkit' ); ?></p>
+		<p><?php esc_html_e( 'Choosing a default form will embed it at the top, bottom or top and bottom of every post or page (in single view only) across your site.', 'convertkit' ); ?></p>
 		<p><?php esc_html_e( 'If you wish to turn off form embedding or select a different form for an individual post or page, you can do so using the Kit meta box on the edit page.', 'convertkit' ); ?></p>
 		<p>
 			<?php
 			printf(
 				/* translators: [convertkit] shortcode, wrapped in <code> tags */
-				esc_html__( 'The default form can be inserted into the middle of post or page content by using the %s shortcode.', 'convertkit' ),
+				esc_html__( 'The default form can be inserted into the middle of post or page content by using either the %s shortcode or block.', 'convertkit' ),
 				'<code>[convertkit]</code>'
 			);
 			?>
 		</p>
+		<?php
+
+	}
+
+	/**
+	 * Prints help info for the advanced section of the settings screen.
+	 *
+	 * @since   2.7.1
+	 */
+	public function print_section_info_advanced() {
+
+		?>
+		<p class="description"><?php esc_html_e( 'Defines advanced configuration settings, usually when working with support or needing to disable JS or CSS.', 'convertkit' ); ?></p>
 		<?php
 
 	}

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -62,12 +62,12 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 			'general'  => array(
 				'title'    => $this->title,
 				'callback' => array( $this, 'print_section_info' ),
-				'wrap'	   => true,
+				'wrap'     => true,
 			),
 			'advanced' => array(
 				'title'    => __( 'Advanced', 'convertkit' ),
 				'callback' => array( $this, 'print_section_info_advanced' ),
-				'wrap'	   => true,
+				'wrap'     => true,
 			),
 		);
 

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -62,10 +62,12 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 			'general'  => array(
 				'title'    => $this->title,
 				'callback' => array( $this, 'print_section_info' ),
+				'wrap'	   => true,
 			),
 			'advanced' => array(
 				'title'    => __( 'Advanced', 'convertkit' ),
 				'callback' => array( $this, 'print_section_info_advanced' ),
+				'wrap'	   => true,
 			),
 		);
 

--- a/admin/section/class-convertkit-settings-oauth.php
+++ b/admin/section/class-convertkit-settings-oauth.php
@@ -105,17 +105,6 @@ class ConvertKit_Settings_OAuth extends ConvertKit_Settings_Base {
 	}
 
 	/**
-	 * Register fields for this section
-	 *
-	 * @since   2.2.0
-	 */
-	public function register_fields() {
-
-		// No fields are registered for the Debug Log.
-		// This function is deliberately blank.
-	}
-
-	/**
 	 * Outputs the OAuth screen.
 	 *
 	 * @since   2.2.0

--- a/admin/section/class-convertkit-settings-tools.php
+++ b/admin/section/class-convertkit-settings-tools.php
@@ -285,15 +285,6 @@ class ConvertKit_Settings_Tools extends ConvertKit_Settings_Base {
 	}
 
 	/**
-	 * Register fields for this section
-	 */
-	public function register_fields() {
-
-		// No fields are registered for the Debug Log.
-		// This function is deliberately blank.
-	}
-
-	/**
 	 * Outputs the Debug Log and System Info view.
 	 *
 	 * @since   1.9.6

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
@@ -30,6 +30,15 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 		$this->title    = __( 'Contact Form 7 Integration Settings', 'convertkit' );
 		$this->tab_text = __( 'Contact Form 7', 'convertkit' );
 
+		// Define settings sections.
+		$this->settings_sections = array(
+			'general' => array(
+				'title'    => $this->title,
+				'callback' => array( $this, 'print_section_info' ),
+				'wrap'     => false,
+			),
+		);
+
 		parent::__construct();
 
 	}
@@ -177,11 +186,11 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 		// Register settings field.
 		settings_fields( $this->settings_key );
 
-		// Render submit button.
-		submit_button();
-
 		// Render closing container.
 		$this->render_container_end();
+
+		// Render submit button.
+		submit_button();
 
 	}
 

--- a/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
@@ -32,20 +32,17 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 		$this->title    = __( 'Forminator Integration Settings', 'convertkit' );
 		$this->tab_text = __( 'Forminator', 'convertkit' );
 
+		// Define settings sections.
+		$this->settings_sections = array(
+			'general' => array(
+				'title'    => $this->title,
+				'callback' => array( $this, 'print_section_info' ),
+				'wrap'     => false,
+			),
+		);
+
 		parent::__construct();
 
-	}
-
-	/**
-	 * Register fields for this section
-	 *
-	 * @since   2.3.0
-	 */
-	public function register_fields() {
-
-		// No fields are registered, because they are output in a WP_List_Table
-		// in this class' render() function.
-		// This function is deliberately blank.
 	}
 
 	/**
@@ -172,11 +169,11 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 		// Register settings field.
 		settings_fields( $this->settings_key );
 
-		// Render submit button.
-		submit_button();
-
 		// Render closing container.
 		$this->render_container_end();
+
+		// Render submit button.
+		submit_button();
 
 	}
 

--- a/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
@@ -32,20 +32,17 @@ class ConvertKit_Wishlist_Admin_Settings extends ConvertKit_Settings_Base {
 		$this->title    = __( 'WishList Member Integration Settings', 'convertkit' );
 		$this->tab_text = __( 'WishList Member', 'convertkit' );
 
+		// Define settings sections.
+		$this->settings_sections = array(
+			'general' => array(
+				'title'    => $this->title,
+				'callback' => array( $this, 'print_section_info' ),
+				'wrap'     => false,
+			),
+		);
+
 		parent::__construct();
 
-	}
-
-	/**
-	 * Register fields for this section.
-	 *
-	 * @since   1.9.6
-	 */
-	public function register_fields() {
-
-		// No fields are registered, because they are output in a WP_List_Table
-		// in this class' render() function.
-		// This function is deliberately blank.
 	}
 
 	/**
@@ -155,11 +152,11 @@ class ConvertKit_Wishlist_Admin_Settings extends ConvertKit_Settings_Base {
 		// Register settings field.
 		settings_fields( $this->settings_key );
 
-		// Render submit button.
-		submit_button();
-
 		// Render closing container.
 		$this->render_container_end();
+
+		// Render submit button.
+		submit_button();
 
 	}
 

--- a/resources/backend/css/settings.css
+++ b/resources/backend/css/settings.css
@@ -105,10 +105,11 @@ body.settings_page__wp_convertkit_settings .wrap .postbox h2 {
 body.settings_page__wp_convertkit_settings .wrap .postbox p {
 	font-size: 14px;
 }
-body.settings_page__wp_convertkit_settings .wrap .postbox p.submit {
+body.settings_page__wp_convertkit_settings p.submit {
+	margin-bottom: 20px;
 	padding: 0;
 }
-body.settings_page__wp_convertkit_settings .wrap .postbox .button {
+body.settings_page__wp_convertkit_settings .button {
 	margin: 0 5px 0 0;
 	padding: 4px 12px;
 	font-size: 14px;
@@ -119,21 +120,21 @@ body.settings_page__wp_convertkit_settings .wrap .postbox .button {
 	text-shadow: none;
 	box-shadow: none;
 }
-body.settings_page__wp_convertkit_settings .wrap .postbox .button-primary {
+body.settings_page__wp_convertkit_settings .button-primary {
 	background: #1e1e1e;
 	border-color: #1e1e1e;
 	color: #fff;
 }
-body.settings_page__wp_convertkit_settings .wrap .postbox .button-primary:hover {
+body.settings_page__wp_convertkit_settings .button-primary:hover {
 	background: #3d3d3d;
 	border-color: #3d3d3d;
 }
-body.settings_page__wp_convertkit_settings .wrap .postbox .button-secondary {
+body.settings_page__wp_convertkit_settings .button-secondary {
 	background: #f0f0f0;
 	border-color: #f0f0f0;
 	color: #3d3d3d;
 }
-body.settings_page__wp_convertkit_settings .wrap .postbox .button-secondary:hover {
+body.settings_page__wp_convertkit_settings .button-secondary:hover {
 	background: #ddd;
 	border-color: #ddd;
 }


### PR DESCRIPTION
## Summary

Improves the UX of the settings screens by grouping relative settings together.

Before:
![Screenshot 2025-01-16 at 17 13 01](https://github.com/user-attachments/assets/2e6ca695-0fb6-4ac4-affb-63d15212161c)
![Screenshot 2025-01-16 at 17 13 04](https://github.com/user-attachments/assets/d867cd5c-58ca-4244-b62e-9ffd0012cbe5)
![Screenshot 2025-01-16 at 17 13 12](https://github.com/user-attachments/assets/64bca007-fd1b-4dcc-a1e6-124cb128ba5a)
![Screenshot 2025-01-16 at 17 13 18](https://github.com/user-attachments/assets/1872eeb2-0aaf-4cc5-8d5e-61523fa747fe)

After:
![general-general](https://github.com/user-attachments/assets/57ada4b9-f76d-4fe9-8a7b-38d264584235)
![general-advanced](https://github.com/user-attachments/assets/43938298-b851-4880-b1b2-8773af66d41f)
![member-content-general](https://github.com/user-attachments/assets/2199922d-93be-48a7-a3d5-4631b8eccbc5)
![member-content-products](https://github.com/user-attachments/assets/8d4edc5e-0976-4761-94a2-1f44fbb43ccc)
![member-content-tags](https://github.com/user-attachments/assets/268a196d-8fd5-400f-bb14-a5ab9eea2065)

## Testing

Existing tests pass

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)