### PR TITLE
Settings: Fix Uncaught TypeError

### DIFF
--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -755,8 +755,8 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 	 *
 	 * @since   2.4.3
 	 *
-	 * @param   array $settings   Submitted Settings Fields.
-	 * @return  array               Sanitized Settings with Defaults
+	 * @param   null|array $settings   Submitted Settings Fields.
+	 * @return  array                   Sanitized Settings with Defaults
 	 */
 	public function sanitize_settings( $settings ) {
 
@@ -765,6 +765,12 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 		// This ensures we only blank these values if we explicitly do so via $settings,
 		// as they won't be included in the Settings screen for security.
 		if ( ! array_key_exists( 'disconnect', $_REQUEST ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			// If settings are null, no checkboxes were ticked and no other form elements
+			// were submitted i.e. the Kit account has no forms.
+			if ( is_null( $settings ) ) {
+				$settings = array();
+			}
+
 			if ( ! array_key_exists( 'access_token', $settings ) ) {
 				$settings['access_token'] = $this->settings->get_access_token();
 			}

--- a/tests/acceptance/general/PluginSettingsGeneralCest.php
+++ b/tests/acceptance/general/PluginSettingsGeneralCest.php
@@ -674,6 +674,38 @@ class PluginSettingsGeneralCest
 
 		// Confirm no Form settings are displayed for non-inline Forms.
 		$I->dontSeeElementInDOM('#_wp_convertkit_settings_non_inline_form');
+
+		// Check Debug, Disable JavaScript and Disable CSS settings.
+		$I->checkOption('#debug');
+		$I->checkOption('#no_scripts');
+		$I->checkOption('#no_css');
+
+		// Click the Save Changes button.
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check the fields remain ticked.
+		$I->seeCheckboxIsChecked('#debug');
+		$I->seeCheckboxIsChecked('#no_scripts');
+		$I->seeCheckboxIsChecked('#no_css');
+
+		// Untick fields.
+		$I->uncheckOption('#debug');
+		$I->uncheckOption('#no_scripts');
+		$I->uncheckOption('#no_css');
+
+		// Click the Save Changes button.
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check the fields remain unticked.
+		$I->dontSeeCheckboxIsChecked('#debug');
+		$I->dontSeeCheckboxIsChecked('#no_scripts');
+		$I->dontSeeCheckboxIsChecked('#no_css');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263837429149?view=List) where clicking Save Changes on the settings screen results in an uncaughty TypeError when a Kit account has no resources, and no checkboxes are checked.

![Screenshot 2025-01-21 at 13 32 47](https://github.com/user-attachments/assets/ee2c8055-8835-462f-9318-55ba88c188a2)

## Testing

- `testSettingsScreenWhenNoResources`: Updated test to save all settings when the Kit account has no resources and no checkboxes are checked on the settings screen.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)