### PR TITLE
Add Intercom to Settings and Setup Wizard Screens

### DIFF
--- a/admin/class-convertkit-admin-settings-restrict-content.php
+++ b/admin/class-convertkit-admin-settings-restrict-content.php
@@ -54,6 +54,11 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 		// Enqueue scripts.
 		add_action( 'convertkit_admin_settings_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 
+		// Output the Intercom messenger.
+		if ( $this->on_settings_screen( $this->name ) ) {
+			add_action( 'admin_footer', array( $this, 'output_intercom' ) );
+		}
+
 		parent::__construct();
 
 	}

--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -44,10 +44,11 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 			),
 		);
 
-		// Register and maybe output notices for this settings screen.
+		// Register and maybe output notices for this settings screen, and the Intercom messenger.
 		if ( $this->on_settings_screen( $this->name ) ) {
 			add_filter( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );
 			add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
+			add_action( 'admin_footer', array( $this, 'output_intercom' ) );
 		}
 
 		// Enqueue scripts and CSS.

--- a/admin/section/class-convertkit-settings-base.php
+++ b/admin/section/class-convertkit-settings-base.php
@@ -727,4 +727,15 @@ abstract class ConvertKit_Settings_Base {
 
 	}
 
+	/**
+	 * Outputs the Intercom help widget in the footer of the Plugin's settings screens.
+	 *
+	 * @since   2.7.2
+	 */
+	public function output_intercom() {
+
+		convertkit_output_intercom_messenger();
+
+	}
+
 }

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -71,10 +71,11 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 			),
 		);
 
-		// Register and maybe output notices for this settings screen.
+		// Register and maybe output notices for this settings screen, and the Intercom messenger.
 		if ( $this->on_settings_screen( $this->name ) ) {
 			add_filter( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );
 			add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
+			add_action( 'admin_footer', array( $this, 'output_intercom' ) );
 		}
 
 		// Enqueue scripts and CSS.

--- a/admin/section/class-convertkit-settings-oauth.php
+++ b/admin/section/class-convertkit-settings-oauth.php
@@ -33,7 +33,7 @@ class ConvertKit_Settings_OAuth extends ConvertKit_Settings_Base {
 		$this->tab_text = __( 'OAuth', 'convertkit' );
 
 		// Maybe output notices for this settings screen, and the Intercom messenger.
-		if ( $this->on_settings_screen( $this->name ) ) {
+		if ( $this->on_settings_screen( 'general' ) ) {
 			add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
 			add_action( 'admin_footer', array( $this, 'output_intercom' ) );
 		}

--- a/admin/section/class-convertkit-settings-oauth.php
+++ b/admin/section/class-convertkit-settings-oauth.php
@@ -32,9 +32,10 @@ class ConvertKit_Settings_OAuth extends ConvertKit_Settings_Base {
 		$this->title    = __( 'OAuth', 'convertkit' );
 		$this->tab_text = __( 'OAuth', 'convertkit' );
 
-		// Output notices for this settings screen.
-		if ( $this->on_settings_screen( 'general' ) ) {
+		// Maybe output notices for this settings screen, and the Intercom messenger.
+		if ( $this->on_settings_screen( $this->name ) ) {
 			add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
+			add_action( 'admin_footer', array( $this, 'output_intercom' ) );
 		}
 
 		parent::__construct();

--- a/admin/section/class-convertkit-settings-tools.php
+++ b/admin/section/class-convertkit-settings-tools.php
@@ -28,10 +28,11 @@ class ConvertKit_Settings_Tools extends ConvertKit_Settings_Base {
 		$this->title        = __( 'Tools', 'convertkit' );
 		$this->tab_text     = __( 'Tools', 'convertkit' );
 
-		// Register and maybe output notices for this settings screen.
+		// Register and maybe output notices for this settings screen, and the Intercom messenger.
 		if ( $this->on_settings_screen( $this->name ) ) {
 			add_filter( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );
 			add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
+			add_action( 'admin_footer', array( $this, 'output_intercom' ) );
 		}
 
 		parent::__construct();

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -614,3 +614,26 @@ function convertkit_get_current_screen( $property ) {
 	return $screen->$property;
 
 }
+
+/**
+ * Outputs the Intercom help widget script.
+ *
+ * @since   2.7.2
+ */
+function convertkit_output_intercom_messenger() {
+
+	?>
+	<script>
+		const KIT_INTERCOM_APP_ID = 'e4n3xtxz';
+		window.intercomSettings = {
+		api_base: 'https://api-iam.intercom.io',
+		app_id: KIT_INTERCOM_APP_ID
+		};
+	</script>
+
+	<script>
+	(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/' + KIT_INTERCOM_APP_ID;var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s, x);};if(document.readyState==='complete'){l();}else if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();
+	</script>
+	<?php
+
+}

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -78,6 +78,7 @@ modules:
             capabilities:
                 goog:chromeOptions:
                     args: [
+                        "--headless=new",
                         "--disable-gpu",
                         "--user-agent=%TEST_SITE_HTTP_USER_AGENT%",
                     ]

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -78,7 +78,6 @@ modules:
             capabilities:
                 goog:chromeOptions:
                     args: [
-                        "--headless=new",
                         "--disable-gpu",
                         "--user-agent=%TEST_SITE_HTTP_USER_AGENT%",
                     ]

--- a/tests/acceptance/general/PluginIntercomCest.php
+++ b/tests/acceptance/general/PluginIntercomCest.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Tests for the Settings > Kit > General screens.
+ *
+ * @since   2.7.2
+ */
+class PluginIntercomCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   2.7.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+	}
+
+	/**
+	 * Test that the Intercom script is loaded on the Plugin settings screens.
+	 *
+	 * @since   2.7.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testIntercomDisplaysOnPluginScreens(AcceptanceTester $I)
+	{
+		// Go to the Plugin's Settings screen, which will show the OAuth Connect button.
+		$I->loadConvertKitSettingsGeneralScreen($I);
+
+		// Confirm the Intercom script is loaded.
+		$this->_seeIntercomScript($I);
+
+		// Authenticate the Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Go to the Plugin's Settings screen, which will show all settings.
+		$I->loadConvertKitSettingsGeneralScreen($I);
+
+		// Confirm the Intercom script is loaded.
+		$this->_seeIntercomScript($I);
+
+		// Go to the Plugin's Tools screen.
+		$I->loadConvertKitSettingsToolsScreen($I);
+
+		// Confirm the Intercom script is loaded.
+		$this->_seeIntercomScript($I);
+
+		// Go to the Plugin's Restrict Content Settings screen.
+		$I->loadConvertKitSettingsRestrictContentScreen($I);
+
+		// Confirm the Intercom script is loaded.
+		$this->_seeIntercomScript($I);
+
+		// Go to the Plugin's Broadcasts screen.
+		$I->loadConvertKitSettingsBroadcastsScreen($I);
+
+		// Confirm the Intercom script is loaded.
+		$this->_seeIntercomScript($I);
+	}
+
+	/**
+	 * Test that the Intercom script is loaded on the Setup Wizard screens.
+	 *
+	 * @since   2.7.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testIntercomDisplaysOnSetupWizardScreens(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Go to the Plugin's Setup Wizard screen.
+		$I->amOnAdminPage('options.php?page=convertkit-setup');
+
+		// Confirm the Intercom script is loaded.
+		$this->_seeIntercomScript($I);
+
+		// Go to the Plugin's Landing Page Wizard screen.
+		$I->amOnAdminPage('options.php?page=convertkit-landing-page-setup&ck_post_type=page');
+
+		// Confirm the Intercom script is loaded.
+		$this->_seeIntercomScript($I);
+
+		// Go to the Plugin's Member Content Wizard screen.
+		$I->amOnAdminPage('options.php?page=convertkit-restrict-content-setup&ck_post_type=page');
+
+		// Confirm the Intercom script is loaded.
+		$this->_seeIntercomScript($I);
+	}
+
+	/**
+	 * Assert that the Intercom script is loaded.
+	 *
+	 * @since   2.7.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	private function _seeIntercomScript(AcceptanceTester $I)
+	{
+		$I->waitForElementVisible('.intercom-lightweight-app-launcher-icon');
+		$I->click('.intercom-lightweight-app-launcher-icon');
+		$I->waitForElementVisible('iframe[data-intercom-frame="true"]');
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   2.7.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}

--- a/views/backend/setup-wizard/footer.php
+++ b/views/backend/setup-wizard/footer.php
@@ -59,6 +59,9 @@
 				</div>
 				<?php
 			}
+
+			// Output Intercom.
+			convertkit_output_intercom_messenger();
 			?>
 		</div>
 	</body>


### PR DESCRIPTION
## Summary

Adds the Intercom help messenger to the Plugin's settings and setup wizard screens, to encourage users to seek support direct from Kit, instead of [leaving a review](https://wordpress.org/support/topic/removing-kit-help/).

![Screenshot 2025-01-29 at 14 28 30](https://github.com/user-attachments/assets/4ac73bb3-6d12-4ba4-bee8-d14c366bbdb2)
![Screenshot 2025-01-29 at 14 28 33](https://github.com/user-attachments/assets/3dfd1af3-20ec-4803-82a6-e39422149a07)
![Screenshot 2025-01-29 at 14 29 01](https://github.com/user-attachments/assets/556c55a7-7895-4efe-a3f9-43c909e4052f)
![Screenshot 2025-01-29 at 14 29 03](https://github.com/user-attachments/assets/a67a2827-c975-427e-9c29-6a437131d64d)

The `user_id` isn't populated, as Identity Verification is enabled, requiring a `user_hash`.

## Testing

- `PluginIntercomCest`: Test that the Intercom messenger displays on the Plugin and Wizard screens.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)