### PR TITLE
Add `Create Broadcast in Kit` to all Post Types

### DIFF
--- a/includes/class-convertkit-broadcasts-exporter.php
+++ b/includes/class-convertkit-broadcasts-exporter.php
@@ -168,6 +168,7 @@ class ConvertKit_Broadcasts_Exporter {
 		// Build URL.
 		$url = add_query_arg(
 			array(
+				'post_type'         => $post->post_type,
 				'convertkit-action' => 'broadcast-export',
 				'id'                => $post->ID,
 				'nonce'             => wp_create_nonce( 'action-convertkit-broadcast-export' ),

--- a/includes/class-convertkit-broadcasts-exporter.php
+++ b/includes/class-convertkit-broadcasts-exporter.php
@@ -72,6 +72,7 @@ class ConvertKit_Broadcasts_Exporter {
 		add_action( 'init', array( $this, 'run_row_action' ) );
 
 		// Add action below Post Title in WP_List_Table classes.
+		add_filter( 'page_row_actions', array( $this, 'add_row_action' ), 10, 2 );
 		add_filter( 'post_row_actions', array( $this, 'add_row_action' ), 10, 2 );
 
 	}

--- a/tests/acceptance/broadcasts/import-export/BroadcastsExportCPTRowActionCest.php
+++ b/tests/acceptance/broadcasts/import-export/BroadcastsExportCPTRowActionCest.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Tests Post export to Broadcast functionality.
+ *
+ * @since   2.7.2
+ */
+class BroadcastsExportCPTRowActionCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   2.7.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		// Activate ConvertKit Plugin.
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Create a public Custom Post Type called Articles, using the Custom Post Type UI Plugin.
+		$I->registerCustomPostType($I, 'article', 'Articles', 'Article');
+	}
+
+	/**
+	 * Tests that no action is displayed in the Articles table when the 'Enable Export Actions' is disabled
+	 * in the Plugin's settings.
+	 *
+	 * @since   2.7.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsExportRowActionWhenDisabled(AcceptanceTester $I)
+	{
+		// Programmatically create an Article.
+		$postID = $I->havePostInDatabase(
+			[
+				'post_type'    => 'article',
+				'post_title'   => 'Kit: Export Article to Broadcast',
+				'post_content' => 'Kit: Export Article to Broadcast: Content',
+				'post_excerpt' => 'Kit: Export Article to Broadcast: Excerpt',
+			]
+		);
+
+		// Navigate to the Articles WP_List_Table.
+		$I->amOnAdminPage('edit.php?post_type=article');
+
+		// Confirm that no action to export the Post is displayed.
+		$I->dontSeeInSource('span.convertkit_broadcast_export');
+	}
+
+	/**
+	 * Tests that an action is displayed in the Articles table when the 'Enable Export Actions' is enabled
+	 * in the Plugin's settings, and a Broadcast is created in ConvertKit when clicked.
+	 *
+	 * @since   2.7.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsExportRowActionWhenEnabled(AcceptanceTester $I)
+	{
+		// Enable Export Actions for Articles.
+		$I->setupConvertKitPluginBroadcasts(
+			$I,
+			[
+				'enabled_export' => true,
+			]
+		);
+
+		// Programmatically create a Post.
+		$postID = $I->havePostInDatabase(
+			[
+				'post_type'    => 'article',
+				'post_title'   => 'Kit: Export Article to Broadcast',
+				'post_content' => '<p class="style-test">Kit: Export Article to Broadcast: Content</p>',
+				'post_excerpt' => 'Kit: Export Article to Broadcast: Excerpt',
+			]
+		);
+
+		// Navigate to the Articles WP_List_Table.
+		$I->amOnAdminPage('edit.php?post_type=article');
+
+		// Hover mouse over Post's table row.
+		$I->moveMouseOver('tr.iedit:first-child');
+
+		// Wait for export link to be visible.
+		$I->waitForElementVisible('tr.iedit:first-child span.convertkit_broadcast_export a');
+
+		// Click the export action.
+		$I->click('tr.iedit:first-child span.convertkit_broadcast_export a');
+
+		// Confirm that a success message displays.
+		$I->waitForElementVisible('.notice-success');
+		$I->see('Successfully created Kit Broadcast from Post');
+
+		// Get Broadcast ID from 'Click here' link.
+		$broadcastID = (int) filter_var($I->grabAttributeFrom('.notice-success p a', 'href'), FILTER_SANITIZE_NUMBER_INT);
+
+		// Fetch Broadcast from the API.
+		$broadcast = $I->apiGetBroadcast($broadcastID);
+
+		// Delete Broadcast.
+		$I->apiDeleteBroadcast($broadcastID);
+
+		// Confirm styles were included in the Broadcast.
+		$I->assertStringContainsString('class="style-test"', $broadcast['broadcast']['content']);
+	}
+
+	/**
+	 * Tests that the 'Disable Styles' setting is honored when enabled in the Plugin's settings, and a
+	 * Broadcast is created in ConvertKit.
+	 *
+	 * @since   2.7.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsExportActionWithDisableStylesEnabled(AcceptanceTester $I)
+	{
+		// Enable Export Actions for Articles.
+		$I->setupConvertKitPluginBroadcasts(
+			$I,
+			[
+				'enabled_export' => true,
+				'no_styles'      => true,
+			]
+		);
+
+		// Programmatically create a Post.
+		$postID = $I->havePostInDatabase(
+			[
+				'post_type'    => 'article',
+				'post_title'   => 'Kit: Export Article to Broadcast: Disable Styles',
+				'post_content' => '<p class="style-test">Kit: Export Post to Broadcast: Disable Styles: Content</p>',
+				'post_excerpt' => 'Kit: Export Article to Broadcast: Disable Styles: Excerpt',
+			]
+		);
+
+		// Navigate to the Articles WP_List_Table.
+		$I->amOnAdminPage('edit.php?post_type=article');
+
+		// Hover mouse over Post's table row.
+		$I->moveMouseOver('tr.iedit:first-child');
+
+		// Wait for export link to be visible.
+		$I->waitForElementVisible('tr.iedit:first-child span.convertkit_broadcast_export a');
+
+		// Click the export action.
+		$I->click('tr.iedit:first-child span.convertkit_broadcast_export a');
+
+		// Confirm that a success message displays.
+		$I->waitForElementVisible('.notice-success');
+		$I->see('Successfully created Kit Broadcast from Post');
+
+		// Get Broadcast ID from 'Click here' link.
+		$broadcastID = (int) filter_var($I->grabAttributeFrom('.notice-success p a', 'href'), FILTER_SANITIZE_NUMBER_INT);
+
+		// Fetch Broadcast from the API.
+		$broadcast = $I->apiGetBroadcast($broadcastID);
+
+		// Delete Broadcast.
+		$I->apiDeleteBroadcast($broadcastID);
+
+		// Confirm styles were not included in the Broadcast.
+		$I->assertStringNotContainsString('class="style-test"', $broadcast['broadcast']['content']);
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   2.7.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->unregisterCustomPostType($I, 'article');
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}


### PR DESCRIPTION
## Summary

This update extends the `Create Broadcast in Kit` option to be available when viewing a list of Pages and Custom Post Types, not just Posts.

Initially, this feature was designed to support only WordPress Posts, as blog posts are the most common content type used for Kit Broadcasts. However, based on [user feedback](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263837780674?view=List), this PR adds support for additional Post Types to improve flexibility.

## Testing

- `BroadcastsExportCPTRowActionCest`: Added tests to confirm the export action displays / does not display on a Custom Post Type, depending on whether the functionality is enabled in the Plugin's settings.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)