### PR TITLE
Remove `ck_subscriber_id`: Use `replaceState` instead of `pushState`

### DIFF
--- a/resources/frontend/js/convertkit.js
+++ b/resources/frontend/js/convertkit.js
@@ -90,8 +90,17 @@ function convertStoreSubscriberEmailAsIDInCookie( emailAddress ) {
  */
 function convertKitRemoveSubscriberIDFromURL( url ) {
 
-	// Remove ck_subscriber_id, retaining other params.
-	const url_object = new URL( url );
+	// Parse URL.
+	const url_object       = new URL( url );
+	const ck_subscriber_id = url_object.searchParams.get( 'ck_subscriber_id' );
+
+	// If ck_subscriber_id is null, it's not included in the URL.
+	// Don't modify the URL.
+	if ( ck_subscriber_id === null ) {
+		return;
+	}
+
+	// Remove ck_subscriber_id from URL params.
 	url_object.searchParams.delete( 'ck_subscriber_id' );
 
 	// Get title and string of parameters.

--- a/resources/frontend/js/convertkit.js
+++ b/resources/frontend/js/convertkit.js
@@ -113,7 +113,7 @@ function convertKitRemoveSubscriberIDFromURL( url ) {
 	}
 
 	// Update history.
-	window.history.pushState( null, title, url_object.pathname + params + url_object.hash );
+	window.history.replaceState( null, title, url_object.pathname + params + url_object.hash );
 
 }
 


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://linear.app/kit/issue/WP-22/kit-for-wordpress-267-and-higher-results-in-needing-to-press-back), where the browser’s history would store the current URL twice due to JavaScript always calling `window.history.pushState` instead of `window.history.replaceState`

Whilst the browser’s back button correctly skips over the duplicate entry, taking the user back to the previous page, using the mouse back button requires two clicks to navigate back, as it does not automatically detect and skip duplicate entries.

This PR resolves by:
- only modifying the history state if a ck_subscriber_id query parameter is present, and
- uses `replaceState` to replace the current history entry, preventing duplicate entries.

## Testing

There doesn't seem to be a Codeception method for simulating a mouse back button press. Manual tests performed to confirm working functionality, with existing tests confirming no regressions.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)