### PR TITLE
Rename Settings Classes to Sections

### DIFF
--- a/admin/class-convertkit-admin-settings.php
+++ b/admin/class-convertkit-admin-settings.php
@@ -313,8 +313,8 @@ class ConvertKit_Admin_Settings {
 
 		// Register the General and Tools settings sections.
 		$sections = array(
-			'general' => new ConvertKit_Settings_General(),
-			'tools'   => new ConvertKit_Settings_Tools(),
+			'general' => new ConvertKit_Admin_Section_General(),
+			'tools'   => new ConvertKit_Admin_Section_Tools(),
 		);
 
 		/**

--- a/admin/class-convertkit-admin-settings.php
+++ b/admin/class-convertkit-admin-settings.php
@@ -302,7 +302,7 @@ class ConvertKit_Admin_Settings {
 		if ( ! $settings->has_access_and_refresh_token() ) {
 			// Just register the OAuth screen.
 			$sections = array(
-				'oauth' => new ConvertKit_Settings_OAuth(),
+				'oauth' => new ConvertKit_Admin_Section_OAuth(),
 			);
 
 			// Assign them to this class.

--- a/admin/section/class-convertkit-admin-section-base.php
+++ b/admin/section/class-convertkit-admin-section-base.php
@@ -12,7 +12,7 @@
  * @package ConvertKit
  * @author ConvertKit
  */
-abstract class ConvertKit_Settings_Base {
+abstract class ConvertKit_Admin_Section_Base {
 
 	/**
 	 * Section name

--- a/admin/section/class-convertkit-admin-section-broadcasts.php
+++ b/admin/section/class-convertkit-admin-section-broadcasts.php
@@ -12,7 +12,7 @@
  * @package ConvertKit
  * @author ConvertKit
  */
-class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
+class ConvertKit_Admin_Section_Broadcasts extends ConvertKit_Admin_Section_Base {
 
 	/**
 	 * Constructor.
@@ -654,7 +654,7 @@ add_action(
 	'convertkit_admin_settings_register_sections',
 	function ( $sections ) {
 
-		$sections['broadcasts'] = new ConvertKit_Admin_Settings_Broadcasts();
+		$sections['broadcasts'] = new ConvertKit_Admin_Section_Broadcasts();
 		return $sections;
 
 	}

--- a/admin/section/class-convertkit-admin-section-general.php
+++ b/admin/section/class-convertkit-admin-section-general.php
@@ -12,7 +12,7 @@
  * @package ConvertKit
  * @author ConvertKit
  */
-class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
+class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 
 	/**
 	 * Holds the API instance.

--- a/admin/section/class-convertkit-admin-section-general.php
+++ b/admin/section/class-convertkit-admin-section-general.php
@@ -160,7 +160,7 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 				// Display a site wide notice.
 				WP_ConvertKit()->get_class( 'admin_notices' )->add( 'authorization_failed' );
 
-				// Redirect to General screen, which will now show the ConvertKit_Settings_OAuth screen, because
+				// Redirect to General screen, which will now show the ConvertKit_Admin_Section_OAuth screen, because
 				// the Plugin has no access token.
 				wp_safe_redirect(
 					add_query_arg(

--- a/admin/section/class-convertkit-admin-section-oauth.php
+++ b/admin/section/class-convertkit-admin-section-oauth.php
@@ -13,7 +13,7 @@
  * @package ConvertKit
  * @author ConvertKit
  */
-class ConvertKit_Settings_OAuth extends ConvertKit_Settings_Base {
+class ConvertKit_Admin_Section_OAuth extends ConvertKit_Admin_Section_Base {
 
 	/**
 	 * Constructor

--- a/admin/section/class-convertkit-admin-section-restrict-content.php
+++ b/admin/section/class-convertkit-admin-section-restrict-content.php
@@ -12,7 +12,7 @@
  * @package ConvertKit
  * @author ConvertKit
  */
-class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Base {
+class ConvertKit_Admin_Section_Restrict_Content extends ConvertKit_Admin_Section_Base {
 
 	/**
 	 * Constructor.
@@ -514,7 +514,7 @@ add_action(
 	'convertkit_admin_settings_register_sections',
 	function ( $sections ) {
 
-		$sections['restrict-content'] = new ConvertKit_Admin_Settings_Restrict_Content();
+		$sections['restrict-content'] = new ConvertKit_Admin_Section_Restrict_Content();
 		return $sections;
 
 	}

--- a/admin/section/class-convertkit-admin-section-tools.php
+++ b/admin/section/class-convertkit-admin-section-tools.php
@@ -12,7 +12,7 @@
  * @package ConvertKit
  * @author ConvertKit
  */
-class ConvertKit_Settings_Tools extends ConvertKit_Settings_Base {
+class ConvertKit_Admin_Section_Tools extends ConvertKit_Admin_Section_Base {
 
 	/**
 	 * Constructor

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-section.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-section.php
@@ -12,7 +12,7 @@
  * @package ConvertKit
  * @author ConvertKit
  */
-class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
+class ConvertKit_ContactForm7_Admin_Section extends ConvertKit_Admin_Section_Base {
 
 	/**
 	 * Constructor
@@ -244,7 +244,7 @@ add_filter(
 		}
 
 		// Register this class as a section at Settings > Kit.
-		$sections['contactform7'] = new ConvertKit_ContactForm7_Admin_Settings();
+		$sections['contactform7'] = new ConvertKit_ContactForm7_Admin_Section();
 		return $sections;
 
 	}

--- a/includes/integrations/forminator/class-convertkit-forminator-admin-section.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-admin-section.php
@@ -12,7 +12,7 @@
  * @package ConvertKit
  * @author ConvertKit
  */
-class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
+class ConvertKit_Forminator_Admin_Section extends ConvertKit_Admin_Section_Base {
 
 	/**
 	 * Constructor
@@ -239,7 +239,7 @@ add_filter(
 		}
 
 		// Register this class as a section at Settings > Kit.
-		$sections['forminator'] = new ConvertKit_Forminator_Admin_Settings();
+		$sections['forminator'] = new ConvertKit_Forminator_Admin_Section();
 		return $sections;
 
 	}

--- a/includes/integrations/wishlist/class-convertkit-wishlist-admin-section.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist-admin-section.php
@@ -12,7 +12,7 @@
  * @package ConvertKit
  * @author ConvertKit
  */
-class ConvertKit_Wishlist_Admin_Settings extends ConvertKit_Settings_Base {
+class ConvertKit_Wishlist_Admin_Section extends ConvertKit_Admin_Section_Base {
 
 	/**
 	 * Constructor.
@@ -198,7 +198,7 @@ add_filter(
 		}
 
 		// Register this class as a section at Settings > Kit.
-		$sections['wishlist-member'] = new ConvertKit_Wishlist_Admin_Settings();
+		$sections['wishlist-member'] = new ConvertKit_Wishlist_Admin_Section();
 		return $sections;
 
 	}

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -125,24 +125,24 @@ if ( is_admin() ) {
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-user.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-setup-wizard.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-multi-value-field-table.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-settings-base.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-settings-general.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-settings-oauth.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-settings-tools.php';
+	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-base.php';
+	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-general.php';
+	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-oauth.php';
+	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-tools.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php';
 
 	// Contact Form 7 Integration.
-	require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php';
+	require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/contactform7/class-convertkit-contactform7-admin-section.php';
 
 	// Forminator Integration.
-	require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php';
+	require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/forminator/class-convertkit-forminator-admin-section.php';
 
 	// WishList Member Integration.
-	require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php';
+	require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/wishlist/class-convertkit-wishlist-admin-section.php';
 
 	// Restrict Content Integration.
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-restrict-content.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-settings-restrict-content.php';
+	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-restrict-content.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php';
 
 	// Landing Page Integration.
@@ -150,7 +150,7 @@ if ( is_admin() ) {
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/setup-wizard/class-convertkit-admin-setup-wizard-landing-page.php';
 
 	// Broadcasts Integration.
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-settings-broadcasts.php';
+	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-broadcasts.php';
 }
 
 // Register Plugin activation and deactivation functions.


### PR DESCRIPTION
## Summary

Renames several PHP admin classes from `Admin_Settings` to `Admin_Section`, renames the files and moves the `ConvertKit_Admin_Settings_Restrict_Content` in to the `admin/section` folder to match the structure of the other settings sections.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)