### PR TITLE
Restrict Content: Refactor Tests

### DIFF
--- a/admin/section/class-convertkit-admin-section-restrict-content.php
+++ b/admin/section/class-convertkit-admin-section-restrict-content.php
@@ -136,6 +136,21 @@ class ConvertKit_Admin_Section_Restrict_Content extends ConvertKit_Admin_Section
 		);
 
 		add_settings_field(
+			'no_access_text_tag',
+			__( 'No Access Text', 'convertkit' ),
+			array( $this, 'text_callback' ),
+			$this->settings_key,
+			$this->name . '-tags',
+			array(
+				'name'        => 'no_access_text_tag',
+				'label_for'   => 'no_access_text_tag',
+				'description' => array(
+					__( 'The text to display for a subscriber who authenticates via the login link, but is not subscribed.', 'convertkit' ),
+				),
+			)
+		);
+
+		add_settings_field(
 			'require_tag_login',
 			__( 'Require Login', 'convertkit' ),
 			array( $this, 'require_tag_login_callback' ),
@@ -244,6 +259,22 @@ class ConvertKit_Admin_Section_Restrict_Content extends ConvertKit_Admin_Section
 		);
 
 		add_settings_field(
+			'no_access_text',
+			__( 'No Access Text', 'convertkit' ),
+			array( $this, 'text_callback' ),
+			$this->settings_key,
+			$this->name . '-products',
+			array(
+				'name'        => 'no_access_text',
+				'label_for'   => 'no_access_text',
+				'description' => array(
+					__( 'The text to display for a subscriber who authenticates via the login link, but is not subscribed.', 'convertkit' ),
+				),
+			)
+		);
+
+		// Member Content.
+		add_settings_field(
 			'email_text',
 			__( 'Email Text', 'convertkit' ),
 			array( $this, 'text_callback' ),
@@ -329,21 +360,6 @@ class ConvertKit_Admin_Section_Restrict_Content extends ConvertKit_Admin_Section
 				'label_for'   => 'email_check_text',
 				'description' => array(
 					__( 'The text to display instructing the subscriber to check their email for the login link that was sent.', 'convertkit' ),
-				),
-			)
-		);
-
-		add_settings_field(
-			'no_access_text',
-			__( 'No Access Text', 'convertkit' ),
-			array( $this, 'text_callback' ),
-			$this->settings_key,
-			$this->name,
-			array(
-				'name'        => 'no_access_text',
-				'label_for'   => 'no_access_text',
-				'description' => array(
-					__( 'The text to display for a subscriber who authenticates via the login link, but is not subscribed.', 'convertkit' ),
 				),
 			)
 		);

--- a/includes/class-convertkit-settings-restrict-content.php
+++ b/includes/class-convertkit-settings-restrict-content.php
@@ -211,6 +211,7 @@ class ConvertKit_Settings_Restrict_Content {
 			// Restrict by Product.
 			'subscribe_heading'       => __( 'Read this post with a premium subscription', 'convertkit' ),
 			'subscribe_text'          => __( 'This post is only available to premium subscribers. Join today to get access to all posts.', 'convertkit' ),
+			'no_access_text'          => __( 'Your account does not have access to this content. Please use the button above to purchase, or enter the email address you used to purchase the product.', 'convertkit' ),
 
 			// Restrict by Tag.
 			'subscribe_heading_tag'   => __( 'Subscribe to keep reading', 'convertkit' ),
@@ -219,6 +220,7 @@ class ConvertKit_Settings_Restrict_Content {
 			'recaptcha_site_key'      => '',
 			'recaptcha_secret_key'    => '',
 			'recaptcha_minimum_score' => '0.5',
+			'no_access_text_tag'      => __( 'Your account does not have access to this content. Please use the form above to subscribe.', 'convertkit' ),
 
 			// All.
 			'subscribe_button_label'  => __( 'Subscribe', 'convertkit' ),
@@ -228,7 +230,6 @@ class ConvertKit_Settings_Restrict_Content {
 			'email_description_text'  => __( 'We\'ll email you a magic code to log you in without a password.', 'convertkit' ),
 			'email_check_heading'     => __( 'We just emailed you a log in code', 'convertkit' ),
 			'email_check_text'        => __( 'Enter the code below to finish logging in', 'convertkit' ),
-			'no_access_text'          => __( 'Your account does not have access to this content. Please use the button above to purchase, or enter the email address you used to purchase the product.', 'convertkit' ),
 		);
 
 		/**

--- a/resources/frontend/css/restrict-content.css
+++ b/resources/frontend/css/restrict-content.css
@@ -75,7 +75,7 @@
 
 
 /* Buttons */
-form#convertkit-restrict-content-form input[type=submit] {
+form.convertkit-restrict-content-form input[type=submit] {
 	height: 42px;
 	line-height: 42px;
 	font-size: 15px;
@@ -86,7 +86,7 @@ form#convertkit-restrict-content-form input[type=submit] {
 }
 
 /* Email input with inline button */
-form#convertkit-restrict-content-form div#convertkit-restrict-content-email-field {
+form.convertkit-restrict-content-form div#convertkit-restrict-content-email-field {
 	display: grid;
 	grid-template-areas: "email button";
 	grid-template-columns: 3fr 1fr;
@@ -104,10 +104,10 @@ form#convertkit-restrict-content-form div#convertkit-restrict-content-email-fiel
 	border: 1px solid #fff;
 	border-radius: 3px;
 }
-form#convertkit-restrict-content-form div#convertkit-restrict-content-email-field.convertkit-restrict-content-error {
+form.convertkit-restrict-content-form div#convertkit-restrict-content-email-field.convertkit-restrict-content-error {
 	border-color: #d3434a;
 }
-form#convertkit-restrict-content-form div#convertkit-restrict-content-email-field input[type=email] {
+form.convertkit-restrict-content-form div#convertkit-restrict-content-email-field input[type=email] {
 	grid-area: email;
 	text-indent: 35px;
 	height: 42px;
@@ -118,12 +118,12 @@ form#convertkit-restrict-content-form div#convertkit-restrict-content-email-fiel
 	background: none;
 	border: none;
 }
-form#convertkit-restrict-content-form div#convertkit-restrict-content-email-field input[type=submit] {
+form.convertkit-restrict-content-form div#convertkit-restrict-content-email-field input[type=submit] {
 	grid-area: button;
 }
 
 /* One time code */
-form#convertkit-restrict-content-form div#convertkit-subscriber-code-container {
+form.convertkit-restrict-content-form div#convertkit-subscriber-code-container {
 	width: 427px;
 	height: 100px;
 	border: 1px solid #dce1e5;
@@ -132,10 +132,10 @@ form#convertkit-restrict-content-form div#convertkit-subscriber-code-container {
 	overflow: hidden;
 	background: #dce1e5;
 }
-form#convertkit-restrict-content-form div#convertkit-subscriber-code-container.convertkit-restrict-content-error {
+form.convertkit-restrict-content-form div#convertkit-subscriber-code-container.convertkit-restrict-content-error {
 	border-color: #d3434a;
 }
-form#convertkit-restrict-content-form div#convertkit-subscriber-code-container input#convertkit_subscriber_code {
+form.convertkit-restrict-content-form div#convertkit-subscriber-code-container input#convertkit_subscriber_code {
 	--otp-digits: 6;
 	--otp-height: 98px;
 	--otp-number-width: 70px;
@@ -209,7 +209,7 @@ form#convertkit-restrict-content-form div#convertkit-subscriber-code-container i
 	border-radius: 8px;
 	text-align: center;
 }
-#convertkit-restrict-content-modal form#convertkit-restrict-content-form div#convertkit-restrict-content-email-field {
+#convertkit-restrict-content-modal form.convertkit-restrict-content-form div#convertkit-restrict-content-email-field {
 	background-color: #f4f6f8;
 }
 #convertkit-restrict-content-modal-close {
@@ -239,11 +239,11 @@ form#convertkit-restrict-content-form div#convertkit-subscriber-code-container i
 		left: 5%;
 		padding: 40px;
 	}
-	form#convertkit-restrict-content-form div#convertkit-subscriber-code-container {
+	form.convertkit-restrict-content-form div#convertkit-subscriber-code-container {
 		width: 213px;
 		height: 50px;
 	}
-	form#convertkit-restrict-content-form div#convertkit-subscriber-code-container input#convertkit_subscriber_code {
+	form.convertkit-restrict-content-form div#convertkit-subscriber-code-container input#convertkit_subscriber_code {
 		--otp-height: 49px;
 		--otp-number-width: 35px;
 		--otp-letter-spacing: 20px;

--- a/resources/frontend/js/restrict-content.js
+++ b/resources/frontend/js/restrict-content.js
@@ -32,7 +32,7 @@ document.addEventListener(
 			'submit',
 			function ( e ) {
 				// Bail if the submission was not for the Restrict Content form.
-				if ( ! e.target.matches( '#convertkit-restrict-content-modal form#convertkit-restrict-content-form' ) ) {
+				if ( ! e.target.matches( 'form#convertkit-restrict-content-form' ) ) {
 					return;
 				}
 
@@ -58,9 +58,21 @@ document.addEventListener(
 	}
 );
 
+/**
+ * Handles Restrict Content Tag form submission when reCAPTCHA is enabled.
+ *
+ * @param string token reCAPTCHA token.
+ */
 function convertKitRestrictContentTagFormSubmit( token ) {
 
-	document.getElementById( 'convertkit-restrict-content-form' ).submit();
+	// Find submit button with the data-callback attribute.
+	const submitButton = document.querySelector( 'input[type="submit"][data-callback="convertKitRestrictContentTagFormSubmit"]' );
+
+	// Get the parent form of the submit button.
+	const form = submitButton.closest( 'form' );
+
+	// Submit the form.
+	form.submit();
 
 }
 

--- a/tests/_support/Helper/Acceptance/ConvertKitRestrictContent.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitRestrictContent.php
@@ -62,6 +62,7 @@ class ConvertKitRestrictContent extends \Codeception\Module
 			// Restrict by Product.
 			'subscribe_heading'       => 'Read this post with a premium subscription',
 			'subscribe_text'          => 'This post is only available to premium subscribers. Join today to get access to all posts.',
+			'no_access_text'          => 'Your account does not have access to this content. Please use the button above to purchase, or enter the email address you used to purchase the product.',
 
 			// Restrict by Tag.
 			'subscribe_heading_tag'   => 'Subscribe to keep reading',
@@ -74,7 +75,6 @@ class ConvertKitRestrictContent extends \Codeception\Module
 			'email_description_text'  => 'We\'ll email you a magic code to log you in without a password.',
 			'email_check_heading'     => 'We just emailed you a log in code',
 			'email_check_text'        => 'Enter the code below to finish logging in',
-			'no_access_text'          => 'Your account does not have access to this content. Please use the button above to purchase, or enter the email address you used to purchase the product.',
 		);
 	}
 
@@ -188,20 +188,13 @@ class ConvertKitRestrictContent extends \Codeception\Module
 	 *
 	 *     @type string $visible_content            Content that should always be visible.
 	 *     @type string $member_content             Content that should only be available to authenticated subscribers.
-	 *     @type array  $text_items                 Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 *     @type array  $settings                   Restrict content settings. If not defined, uses expected defaults.
 	 * }
 	 */
 	public function testRestrictedContentByProductOnFrontend($I, $urlOrPageID, $options = false)
 	{
-		// Merge options with defaults.
-		$options = $this->_getRestrictedContentOptionsWithDefaultsMerged($options);
-
-		// Navigate to the page.
-		if ( is_numeric( $urlOrPageID ) ) {
-			$I->amOnPage('?p=' . $urlOrPageID);
-		} else {
-			$I->amOnUrl($urlOrPageID);
-		}
+		// Setup test.
+		$options = $this->setupRestrictContentTest($I, $options, $urlOrPageID);
 
 		// Confirm Restrict Content CSS is output.
 		$I->seeInSource('<link rel="stylesheet" id="convertkit-restrict-content-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/restrict-content.css');
@@ -210,37 +203,26 @@ class ConvertKitRestrictContent extends \Codeception\Module
 		$this->testRestrictContentByProductHidesContentWithCTA($I, $options);
 
 		// Login as a ConvertKit subscriber who does not exist in ConvertKit.
-		$I->waitForElementVisible('input#convertkit_email');
-		$I->fillField('convertkit_email', 'fail@kit.com');
-		$I->click('input.wp-block-button__link');
+		$this->loginToRestrictContentWithEmail($I, 'fail@kit.com');
 
 		// Confirm an inline error message is displayed.
-		$I->seeInSource('<div class="convertkit-restrict-content-notice convertkit-restrict-content-notice-error">invalid: Email address is invalid</div>');
-		$I->seeInSource('<div id="convertkit-restrict-content-email-field" class="convertkit-restrict-content-error">');
+		$this->seeRestrictContentError($I, 'invalid: Email address is invalid');
 
 		// Check content is not displayed, and CTA displays with expected text.
 		$this->testRestrictContentByProductHidesContentWithCTA($I, $options);
 
 		// Set cookie with signed subscriber ID and reload the restricted content page, as if we entered the
-		// code sent in the email as a ConvertKit subscriber who has not subscribed to the product.
-		$I->setCookie('ck_subscriber_id', $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID_NO_ACCESS']);
-		if ( is_numeric( $urlOrPageID ) ) {
-			$I->amOnPage('?p=' . $urlOrPageID . '&ck-cache-bust=' . microtime() );
-		} else {
-			$I->amOnUrl($urlOrPageID . '?ck-cache-bust=' . microtime() );
-		}
+		// code sent in the email as a Kit subscriber who has not subscribed to the product.
+		$this->setRestrictContentCookieAndReload($I, $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID_NO_ACCESS'], $urlOrPageID);
 
 		// Confirm an inline error message is displayed.
-		$I->seeInSource('<div class="convertkit-restrict-content-notice convertkit-restrict-content-notice-error">' . $options['text_items']['no_access_text'] . '</div>');
-		$I->seeInSource('<div id="convertkit-restrict-content-email-field" class="convertkit-restrict-content-error">');
+		$this->seeRestrictContentError($I, $options['settings']['no_access_text']);
 
 		// Check content is not displayed, and CTA displays with expected text.
 		$this->testRestrictContentByProductHidesContentWithCTA($I, $options);
 
 		// Login as a ConvertKit subscriber who has subscribed to the product.
-		$I->waitForElementVisible('input#convertkit_email');
-		$I->fillField('convertkit_email', $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']);
-		$I->click('input.wp-block-button__link');
+		$this->loginToRestrictContentWithEmail($I, $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']);
 
 		// Confirm that confirmation an email has been sent is displayed.
 		// Confirm that the visible text displays, hidden text does not display and the CTA displays.
@@ -250,90 +232,18 @@ class ConvertKitRestrictContent extends \Codeception\Module
 		$I->dontSee($options['member_content']);
 
 		// Confirm that the CTA displays with the expected text.
-		$I->seeElementInDOM('#convertkit-restrict-content');
-		$I->seeInSource('<h4>' . $options['text_items']['email_check_heading'] . '</h4>');
-		$I->see($options['text_items']['email_check_text']);
-		$I->seeElementInDOM('input#convertkit_subscriber_code');
-		$I->seeElementInDOM('input.wp-block-button__link');
+		$this->seeRestrictContentSubscriberCode($I, $options['settings']['email_check_heading'], $options['settings']['email_check_text']);
 
 		// Enter an invalid code.
-		$I->fillField('subscriber_code', '999999');
-		$I->click('Verify');
+		$this->submitRestrictContentSubscriberCode($I, '999999');
 
 		// Confirm an inline error message is displayed.
-		$I->seeInSource('<div class="convertkit-restrict-content-notice convertkit-restrict-content-notice-error">The entered code is invalid. Please try again, or click the link sent in the email.</div>');
-		$I->seeInSource('<div id="convertkit-subscriber-code-container" class="convertkit-restrict-content-error">');
+		$this->seeRestrictContentError($I, 'The entered code is invalid. Please try again, or click the link sent in the email.');
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// as if we entered the code sent in the email.
-		$this->testRestrictedContentShowsContentWithValidSubscriberID($I, $urlOrPageID, $options);
-	}
-
-	/**
-	 * Run frontend tests for restricted content by ConvertKit Product, using the modal authentication flow, to confirm
-	 * that visible and member's content is / is not displayed when logging in with valid and invalid subscriber email addresses.
-	 *
-	 * @since   2.3.8
-	 *
-	 * @param   AcceptanceTester $I                  Tester.
-	 * @param   string|int       $urlOrPageID        URL or ID of Restricted Content Page.
-	 * @param   bool|array       $options {
-	 *           Optional. An array of settings.
-	 *
-	 *     @type string $visible_content            Content that should always be visible.
-	 *     @type string $member_content             Content that should only be available to authenticated subscribers.
-	 *     @type array  $text_items                 Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
-	 * }
-	 */
-	public function testRestrictedContentModalByProductOnFrontend($I, $urlOrPageID, $options = false)
-	{
-		// Merge options with defaults.
-		$options = $this->_getRestrictedContentOptionsWithDefaultsMerged($options);
-
-		// Navigate to the page.
-		if ( is_numeric( $urlOrPageID ) ) {
-			$I->amOnPage('?p=' . $urlOrPageID);
-		} else {
-			$I->amOnUrl($urlOrPageID);
-		}
-
-		// Confirm Restrict Content CSS is output.
-		$I->seeInSource('<link rel="stylesheet" id="convertkit-restrict-content-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/restrict-content.css');
-
-		// Check content is not displayed, and CTA displays with expected text.
-		$this->testRestrictContentByProductHidesContentWithCTA($I, $options);
-
-		// Login as a ConvertKit subscriber who does not exist in ConvertKit.
-		$I->click('a.convertkit-restrict-content-modal-open');
-		$I->waitForElementVisible('#convertkit-restrict-content-modal');
-		$I->waitForElementVisible('input#convertkit_email');
-		$I->fillField('convertkit_email', 'fail@kit.com');
-		$I->click('#convertkit-restrict-content-modal input.wp-block-button__link');
-
-		// Confirm an inline error message is displayed.
-		$I->waitForElementVisible('.convertkit-restrict-content-notice-error');
-		$I->see('invalid: Email address is invalid', '.convertkit-restrict-content-notice-error');
-
-		// Login as a ConvertKit subscriber who has subscribed to the product.
-		$I->fillField('convertkit_email', $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']);
-		$I->click('#convertkit-restrict-content-modal input.wp-block-button__link');
-
-		// Confirm that confirmation an email has been sent is displayed.
-		$I->waitForElementVisible('input#convertkit_subscriber_code');
-		$I->see($options['text_items']['email_check_heading'], 'h4');
-		$I->see($options['text_items']['email_check_text'], 'p');
-
-		// Enter an invalid code.
-		$I->fillField('subscriber_code', '999999');
-
-		// Confirm an inline error message is displayed.
-		$I->waitForElementVisible('.convertkit-restrict-content-notice-error');
-		$I->see('The entered code is invalid. Please try again, or click the link sent in the email.', '.convertkit-restrict-content-notice-error');
-		$I->seeElementInDOM('input#convertkit_subscriber_code');
-
-		// Test that the restricted content displays when a valid signed subscriber ID is used,
-		// as if we entered the code sent in the email.
-		$this->testRestrictedContentShowsContentWithValidSubscriberID($I, $urlOrPageID, $options);
+		$this->setRestrictContentCookieAndReload($I, $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID'], $urlOrPageID);
+		$this->testRestrictContentDisplaysContent($I, $options);
 	}
 
 	/**
@@ -350,74 +260,46 @@ class ConvertKitRestrictContent extends \Codeception\Module
 	 *
 	 *     @type string $visible_content            Content that should always be visible.
 	 *     @type string $member_content             Content that should only be available to authenticated subscribers.
-	 *     @type array  $text_items                 Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 *     @type array  $settings                   Restrict content settings. If not defined, uses expected defaults.
 	 * }
-	 * @param   bool             $recaptchaEnabled   Whether the reCAPTCHA settings are enabled in the Plugin settings.
 	 */
-	public function testRestrictedContentByTagOnFrontend($I, $urlOrPageID, $emailAddress, $options = false, $recaptchaEnabled = false)
+	public function testRestrictedContentByTagOnFrontend($I, $urlOrPageID, $emailAddress, $options = false)
 	{
-		// Merge options with defaults.
-		$options = $this->_getRestrictedContentOptionsWithDefaultsMerged($options);
-
-		// Navigate to the page.
-		if ( is_numeric( $urlOrPageID ) ) {
-			$I->amOnPage('?p=' . $urlOrPageID);
-		} else {
-			$I->amOnUrl($urlOrPageID);
-		}
-
-		// Clear any existing cookie from a previous test and reload.
-		$I->resetCookie('ck_subscriber_id');
-		$I->reloadPage();
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Setup test.
+		$options = $this->setupRestrictContentTest($I, $options, $urlOrPageID);
 
 		// Confirm Restrict Content CSS is output.
 		$I->seeInSource('<link rel="stylesheet" id="convertkit-restrict-content-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/restrict-content.css');
 
-		// Confirm that the visible text displays, hidden text does not display and the CTA displays.
-		$I->see($options['visible_content']);
-		$I->dontSee($options['member_content']);
+		// Check content is not displayed, and CTA displays with expected text.
+		$this->testRestrictContentByTagHidesContentWithCTA($I, $options);
 
-		// Confirm that the CTA displays with the expected headings, text and other elements.
-		$I->seeElementInDOM('#convertkit-restrict-content');
-		$I->seeInSource('<h3>' . $options['text_items']['subscribe_heading_tag'] . '</h3>');
-		$I->see($options['text_items']['subscribe_text_tag']);
-		$I->seeInSource('<input type="submit" class="wp-block-button__link wp-block-button__link' . ( $recaptchaEnabled ? ' g-recaptcha' : '' ) . '" value="' . $options['text_items']['subscribe_button_label'] . '"');
-
-		// Set cookie with subscriber ID that does not have access to the tag, and reload the restricted content page.
-		$I->setCookie('ck_subscriber_id', $_ENV['CONVERTKIT_API_SUBSCRIBER_ID_NO_ACCESS']);
-		if ( is_numeric( $urlOrPageID ) ) {
-			$I->amOnPage('?p=' . $urlOrPageID . '&ck-cache-bust=' . microtime() );
-		} else {
-			$I->amOnUrl($urlOrPageID . '?ck-cache-bust=' . microtime() );
-		}
+		// Set cookie with signed subscriber ID and reload the restricted content page, as if we entered the
+		// code sent in the email as a Kit subscriber who has not subscribed to the tag.
+		$this->setRestrictContentCookieAndReload($I, $_ENV['CONVERTKIT_API_SUBSCRIBER_ID_NO_ACCESS'], $urlOrPageID);
 
 		// Confirm an inline error message is displayed.
-		$I->seeInSource('<div class="convertkit-restrict-content-notice convertkit-restrict-content-notice-error">' . $options['text_items']['no_access_text'] . '</div>');
-		$I->seeInSource('<div id="convertkit-restrict-content-email-field" class="convertkit-restrict-content-error">');
+		$this->seeRestrictContentError($I, $options['settings']['no_access_text']);
 
-		// Confirm that the visible text displays, hidden text does not display and the CTA displays.
-		$I->see($options['visible_content']);
-		$I->dontSee($options['member_content']);
+		// Check content is not displayed, and CTA displays with expected text.
+		$this->testRestrictContentByTagHidesContentWithCTA($I, $options);
 
 		// Enter the email address and submit the form.
-		$I->fillField('convertkit_email', $emailAddress);
-		$I->click('input.wp-block-button__link');
+		$this->loginToRestrictContentWithEmail($I, $emailAddress);
 
 		// Wait for reCAPTCHA to fully load.
-		if ( $recaptchaEnabled ) {
+		if ($options['settings']['recaptcha_site_key']) {
 			$I->wait(3);
 		}
 
 		// Confirm that the restricted content is now displayed.
-		$I->testRestrictContentDisplaysContent($I, $options);
+		$this->testRestrictContentDisplaysContent($I, $options);
 	}
 
 	/**
 	 * Run frontend tests for restricted content by Kit Tag, to confirm that visible and member's content
-	 * is / is not displayed when using signed subscriber IDs that do / do not have access to the content.
+	 * is / is not displayed when the 'Require Login' option is enabled, therefore requiring
+	 * the use of signed subscriber IDs.
 	 *
 	 * @since   2.7.1
 	 *
@@ -429,47 +311,22 @@ class ConvertKitRestrictContent extends \Codeception\Module
 	 *
 	 *     @type string $visible_content            Content that should always be visible.
 	 *     @type string $member_content             Content that should only be available to authenticated subscribers.
-	 *     @type array  $text_items                 Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 *     @type array  $settings                   Restrict content settings. If not defined, uses expected defaults.
 	 * }
-	 * @param   bool             $recaptchaEnabled   Whether the reCAPTCHA settings are enabled in the Plugin settings.
 	 */
-	public function testRestrictedContentByTagOnFrontendUsingSignedSubscriberID($I, $urlOrPageID, $emailAddress, $options = false, $recaptchaEnabled = false)
+	public function testRestrictedContentByTagOnFrontendWhenRequireLoginEnabled($I, $urlOrPageID, $emailAddress, $options = false)
 	{
-		// Merge options with defaults.
-		$options = $this->_getRestrictedContentOptionsWithDefaultsMerged($options);
-
-		// Navigate to the page.
-		if ( is_numeric( $urlOrPageID ) ) {
-			$I->amOnPage('?p=' . $urlOrPageID);
-		} else {
-			$I->amOnUrl($urlOrPageID);
-		}
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Setup test.
+		$options = $this->setupRestrictContentTest($I, $options, $urlOrPageID);
 
 		// Confirm Restrict Content CSS is output.
 		$I->seeInSource('<link rel="stylesheet" id="convertkit-restrict-content-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/restrict-content.css');
 
-		// Confirm that the visible text displays, hidden text does not display and the CTA displays.
-		$I->see($options['visible_content']);
-		$I->dontSee($options['member_content']);
+		// Check content is not displayed, and CTA displays with expected text.
+		$this->testRestrictContentByTagHidesContentWithCTA($I, $options);
 
-		// Confirm that the CTA displays with the expected headings, text and other elements.
-		$I->seeElementInDOM('#convertkit-restrict-content');
-		$I->seeInSource('<h3>' . $options['text_items']['subscribe_heading_tag'] . '</h3>');
-		$I->see($options['text_items']['subscribe_text_tag']);
-		$I->seeInSource('<input type="submit" class="wp-block-button__link wp-block-button__link' . ( $recaptchaEnabled ? ' g-recaptcha' : '' ) . '" value="' . $options['text_items']['subscribe_button_label'] . '"');
-
-		// Signup.
-		$I->waitForElementVisible('input#convertkit_email');
-		$I->fillField('convertkit_email', $emailAddress);
-		$I->click('input.wp-block-button__link');
-
-		// Wait for reCAPTCHA to fully load.
-		if ( $recaptchaEnabled ) {
-			$I->wait(3);
-		}
+		// Login.
+		$this->loginToRestrictContentWithEmail($I, $emailAddress);
 
 		// Confirm that confirmation an email has been sent is displayed.
 		// Confirm that the visible text displays, hidden text does not display and the CTA displays.
@@ -479,30 +336,25 @@ class ConvertKitRestrictContent extends \Codeception\Module
 		$I->dontSee($options['member_content']);
 
 		// Confirm that the CTA displays with the expected text.
-		$I->seeElementInDOM('#convertkit-restrict-content');
-		$I->seeInSource('<h4>' . $options['text_items']['email_check_heading'] . '</h4>');
-		$I->see($options['text_items']['email_check_text']);
-		$I->seeElementInDOM('input#convertkit_subscriber_code');
-		$I->seeElementInDOM('input.wp-block-button__link');
+		$this->seeRestrictContentSubscriberCode($I, $options['settings']['email_check_heading'], $options['settings']['email_check_text']);
 
 		// Enter an invalid code.
-		$I->fillField('subscriber_code', '999999');
-		$I->click('Verify');
+		$this->submitRestrictContentSubscriberCode($I, '999999');
 
 		// Confirm an inline error message is displayed.
-		$I->seeInSource('<div class="convertkit-restrict-content-notice convertkit-restrict-content-notice-error">The entered code is invalid. Please try again, or click the link sent in the email.</div>');
-		$I->seeInSource('<div id="convertkit-subscriber-code-container" class="convertkit-restrict-content-error">');
+		$this->seeRestrictContentError($I, 'The entered code is invalid. Please try again, or click the link sent in the email.');
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// as if we entered the code sent in the email.
-		$this->testRestrictedContentShowsContentWithValidSubscriberID($I, $urlOrPageID, $options);
+		$this->setRestrictContentCookieAndReload($I, $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID'], $urlOrPageID);
+		$this->testRestrictContentDisplaysContent($I, $options);
 	}
 
 	/**
-	 * Run frontend tests for restricted content, to confirm that both visible and member content is displayed
-	 * when a valid signed subscriber ID is set as a cookie, as if the user entered a code sent in the email.
+	 * Run frontend tests for restricted content functionality, using the modal authentication flow, to confirm
+	 * that visible and member's content is / is not displayed when logging in with valid and invalid subscriber email addresses.
 	 *
-	 * @since   2.2.2
+	 * @since   2.7.3
 	 *
 	 * @param   AcceptanceTester $I                  Tester.
 	 * @param   string|int       $urlOrPageID        URL or ID of Restricted Content Page.
@@ -511,27 +363,45 @@ class ConvertKitRestrictContent extends \Codeception\Module
 	 *
 	 *     @type string $visible_content            Content that should always be visible.
 	 *     @type string $member_content             Content that should only be available to authenticated subscribers.
-	 *     @type array  $text_items                 Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 *     @type array  $settings                   Restrict content settings. If not defined, uses expected defaults.
 	 * }
 	 */
-	public function testRestrictedContentShowsContentWithValidSubscriberID($I, $urlOrPageID, $options = false)
+	public function testRestrictedContentModal($I, $urlOrPageID, $options = false)
 	{
-		// Set cookie with signed subscriber ID, as if we entered the code sent in the email.
-		$I->setCookie('ck_subscriber_id', $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID']);
+		// Setup test.
+		$options = $this->setupRestrictContentTest($I, $options, $urlOrPageID);
 
-		// Reload the restricted content page.
-		if ( is_numeric( $urlOrPageID ) ) {
-			$I->amOnPage('?p=' . $urlOrPageID );
-		} else {
-			$I->amOnUrl($urlOrPageID );
-		}
+		// Confirm Restrict Content CSS is output.
+		$I->seeInSource('<link rel="stylesheet" id="convertkit-restrict-content-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/restrict-content.css');
 
-		// Confirm cookie was set with the expected value.
-		$I->assertEquals($I->grabCookie('ck_subscriber_id'), $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID']);
+		// Check content is not displayed, and CTA displays with expected text.
+		$this->testRestrictContentByProductHidesContentWithCTA($I, $options);
 
-		// Confirm that the restricted content is now displayed, as we've authenticated as a subscriber
-		// who has access to this Product.
-		$I->testRestrictContentDisplaysContent($I, $options);
+		// Click the login link to open the login modal.
+		$this->clickRestrictContentLoginLink($I);
+
+		// Login as a ConvertKit subscriber who does not exist in ConvertKit.
+		$this->loginToRestrictContentWithEmail($I, 'fail@kit.com');
+
+		// Confirm an inline error message is displayed.
+		$this->seeRestrictContentError($I, 'invalid: Email address is invalid');
+
+		// Login as a ConvertKit subscriber who has subscribed to the product.
+		$this->loginToRestrictContentWithEmail($I, $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']);
+
+		// Confirm that the subscriber code form dispays.
+		$this->seeRestrictContentSubscriberCode($I, $options['settings']['email_check_heading'], $options['settings']['email_check_text']);
+
+		// Enter an invalid code.
+		$this->submitRestrictContentSubscriberCodeModal($I, '999999');
+
+		// Confirm an inline error message is displayed.
+		$this->seeRestrictContentError($I, 'The entered code is invalid. Please try again, or click the link sent in the email.');
+
+		// Test that the restricted content displays when a valid signed subscriber ID is used,
+		// as if we entered the code sent in the email.
+		$this->setRestrictContentCookieAndReload($I, $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID'], $urlOrPageID);
+		$this->testRestrictContentDisplaysContent($I, $options);
 	}
 
 	/**
@@ -548,7 +418,7 @@ class ConvertKitRestrictContent extends \Codeception\Module
 	 *
 	 *     @type string $visible_content            Content that should always be visible.
 	 *     @type string $member_content             Content that should only be available to authenticated subscribers.
-	 *     @type array  $text_items                 Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 *     @type array  $settings                   Restrict content settings. If not defined, uses expected defaults.
 	 * }
 	 */
 	public function testRestrictContentByProductHidesContentWithCTA($I, $options = false)
@@ -568,15 +438,53 @@ class ConvertKitRestrictContent extends \Codeception\Module
 		// Confirm that the CTA displays with the expected headings, text, buttons and other elements.
 		$I->seeElementInDOM('#convertkit-restrict-content');
 
-		$I->seeInSource('<h3>' . $options['text_items']['subscribe_heading'] . '</h3>');
-		$I->see($options['text_items']['subscribe_text']);
+		$I->seeInSource('<h3>' . $options['settings']['subscribe_heading'] . '</h3>');
+		$I->see($options['settings']['subscribe_text']);
 
-		$I->see($options['text_items']['subscribe_button_label']);
+		$I->see($options['settings']['subscribe_button_label']);
 		$I->seeInSource('<a href="' . $_ENV['CONVERTKIT_API_PRODUCT_URL'] . '" class="wp-block-button__link');
 
-		$I->see($options['text_items']['email_text']);
-		$I->seeInSource('<input type="submit" class="wp-block-button__link wp-block-button__link" value="' . $options['text_items']['email_button_label'] . '"');
-		$I->seeInSource('<small>' . $options['text_items']['email_description_text'] . '</small>');
+		$I->see($options['settings']['email_text']);
+		$I->seeInSource('<input type="submit" class="wp-block-button__link wp-block-button__link" value="' . $options['settings']['email_button_label'] . '"');
+		$I->seeInSource('<small>' . $options['settings']['email_description_text'] . '</small>');
+	}
+
+	/**
+	 * Run frontend tests for restricted content, to confirm that:
+	 * - visible content is displayed,
+	 * - member's content is not displayed,
+	 * - the CTA is displayed with the expected text
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I                  Tester.
+	 * @param   bool|array       $options {
+	 *           Optional. An array of settings.
+	 *
+	 *     @type string $visible_content            Content that should always be visible.
+	 *     @type string $member_content             Content that should only be available to authenticated subscribers.
+	 *     @type array  $settings                   Restrict content settings. If not defined, uses expected defaults.
+	 * }
+	 */
+	public function testRestrictContentByTagHidesContentWithCTA($I, $options = false)
+	{
+		// Merge options with defaults.
+		$options = $this->_getRestrictedContentOptionsWithDefaultsMerged($options);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the visible text displays, hidden text does not display and the CTA displays.
+		if ( ! empty($options['visible_content'])) {
+			$I->see($options['visible_content']);
+		}
+		$I->dontSee($options['member_content']);
+
+		// Confirm that the CTA displays with the expected headings, text, buttons and other elements.
+		$I->seeElementInDOM('#convertkit-restrict-content');
+		$I->seeInSource('<h3>' . $options['settings']['subscribe_heading_tag'] . '</h3>');
+		$I->see($options['settings']['subscribe_text_tag']);
+		$I->seeInSource('<input type="submit" class="wp-block-button__link wp-block-button__link' . ( $options['settings']['recaptcha_site_key'] ? ' g-recaptcha' : '' ) . '" value="' . $options['settings']['subscribe_button_label'] . '"');
 	}
 
 	/**
@@ -593,7 +501,7 @@ class ConvertKitRestrictContent extends \Codeception\Module
 	 *
 	 *     @type string $visible_content            Content that should always be visible.
 	 *     @type string $member_content             Content that should only be available to authenticated subscribers.
-	 *     @type array  $text_items                 Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 *     @type array  $settings                   Restrict content settings. If not defined, uses expected defaults.
 	 * }
 	 */
 	public function testRestrictContentDisplaysContent($I, $options = false)
@@ -615,6 +523,146 @@ class ConvertKitRestrictContent extends \Codeception\Module
 	}
 
 	/**
+	 * Setup Restrict Content options, clear the cookie and navigate
+	 * to the page ID or URL.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I                  Tester.
+	 * @param   bool|array       $options {
+	 *           Optional. An array of settings.
+	 *
+	 *     @type string $visible_content            Content that should always be visible.
+	 *     @type string $member_content             Content that should only be available to authenticated subscribers.
+	 *     @type array  $settings                   Restrict content settings. If not defined, uses expected defaults.
+	 * }
+	 * @param   string|int       $urlOrPageID        URL or ID of Restricted Content Page.
+	 * @return  array
+	 */
+	public function setupRestrictContentTest($I, $options, $urlOrPageID)
+	{
+		// Merge options with defaults.
+		$options = $this->_getRestrictedContentOptionsWithDefaultsMerged($options);
+
+		// Clear any existing cookie from a previous test and reload.
+		$I->resetCookie('ck_subscriber_id');
+
+		// Navigate to the page.
+		if ( is_numeric( $urlOrPageID ) ) {
+			$I->amOnPage('?p=' . $urlOrPageID);
+		} else {
+			$I->amOnUrl($urlOrPageID);
+		}
+
+		return $options;
+	}
+
+	/**
+	 * Assert that the subscriber code form displays, with the expected heading and text.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I         Tester.
+	 * @param   string           $heading   Heading text.
+	 * @param   string           $text      Text.
+	 */
+	public function seeRestrictContentSubscriberCode($I, $heading, $text)
+	{
+		$I->waitForElementVisible('input#convertkit_subscriber_code');
+		$I->see($heading, 'h4');
+		$I->see($text, 'p');
+	}
+
+	/**
+	 * Submit the given code in the subscriber code form.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I     Tester.
+	 * @param   string           $code  Subsciber code.
+	 */
+	public function submitRestrictContentSubscriberCode($I, $code)
+	{
+		$I->fillField('subscriber_code', $code);
+		$I->click('Verify');
+	}
+
+	/**
+	 * Submit the given code in the subscriber code form modal.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I     Tester.
+	 * @param   string           $code  Subsciber code.
+	 */
+	public function submitRestrictContentSubscriberCodeModal($I, $code)
+	{
+		$I->fillField('subscriber_code', $code);
+	}
+
+	/**
+	 * Click the restrict content login link, and confirm the modal displays.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I                  Tester.
+	 */
+	public function clickRestrictContentLoginLink($I)
+	{
+		$I->click('a.convertkit-restrict-content-modal-open');
+		$I->waitForElementVisible('#convertkit-restrict-content-modal');
+	}
+
+	/**
+	 * Enter the given email address in the login form for restrict content.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I             Tester.
+	 * @param   string           $emailAddress  Email address.
+	 */
+	public function loginToRestrictContentWithEmail($I, $emailAddress)
+	{
+		$I->waitForElementVisible('#convertkit-restrict-content-email-field input#convertkit_email');
+		$I->fillField('#convertkit-restrict-content-email-field input#convertkit_email', $emailAddress);
+		$I->waitForElementVisible('#convertkit-restrict-content-email-field input.wp-block-button__link');
+		$I->click('#convertkit-restrict-content-email-field input.wp-block-button__link');
+	}
+
+	/**
+	 * Assert that the given error is displayed for restrict content.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I         Tester.
+	 * @param   string           $error     Error message.
+	 */
+	public function seeRestrictContentError($I, $error)
+	{
+		$I->waitForElementVisible('.convertkit-restrict-content-notice-error');
+		$I->see($error, '.convertkit-restrict-content-notice-error');
+	}
+
+	/**
+	 * Set the subscriber ID cookie and reload the given URL or Page ID.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I                  Tester.
+	 * @param   string|int       $subscriberID       Signed subscriber ID or subscriber ID.
+	 * @param   string|int       $urlOrPageID        URL or ID of Restricted Content Page.
+	 */
+	public function setRestrictContentCookieAndReload($I, $subscriberID, $urlOrPageID)
+	{
+		$I->setCookie('ck_subscriber_id', $subscriberID);
+		if ( is_numeric( $urlOrPageID ) ) {
+			$I->amOnPage('?p=' . $urlOrPageID . '&ck-cache-bust=' . microtime() );
+		} else {
+			$I->amOnUrl($urlOrPageID . '?ck-cache-bust=' . microtime() );
+		}
+	}
+
+	/**
 	 * Return an array of Restrict Content strings for tests, based on the optional supplied strings.
 	 *
 	 * @since   2.4.1
@@ -622,9 +670,9 @@ class ConvertKitRestrictContent extends \Codeception\Module
 	 * @param   bool|array $options {
 	 *     Optional. An array of settings.
 	 *
-	 *     @type string $visible_content            Content that should always be visible.
-	 *     @type string $member_content             Content that should only be available to authenticated subscribers.
-	 *     @type array  $text_items                 Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 *     @type string $visible_content          Content that should always be visible.
+	 *     @type string $member_content           Content that should only be available to authenticated subscribers.
+	 *     @type array  $settings                 Restrict content settings. If not defined, uses expected defaults.
 	 * }
 	 */
 	private function _getRestrictedContentOptionsWithDefaultsMerged($options = false)
@@ -633,15 +681,25 @@ class ConvertKitRestrictContent extends \Codeception\Module
 		$defaults = [
 			'visible_content' => 'Visible content.',
 			'member_content'  => 'Member-only content.',
-			'text_items'      => $this->getRestrictedContentDefaultSettings(),
+			'settings'        => $this->getRestrictedContentDefaultSettings(),
 		];
 
-		// If supplied options are an array, merge them with the defaults.
-		if (is_array($options)) {
-			return array_merge($defaults, $options);
+		// If supplied options are false, just return the defaults.
+		if ( ! $options ) {
+			return $defaults;
 		}
 
-		// Just return defaults.
+		// Override defaults if supplied in options array.
+		if ( array_key_exists('visible_content', $options ) ) {
+			$defaults['visible_content'] = $options['visible_content'];
+		}
+		if ( array_key_exists('member_content', $options ) ) {
+			$defaults['member_content'] = $options['member_content'];
+		}
+		if ( array_key_exists('settings', $options ) ) {
+			$defaults['settings'] = array_merge($defaults['settings'], $options['settings']);
+		}
+
 		return $defaults;
 	}
 }

--- a/tests/acceptance/restrict-content/general/RestrictContentCacheCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentCacheCest.php
@@ -63,7 +63,8 @@ class RestrictContentCacheCest
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// to confirm caching does not show the incorrect content.
-		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID);
+		$I->setRestrictContentCookieAndReload($I, $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID'], $pageID);
+		$I->testRestrictContentDisplaysContent($I);
 
 		// Deactivate Litespeed Cache Plugin.
 		$I->deactivateThirdPartyPlugin($I, 'litespeed-cache');
@@ -112,7 +113,8 @@ class RestrictContentCacheCest
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// to confirm caching does not show the incorrect content.
-		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID);
+		$I->setRestrictContentCookieAndReload($I, $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID'], $pageID);
+		$I->testRestrictContentDisplaysContent($I);
 
 		// Deactivate W3 Total Cache Plugin.
 		$I->deactivateThirdPartyPlugin($I, 'w3-total-cache');
@@ -159,7 +161,8 @@ class RestrictContentCacheCest
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// to confirm caching does not show the incorrect content.
-		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID);
+		$I->setRestrictContentCookieAndReload($I, $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID'], $pageID);
+		$I->testRestrictContentDisplaysContent($I);
 
 		// Deactivate WP Fastest Cache Plugin.
 		$I->deactivateThirdPartyPlugin($I, 'wp-fastest-cache');
@@ -206,7 +209,8 @@ class RestrictContentCacheCest
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// to confirm caching does not show the incorrect content.
-		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID);
+		$I->setRestrictContentCookieAndReload($I, $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID'], $pageID);
+		$I->testRestrictContentDisplaysContent($I);
 
 		// Deactivate WP-Optimize Cache Plugin.
 		$I->deactivateThirdPartyPlugin($I, 'wp-optimize');
@@ -253,7 +257,8 @@ class RestrictContentCacheCest
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// to confirm caching does not show the incorrect content.
-		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID);
+		$I->setRestrictContentCookieAndReload($I, $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID'], $pageID);
+		$I->testRestrictContentDisplaysContent($I);
 
 		// Deactivate WP Super Cache Plugin.
 		$I->deactivateThirdPartyPlugin($I, 'wp-super-cache');
@@ -293,7 +298,8 @@ class RestrictContentCacheCest
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// to confirm caching does not show the incorrect content.
-		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID);
+		$I->setRestrictContentCookieAndReload($I, $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID'], $pageID);
+		$I->testRestrictContentDisplaysContent($I);
 
 		// Deactivate WP Super Cache Plugin.
 		$I->deactivateThirdPartyPlugin($I, 'wp-rocket');

--- a/tests/acceptance/restrict-content/general/RestrictContentFilterCPTCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentFilterCPTCest.php
@@ -141,6 +141,56 @@ class RestrictContentFilterCPTCest
 	}
 
 	/**
+	 * Test that filtering by Tag works on the Articles screen.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFilterByTag(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Create Article, set to restrict content to a Product.
+		$I->createRestrictedContentPage(
+			$I,
+			[
+				'post_type'                => 'article',
+				'post_title'               => 'Kit: Article: Restricted Content: Tag: Filter Test',
+				'restrict_content_setting' => 'tag_' . $_ENV['CONVERTKIT_API_TAG_ID'],
+			]
+		);
+
+		// Navigate to Articles.
+		$I->amOnAdminPage('edit.php?post_type=article');
+
+		// Wait for the WP_List_Table of Articles to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Article is listed, and has the 'Kit Member Content' label.
+		$I->see('Kit: Article: Restricted Content: Tag: Filter Test');
+		$I->see('Kit Member Content');
+
+		// Filter by Tag.
+		$I->selectOption('#wp-convertkit-restrict-content-filter', $_ENV['CONVERTKIT_API_TAG_NAME']);
+		$I->click('Filter');
+
+		// Wait for the WP_List_Table of Articles to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Article is still listed, and has the 'Kit Member Content' label.
+		$I->see('Kit: Article: Restricted Content: Tag: Filter Test');
+		$I->see('Kit Member Content');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/acceptance/restrict-content/general/RestrictContentFilterPageCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentFilterPageCest.php
@@ -111,6 +111,55 @@ class RestrictContentFilterPageCest
 	}
 
 	/**
+	 * Test that filtering by Tag works on the Pages screen.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFilterByTag(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Create Page, set to restrict content to a Tag.
+		$I->createRestrictedContentPage(
+			$I,
+			[
+				'post_title'               => 'Kit: Page: Restricted Content: Tag: Filter Test',
+				'restrict_content_setting' => 'tag_' . $_ENV['CONVERTKIT_API_TAG_ID'],
+			]
+		);
+
+		// Navigate to Pages.
+		$I->amOnAdminPage('edit.php?post_type=page');
+
+		// Wait for the WP_List_Table of Pages to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Page is listed, and has the 'Kit Member Content' label.
+		$I->see('Kit: Page: Restricted Content: Tag: Filter Test');
+		$I->see('Kit Member Content');
+
+		// Filter by Tag.
+		$I->selectOption('#wp-convertkit-restrict-content-filter', $_ENV['CONVERTKIT_API_TAG_NAME']);
+		$I->click('Filter');
+
+		// Wait for the WP_List_Table of Pages to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Page is still listed, and has the 'Kit Member Content' label.
+		$I->see('Kit: Page: Restricted Content: Tag: Filter Test');
+		$I->see('Kit Member Content');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/acceptance/restrict-content/general/RestrictContentFilterPostCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentFilterPostCest.php
@@ -112,6 +112,56 @@ class RestrictContentFilterPostCest
 	}
 
 	/**
+	 * Test that filtering by Tag works on the Posts screen.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFilterByTag(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Create Post, set to restrict content to a Tag.
+		$I->createRestrictedContentPage(
+			$I,
+			[
+				'post_type'                => 'post',
+				'post_title'               => 'Kit: Post: Restricted Content: Tag: Filter Test',
+				'restrict_content_setting' => 'tag_' . $_ENV['CONVERTKIT_API_TAG_ID'],
+			]
+		);
+
+		// Navigate to Posts.
+		$I->amOnAdminPage('edit.php?post_type=post');
+
+		// Wait for the WP_List_Table of Posts to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Post is listed, and has the 'Kit Member Content' label.
+		$I->see('Kit: Post: Restricted Content: Tag: Filter Test');
+		$I->see('Kit Member Content');
+
+		// Filter by Tag.
+		$I->selectOption('#wp-convertkit-restrict-content-filter', $_ENV['CONVERTKIT_API_TAG_NAME']);
+		$I->click('Filter');
+
+		// Wait for the WP_List_Table of Posts to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Post is still listed, and has the 'Kit Member Content' label.
+		$I->see('Kit: Post: Restricted Content: Tag: Filter Test');
+		$I->see('Kit Member Content');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/acceptance/restrict-content/general/RestrictContentSettingsCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentSettingsCest.php
@@ -92,6 +92,7 @@ class RestrictContentSettingsCest
 			// Restrict by Tag.
 			'subscribe_heading_tag'   => '',
 			'subscribe_text_tag'      => '',
+			'no_access_text_tag'      => '',
 			'require_tag_login'       => '',
 			'recaptcha_site_key'      => '',
 			'recaptcha_secret_key'    => '',
@@ -149,6 +150,7 @@ class RestrictContentSettingsCest
 			// Restrict by Tag.
 			'subscribe_heading_tag'   => 'Subscribe Heading Tag',
 			'subscribe_text_tag'      => 'Subscribe Text Tag',
+			'no_access_text_tag'      => 'No Access Text Tag',
 			'require_tag_login'       => 'on',
 			'recaptcha_site_key'      => 'reCAPTCHASiteKey',
 			'recaptcha_secret_key'    => 'reCAPTCHASecretKey',

--- a/tests/acceptance/restrict-content/general/RestrictContentSettingsCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentSettingsCest.php
@@ -87,6 +87,7 @@ class RestrictContentSettingsCest
 			// Restrict by Product.
 			'subscribe_heading'       => '',
 			'subscribe_text'          => '',
+			'no_access_text'          => '',
 
 			// Restrict by Tag.
 			'subscribe_heading_tag'   => '',
@@ -104,7 +105,6 @@ class RestrictContentSettingsCest
 			'email_description_text'  => '',
 			'email_check_heading'     => '',
 			'email_check_text'        => '',
-			'no_access_text'          => '',
 		);
 
 		// Save settings.
@@ -144,6 +144,7 @@ class RestrictContentSettingsCest
 			// Restrict by Product.
 			'subscribe_heading'       => 'Subscribe Heading',
 			'subscribe_text'          => 'Subscribe Text',
+			'no_access_text'          => 'No Access Text',
 
 			// Restrict by Tag.
 			'subscribe_heading_tag'   => 'Subscribe Heading Tag',
@@ -161,7 +162,6 @@ class RestrictContentSettingsCest
 			'email_description_text'  => 'Email Description Text',
 			'email_check_heading'     => 'Email Check Heading',
 			'email_check_text'        => 'Email Check Text',
-			'no_access_text'          => 'No Access Text',
 		);
 
 		// Save settings.
@@ -184,7 +184,7 @@ class RestrictContentSettingsCest
 			$I,
 			$pageID,
 			[
-				'text_items' => $settings,
+				'settings' => $settings,
 			]
 		);
 	}

--- a/tests/acceptance/restrict-content/general/RestrictContentTagCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentTagCest.php
@@ -130,7 +130,7 @@ class RestrictContentTagCest
 				'recaptcha_site_key'      => $_ENV['CONVERTKIT_API_RECAPTCHA_SITE_KEY'],
 				'recaptcha_secret_key'    => $_ENV['CONVERTKIT_API_RECAPTCHA_SECRET_KEY'],
 				'recaptcha_minimum_score' => '0.01', // Set a low score to ensure reCAPTCHA passes the subscriber.
-			]
+			],
 		];
 
 		// Setup Restrict Content functionality with Require Login and reCAPTCHA enabled.
@@ -160,8 +160,6 @@ class RestrictContentTagCest
 		// Test Restrict Content functionality.
 		$I->testRestrictedContentByTagOnFrontendWhenRequireLoginEnabled($I, $url, $I->generateEmailAddress(), $options);
 	}
-
-	// @TODO Test as above but using modal by clicking login instead.
 
 	/**
 	 * Test that restricting content by a Tag that does not exist does not output
@@ -214,7 +212,7 @@ class RestrictContentTagCest
 				'recaptcha_site_key'      => $_ENV['CONVERTKIT_API_RECAPTCHA_SITE_KEY'],
 				'recaptcha_secret_key'    => $_ENV['CONVERTKIT_API_RECAPTCHA_SECRET_KEY'],
 				'recaptcha_minimum_score' => '0.01', // Set a low score to ensure reCAPTCHA passes the subscriber.
-			]
+			],
 		];
 
 		// Setup Restrict Content functionality with reCAPTCHA enabled.

--- a/tests/acceptance/restrict-content/general/RestrictContentTagCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentTagCest.php
@@ -60,7 +60,7 @@ class RestrictContentTagCest
 	/**
 	 * Test that restricting content by a Tag specified in the Page Settings works when:
 	 * - the Plugin is set to Require Login,
-	 * - creating a viewing a new WordPress Page,
+	 * - creating and viewing a new WordPress Page,
 	 * - entering an email address displays the code verification screen
 	 * - using a signed subscriber ID that has access to the Tag displays the content.
 	 *
@@ -110,7 +110,7 @@ class RestrictContentTagCest
 	 * Test that restricting content by a Tag specified in the Page Settings works when:
 	 * - the Plugin is set to Require Login,
 	 * - the Plugin has its Recaptcha settings defined,
-	 * - creating a viewing a new WordPress Page,
+	 * - creating and viewing a new WordPress Page,
 	 * - entering an email address displays the code verification screen
 	 * - using a signed subscriber ID that has access to the Tag displays the content.
 	 *
@@ -159,6 +159,58 @@ class RestrictContentTagCest
 
 		// Test Restrict Content functionality.
 		$I->testRestrictedContentByTagOnFrontendWhenRequireLoginEnabled($I, $url, $I->generateEmailAddress(), $options);
+	}
+
+	/**
+	 * Test that restricting content by a Tag specified in the Page Settings works when:
+	 * - the Plugin is set to Require Login,
+	 * - the Plugin has its Recaptcha settings defined,
+	 * - creating and viewing a new WordPress Page,
+	 * - entering an email address displays the code verification screen
+	 * - using a signed subscriber ID that has access to the Tag displays the content.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentByTagUsingLoginModal(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Define reCAPTCHA settings.
+		$options = [
+			'settings' => [
+				'require_tag_login' => 'on',
+			],
+		];
+
+		// Setup Restrict Content functionality with Require Login enabled.
+		$I->setupConvertKitPluginRestrictContent($I, $options['settings']);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'Kit: Page: Restrict Content: Tag: Login Modal');
+
+		// Configure metabox's Restrict Content setting = Tag name.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form'             => [ 'select2', 'None' ],
+				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
+			]
+		);
+
+		// Add blocks.
+		$I->addGutenbergParagraphBlock($I, 'Visible content.');
+		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
+
+		// Publish Page.
+		$url = $I->publishGutenbergPage($I);
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentByTagOnFrontendUsingLoginModal($I, $url, $options);
 	}
 
 	/**

--- a/tests/acceptance/restrict-content/general/RestrictContentTagCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentTagCest.php
@@ -15,9 +15,8 @@ class RestrictContentTagCest
 	 */
 	public function _before(AcceptanceTester $I)
 	{
-		// Activate and Setup ConvertKit plugin.
+		// Activate ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
 	}
 
 	/**
@@ -30,6 +29,9 @@ class RestrictContentTagCest
 	 */
 	public function testRestrictContentByTag(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin, disabling JS.
+		$I->setupConvertKitPluginDisableJS($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'Kit: Page: Restrict Content: Tag');
 
@@ -68,6 +70,9 @@ class RestrictContentTagCest
 	 */
 	public function testRestrictContentByTagWithRequireLoginEnabled(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin, disabling JS.
+		$I->setupConvertKitPluginDisableJS($I);
+
 		// Setup Restrict Content functionality with Require Login enabled.
 		$I->setupConvertKitPluginRestrictContent(
 			$I,
@@ -98,7 +103,7 @@ class RestrictContentTagCest
 		$url = $I->publishGutenbergPage($I);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentByTagOnFrontendUsingSignedSubscriberID($I, $url, $I->generateEmailAddress());
+		$I->testRestrictedContentByTagOnFrontendWhenRequireLoginEnabled($I, $url, $I->generateEmailAddress());
 	}
 
 	/**
@@ -115,16 +120,21 @@ class RestrictContentTagCest
 	 */
 	public function testRestrictContentByTagWithRecaptchaAndRequireLoginEnabled(AcceptanceTester $I)
 	{
-		// Setup Restrict Content functionality with Require Login and reCAPTCHA enabled.
-		$I->setupConvertKitPluginRestrictContent(
-			$I,
-			[
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Define reCAPTCHA settings.
+		$options = [
+			'settings' => [
 				'require_tag_login'       => 'on',
 				'recaptcha_site_key'      => $_ENV['CONVERTKIT_API_RECAPTCHA_SITE_KEY'],
 				'recaptcha_secret_key'    => $_ENV['CONVERTKIT_API_RECAPTCHA_SECRET_KEY'],
 				'recaptcha_minimum_score' => '0.01', // Set a low score to ensure reCAPTCHA passes the subscriber.
 			]
-		);
+		];
+
+		// Setup Restrict Content functionality with Require Login and reCAPTCHA enabled.
+		$I->setupConvertKitPluginRestrictContent($I, $options['settings']);
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'Kit: Page: Restrict Content: Tag: Recaptcha and Require Login');
@@ -148,8 +158,10 @@ class RestrictContentTagCest
 		$url = $I->publishGutenbergPage($I);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentByTagOnFrontendUsingSignedSubscriberID($I, $url, $I->generateEmailAddress(), false, true);
+		$I->testRestrictedContentByTagOnFrontendWhenRequireLoginEnabled($I, $url, $I->generateEmailAddress(), $options);
 	}
+
+	// @TODO Test as above but using modal by clicking login instead.
 
 	/**
 	 * Test that restricting content by a Tag that does not exist does not output
@@ -164,6 +176,9 @@ class RestrictContentTagCest
 	 */
 	public function testRestrictContentByInvalidTag(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin, disabling JS.
+		$I->setupConvertKitPluginDisableJS($I);
+
 		// Programmatically create a Page.
 		$pageID = $I->createRestrictedContentPage(
 			$I,
@@ -190,15 +205,20 @@ class RestrictContentTagCest
 	 */
 	public function testRestrictContentByTagWithRecaptchaEnabled(AcceptanceTester $I)
 	{
-		// Setup Restrict Content functionality with reCAPTCHA enabled.
-		$I->setupConvertKitPluginRestrictContent(
-			$I,
-			[
+		// Setup ConvertKit Plugin, disabling JS.
+		$I->setupConvertKitPluginDisableJS($I);
+
+		// Define options.
+		$options = [
+			'settings' => [
 				'recaptcha_site_key'      => $_ENV['CONVERTKIT_API_RECAPTCHA_SITE_KEY'],
 				'recaptcha_secret_key'    => $_ENV['CONVERTKIT_API_RECAPTCHA_SECRET_KEY'],
 				'recaptcha_minimum_score' => '0.01', // Set a low score to ensure reCAPTCHA passes the subscriber.
 			]
-		);
+		];
+
+		// Setup Restrict Content functionality with reCAPTCHA enabled.
+		$I->setupConvertKitPluginRestrictContent($I, $options);
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'Kit: Page: Restrict Content: Tag: reCAPTCHA');
@@ -222,7 +242,7 @@ class RestrictContentTagCest
 		$url = $I->publishGutenbergPage($I);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentByTagOnFrontend($I, $url, $I->generateEmailAddress(), false, true);
+		$I->testRestrictedContentByTagOnFrontend($I, $url, $I->generateEmailAddress(), $options['settings']);
 	}
 
 	/**
@@ -235,6 +255,9 @@ class RestrictContentTagCest
 	 */
 	public function testRestrictContentByTagWithRecaptchaEnabledWithHighMinimumScore(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+
 		// Setup Restrict Content functionality with reCAPTCHA enabled.
 		$I->setupConvertKitPluginRestrictContent(
 			$I,
@@ -291,6 +314,9 @@ class RestrictContentTagCest
 	 */
 	public function testRestrictContentByTagUsingQuickEdit(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin, disabling JS.
+		$I->setupConvertKitPluginDisableJS($I);
+
 		// Programmatically create a Page.
 		$pageID = $I->createRestrictedContentPage(
 			$I,
@@ -323,6 +349,9 @@ class RestrictContentTagCest
 	 */
 	public function testRestrictContentByTagUsingBulkEdit(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin, disabling JS.
+		$I->setupConvertKitPluginDisableJS($I);
+
 		// Programmatically create two Pages.
 		$pageIDs = array(
 			$I->createRestrictedContentPage(

--- a/tests/acceptance/restrict-content/post-types/RestrictContentProductCPTCest.php
+++ b/tests/acceptance/restrict-content/post-types/RestrictContentProductCPTCest.php
@@ -200,7 +200,7 @@ class RestrictContentProductCPTCest
 		$url = $I->publishGutenbergPage($I);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentModalByProductOnFrontend($I, $url);
+		$I->testRestrictedContentModal($I, $url);
 	}
 
 	/**

--- a/tests/acceptance/restrict-content/post-types/RestrictContentProductPageCest.php
+++ b/tests/acceptance/restrict-content/post-types/RestrictContentProductPageCest.php
@@ -171,7 +171,7 @@ class RestrictContentProductPageCest
 		$url = $I->publishGutenbergPage($I);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentModalByProductOnFrontend($I, $url);
+		$I->testRestrictedContentModal($I, $url);
 	}
 
 	/**

--- a/tests/acceptance/restrict-content/post-types/RestrictContentProductPostCest.php
+++ b/tests/acceptance/restrict-content/post-types/RestrictContentProductPostCest.php
@@ -150,8 +150,10 @@ class RestrictContentProductPostCest
 		$I->setupConvertKitPluginDisableJS($I);
 
 		// Define visible content and member-only content.
-		$excerpt           = 'This is a defined excerpt';
-		$memberOnlyContent = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at velit purus. Nam gravida tempor tellus, sit amet euismod arcu. Mauris sed mattis leo. Mauris viverra eget tellus sit amet vehicula. Nulla eget sapien quis felis euismod pellentesque. Quisque elementum et diam nec eleifend. Sed ornare quam eget augue consequat, in maximus quam fringilla. Morbi';
+		$options = [
+			'visible_content' => 'This is a defined excerpt',
+			'member_content'  => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at velit purus. Nam gravida tempor tellus, sit amet euismod arcu. Mauris sed mattis leo. Mauris viverra eget tellus sit amet vehicula. Nulla eget sapien quis felis euismod pellentesque. Quisque elementum et diam nec eleifend. Sed ornare quam eget augue consequat, in maximus quam fringilla. Morbi',
+		];
 
 		// Add a Post using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'post', 'Kit: Post: Restrict Content: Product: Defined Excerpt');
@@ -168,10 +170,10 @@ class RestrictContentProductPostCest
 
 		// Add member content only as a block.
 		// Visible content will be defined in the excerpt.
-		$I->addGutenbergParagraphBlock($I, $memberOnlyContent);
+		$I->addGutenbergParagraphBlock($I, $options['member_content']);
 
 		// Define excerpt.
-		$I->addGutenbergExcerpt($I, $excerpt);
+		$I->addGutenbergExcerpt($I, $options['visible_content']);
 
 		// Publish Post.
 		$url = $I->publishGutenbergPage($I);
@@ -181,28 +183,19 @@ class RestrictContentProductPostCest
 
 		// Test Restrict Content functionality.
 		// Check content is not displayed, and CTA displays with expected text.
-		$I->testRestrictContentByProductHidesContentWithCTA(
-			$I,
-			[
-				'visible_content' => $excerpt,
-				'member_content'  => $memberOnlyContent,
-			]
-		);
+		$I->testRestrictContentByProductHidesContentWithCTA($I, $options);
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// as if we entered the code sent in the email.
 		// Excerpt should not be displayed, as its an excerpt, and we now show the member content instead.
-		$I->testRestrictedContentShowsContentWithValidSubscriberID(
-			$I,
-			$url,
-			[
-				'visible_content' => '',
-				'member_content'  => $memberOnlyContent,
-			]
-		);
+		$I->setRestrictContentCookieAndReload($I, $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID'], $url);
+
+		// The excerpt shouldn't display, so update the options.
+		$options['visible_content'] = '';
+		$I->testRestrictContentDisplaysContent($I, $options);
 
 		// Assert that the excerpt is no longer displayed.
-		$I->dontSee($excerpt);
+		$I->dontSee('This is a defined excerpt');
 	}
 
 	/**
@@ -241,7 +234,7 @@ class RestrictContentProductPostCest
 		$url = $I->publishGutenbergPage($I);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentModalByProductOnFrontend($I, $url);
+		$I->testRestrictedContentModal($I, $url);
 	}
 
 	/**

--- a/views/frontend/restrict-content/code.php
+++ b/views/frontend/restrict-content/code.php
@@ -16,8 +16,8 @@
 		<?php echo esc_html( WP_ConvertKit()->get_class( 'output_restrict_content' )->restrict_content_settings->get_by_key( 'email_check_text' ) ); ?>
 	</p>
 
-	<div class="convertkit-restrict-content-actions">
-		<form id="convertkit-restrict-content-form" action="<?php echo esc_attr( add_query_arg( array( 'convertkit_login' => 1 ), get_permalink( WP_ConvertKit()->get_class( 'output_restrict_content' )->post_id ) ) ); ?>" method="post">
+	<div id="convertkit-restrict-content-form" class="convertkit-restrict-content-actions">
+		<form class="convertkit-restrict-content-form" action="<?php echo esc_attr( add_query_arg( array( 'convertkit_login' => 1 ), get_permalink( WP_ConvertKit()->get_class( 'output_restrict_content' )->post_id ) ) ); ?>" method="post">
 			<div id="convertkit-subscriber-code-container" class="<?php echo sanitize_html_class( ( is_wp_error( WP_ConvertKit()->get_class( 'output_restrict_content' )->error ) ? 'convertkit-restrict-content-error' : '' ) ); ?>">
 				<input type="text" name="subscriber_code" id="convertkit_subscriber_code" inputmode="numeric" maxlength="6" pattern="[0-9]{6}" autocomplete="one-time-code" value="" required />
 			</div>

--- a/views/frontend/restrict-content/login-email.php
+++ b/views/frontend/restrict-content/login-email.php
@@ -9,7 +9,7 @@
  */
 
 ?>
-<form id="convertkit-restrict-content-form" action="<?php echo esc_attr( add_query_arg( array( 'convertkit_login' => 1 ), get_permalink( WP_ConvertKit()->get_class( 'output_restrict_content' )->post_id ) ) ); ?>#convertkit-restrict-content" method="post">
+<form id="convertkit-restrict-content-form" class="convertkit-restrict-content-form" action="<?php echo esc_attr( add_query_arg( array( 'convertkit_login' => 1 ), get_permalink( WP_ConvertKit()->get_class( 'output_restrict_content' )->post_id ) ) ); ?>#convertkit-restrict-content" method="post">
 	<div id="convertkit-restrict-content-email-field" class="<?php echo sanitize_html_class( ( is_wp_error( WP_ConvertKit()->get_class( 'output_restrict_content' )->error ) ? 'convertkit-restrict-content-error' : '' ) ); ?>">
 		<input type="email" name="convertkit_email" id="convertkit_email" value="" placeholder="<?php esc_attr_e( 'Email Address', 'convertkit' ); ?>" required />
 		<input type="submit" class="wp-block-button__link wp-block-button__link" value="<?php echo esc_attr( WP_ConvertKit()->get_class( 'output_restrict_content' )->restrict_content_settings->get_by_key( 'email_button_label' ) ); ?>" />
@@ -21,6 +21,7 @@
 </form>
 
 <?php
+// Output notices.
 require 'notices.php';
 ?>
 

--- a/views/frontend/restrict-content/login-modal-content-code.php
+++ b/views/frontend/restrict-content/login-modal-content-code.php
@@ -16,7 +16,7 @@
 </p>
 
 <div class="convertkit-restrict-content-actions">
-	<form id="convertkit-restrict-content-form" action="<?php echo esc_attr( add_query_arg( array( 'convertkit_login' => 1 ), get_permalink( WP_ConvertKit()->get_class( 'output_restrict_content' )->post_id ) ) ); ?>" method="post">
+	<form id="convertkit-restrict-content-form" class="convertkit-restrict-content-form" action="<?php echo esc_attr( add_query_arg( array( 'convertkit_login' => 1 ), get_permalink( WP_ConvertKit()->get_class( 'output_restrict_content' )->post_id ) ) ); ?>" method="post">
 		<div id="convertkit-subscriber-code-container" class="<?php echo sanitize_html_class( ( is_wp_error( WP_ConvertKit()->get_class( 'output_restrict_content' )->error ) ? 'convertkit-restrict-content-error' : '' ) ); ?>">
 			<input type="text" name="subscriber_code" id="convertkit_subscriber_code" inputmode="numeric" maxlength="6" pattern="[0-9]{6}" autocomplete="one-time-code" value="" required />
 		</div>

--- a/views/frontend/restrict-content/login.php
+++ b/views/frontend/restrict-content/login.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Outputs the restricted content product email field
+ * for the subscriber to enter their email address if
+ * they've already subscribed to the ConvertKit resource.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+// If scripts are disabled in the Plugin's settings, output the email login form now.
+if ( $this->settings->scripts_disabled() ) {
+	?>
+	<p>
+		<?php echo esc_html( $this->restrict_content_settings->get_by_key( 'email_text' ) ); ?>
+	</p>
+	<?php
+	require 'login-email.php';
+} else {
+	// Just output the paragraph with a link to login, which will trigger the modal to display.
+	?>
+	<p>
+		<?php echo esc_html( $this->restrict_content_settings->get_by_key( 'email_text' ) ); ?>
+		<a href="#" class="convertkit-restrict-content-modal-open"><?php echo esc_attr( $this->restrict_content_settings->get_by_key( 'email_button_label' ) ); ?></a>
+	</p>
+	<?php
+}

--- a/views/frontend/restrict-content/product.php
+++ b/views/frontend/restrict-content/product.php
@@ -20,22 +20,7 @@
 		echo $button; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
-	// If scripts are disabled in the Plugin's settings, output the email login form now.
-	if ( $this->settings->scripts_disabled() ) {
-		?>
-		<p>
-			<?php echo esc_html( $this->restrict_content_settings->get_by_key( 'email_text' ) ); ?>
-		</p>
-		<?php
-		require 'login-email.php';
-	} else {
-		// Just output the paragraph with a link to login, which will trigger the modal to display.
-		?>
-		<p>
-			<?php echo esc_html( $this->restrict_content_settings->get_by_key( 'email_text' ) ); ?>
-			<a href="#" class="convertkit-restrict-content-modal-open"><?php echo esc_attr( $this->restrict_content_settings->get_by_key( 'email_button_label' ) ); ?></a>
-		</p>
-		<?php
-	}
+	// Output a login link or form, if require login enabled.
+	require 'login.php';
 	?>
 </div>

--- a/views/frontend/restrict-content/tag.php
+++ b/views/frontend/restrict-content/tag.php
@@ -17,7 +17,7 @@
 		require 'header.php';
 		?>
 
-		<form id="convertkit-restrict-content-form" action="<?php echo esc_attr( add_query_arg( array( 'convertkit_login' => 1 ), get_permalink( $post_id ) ) ); ?>#convertkit-restrict-content" method="post">
+		<form class="convertkit-restrict-content-form" action="<?php echo esc_attr( add_query_arg( array( 'convertkit_login' => 1 ), get_permalink( $post_id ) ) ); ?>#convertkit-restrict-content" method="post">
 			<div id="convertkit-restrict-content-email-field" class="<?php echo sanitize_html_class( ( is_wp_error( $this->error ) ? 'convertkit-restrict-content-error' : '' ) ); ?>">
 				<input type="email" name="convertkit_email" id="convertkit_email" value="" placeholder="<?php esc_attr_e( 'Email Address', 'convertkit' ); ?>" required />
 				<?php
@@ -43,6 +43,11 @@
 		</form>
 
 		<?php
+		// Maybe output a login link or form, if require login enabled.
+		if ( $this->restrict_content_settings->require_tag_login() && ! $this->settings->scripts_disabled() ) {
+			require 'login.php';
+		}
+
 		// Output notices.
 		require 'notices.php';
 		?>


### PR DESCRIPTION
## Summary

Refactors restrict content tests, adding a number of helper methods for repetitive test assertions.

## Testing

Existing tests pass

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)