### PR TITLE
Restrict Content by Form

### DIFF
--- a/admin/class-convertkit-admin-post.php
+++ b/admin/class-convertkit-admin-post.php
@@ -224,8 +224,9 @@ class ConvertKit_Admin_Post {
 		$restrict_content_settings = new ConvertKit_Settings_Restrict_Content();
 
 		// Fetch Post Settings, Forms, Landing Pages and Tags.
-		$convertkit_post          = new ConvertKit_Post( $post->ID );
-		$convertkit_forms         = new ConvertKit_Resource_Forms();
+		$convertkit_post  = new ConvertKit_Post( $post->ID );
+		$convertkit_forms = new ConvertKit_Resource_Forms();
+
 		$convertkit_landing_pages = new ConvertKit_Resource_Landing_Pages();
 		$convertkit_products      = new ConvertKit_Resource_Products();
 		$convertkit_tags          = new ConvertKit_Resource_Tags();

--- a/admin/class-convertkit-admin-restrict-content.php
+++ b/admin/class-convertkit-admin-restrict-content.php
@@ -18,6 +18,15 @@
 class ConvertKit_Admin_Restrict_Content {
 
 	/**
+	 * Holds the ConvertKit Forms resource class.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @var     bool|ConvertKit_Resource_Forms
+	 */
+	public $forms = false;
+
+	/**
 	 * Holds the ConvertKit Tags resource class.
 	 *
 	 * @since   2.3.2

--- a/admin/class-convertkit-admin-restrict-content.php
+++ b/admin/class-convertkit-admin-restrict-content.php
@@ -193,7 +193,8 @@ class ConvertKit_Admin_Restrict_Content {
 			return;
 		}
 
-		// Fetch Products and Tags.
+		// Initialize Forms, Products and Tags resource classes.
+		$this->forms    = new ConvertKit_Resource_Forms();
 		$this->products = new ConvertKit_Resource_Products();
 		$this->tags     = new ConvertKit_Resource_Tags();
 

--- a/admin/section/class-convertkit-admin-section-restrict-content.php
+++ b/admin/section/class-convertkit-admin-section-restrict-content.php
@@ -39,6 +39,11 @@ class ConvertKit_Admin_Section_Restrict_Content extends ConvertKit_Admin_Section
 				'callback' => array( $this, 'print_section_info' ),
 				'wrap'     => true,
 			),
+			'forms'    => array(
+				'title'    => __( 'Forms', 'convertkit' ),
+				'callback' => array( $this, 'print_section_info_forms' ),
+				'wrap'     => true,
+			),
 			'products' => array(
 				'title'    => __( 'Products', 'convertkit' ),
 				'callback' => array( $this, 'print_section_info_products' ),
@@ -101,6 +106,22 @@ class ConvertKit_Admin_Section_Restrict_Content extends ConvertKit_Admin_Section
 				'label_for'   => 'permit_crawlers',
 				'label'       => __( 'When enabled, search engine crawlers (such as Google and Bing) are able to access Member Content for indexing.', 'convertkit' ),
 				'description' => '',
+			)
+		);
+
+		// Restrict by Form.
+		add_settings_field(
+			'no_access_text_form',
+			__( 'No Access Text', 'convertkit' ),
+			array( $this, 'text_callback' ),
+			$this->settings_key,
+			$this->name . '-forms',
+			array(
+				'name'        => 'no_access_text_form',
+				'label_for'   => 'no_access_text_form',
+				'description' => array(
+					__( 'The text to display for a subscriber who authenticates via the login link, but is not subscribed.', 'convertkit' ),
+				),
 			)
 		);
 
@@ -375,6 +396,19 @@ class ConvertKit_Admin_Section_Restrict_Content extends ConvertKit_Admin_Section
 
 		?>
 		<p class="description"><?php esc_html_e( 'Defines the text and button labels to display when a Page, Post or Custom Post has its Member Content setting defined.', 'convertkit' ); ?></p>
+		<?php
+
+	}
+
+	/**
+	 * Prints help info for the forms section of the settings screen.
+	 *
+	 * @since   2.7.3
+	 */
+	public function print_section_info_forms() {
+
+		?>
+		<p class="description"><?php esc_html_e( 'Defines settings when a Page, Post or Custom Post type has its member content setting set to a Kit form.', 'convertkit' ); ?></p>
 		<?php
 
 	}

--- a/includes/class-convertkit-output-restrict-content.php
+++ b/includes/class-convertkit-output-restrict-content.php
@@ -206,6 +206,45 @@ class ConvertKit_Output_Restrict_Content {
 				$this->token = $result;
 				break;
 
+			case 'form':
+				// Create subscriber.
+				$subscriber = $this->api->create_subscriber( $email );
+
+				// Bail if an error occured.
+				if ( is_wp_error( $subscriber ) ) {
+					$this->error = $subscriber;
+					return;
+				}
+
+				// Add subscriber to form.
+				$result = $this->api->add_subscriber_to_form( $form_id, $subscriber['subscriber']['id'] );
+
+				// Bail if an error occured.
+				if ( is_wp_error( $result ) ) {
+					$this->error = $result;
+					return;
+				}
+
+				// Send email to subscriber with a link to authenticate they have access to the email address submitted.
+				$result = $this->api->subscriber_authentication_send_code(
+					$email,
+					$this->get_url()
+				);
+
+				// Bail if an error occured.
+				if ( is_wp_error( $result ) ) {
+					$this->error = $result;
+					return;
+				}
+
+				// Clear any existing subscriber ID cookie, as the authentication flow has started by sending the email.
+				$subscriber = new ConvertKit_Subscriber();
+				$subscriber->forget();
+
+				// Store the token so it's included in the subscriber code form.
+				$this->token = $result;
+				break;
+
 			case 'tag':
 				// If require login is enabled, show the login screen.
 				if ( $this->restrict_content_settings->require_tag_login() ) {
@@ -819,6 +858,19 @@ class ConvertKit_Output_Restrict_Content {
 				// Product exists in ConvertKit.
 				return true;
 
+			case 'form':
+				// Get Form.
+				$forms = new ConvertKit_Resource_Forms( 'restrict_content' );
+				$form  = $forms->get_by_id( $this->resource_id );
+
+				// If the Form does not exist, return false.
+				if ( ! $form ) {
+					return false;
+				}
+
+				// Form exists in ConvertKit.
+				return true;
+
 			case 'tag':
 				// Get Tag.
 				$tags = new ConvertKit_Resource_Tags( 'restrict_content' );
@@ -867,6 +919,10 @@ class ConvertKit_Output_Restrict_Content {
 			case 'product':
 				// For products, the subscriber ID has to be a signed subscriber ID string.
 				return $this->subscriber_has_access_to_product_by_signed_subscriber_id( $subscriber_id, absint( $this->resource_id ) );
+
+			case 'form':
+				// For forms, the subscriber ID has to be a signed subscriber ID string.
+				return $this->subscriber_has_access_to_form_by_signed_subscriber_id( $subscriber_id, absint( $this->resource_id ) );
 
 			case 'tag':
 				// If the subscriber ID is numeric, check using get_subscriber_tags().
@@ -918,6 +974,36 @@ class ConvertKit_Output_Restrict_Content {
 
 		// Return if the subscriber is subscribed to the product or not.
 		return in_array( $product_id, $result['products'], true );
+
+	}
+
+	/**
+	 * Determines if the given signed subscriber ID has an active subscription to
+	 * the given form.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   string $signed_subscriber_id   Signed Subscriber ID.
+	 * @param   int    $form_id        		   Form ID.
+	 * @return  bool                		   Has access to form
+	 */
+	private function subscriber_has_access_to_form_by_signed_subscriber_id( $signed_subscriber_id, $form_id ) {
+
+		// Get products that the subscriber has access to.
+		$result = $this->api->profile( $signed_subscriber_id );
+
+		// If an error occured, the subscriber ID is invalid.
+		if ( is_wp_error( $result ) ) {
+			return false;
+		}
+
+		// If no forms exist, there's no access.
+		if ( ! $result['forms'] || ! count( $result['forms'] ) ) {
+			return false;
+		}
+
+		// Return if the subscriber is subscribed to the form or not.
+		return in_array( $tag_id, $result['forms'], true );
 
 	}
 
@@ -1215,6 +1301,29 @@ class ConvertKit_Output_Restrict_Content {
 				ob_start();
 				$button = $products->get_html( $this->resource_id, $this->restrict_content_settings->get_by_key( 'subscribe_button_label' ) );
 				include CONVERTKIT_PLUGIN_PATH . '/views/frontend/restrict-content/product.php';
+				return trim( ob_get_clean() );
+
+			case 'form':
+				// Display the Form.
+				$forms = new ConvertKit_Resource_Forms( 'restrict_content' );
+				$form = $forms->get_html( $this->resource_id );
+
+				// If scripts are enabled, output the email login form in a modal, which will be displayed
+				// when the 'log in' link is clicked.
+				if ( ! $this->settings->scripts_disabled() ) {
+					add_action(
+						'wp_footer',
+						function () {
+
+							include_once CONVERTKIT_PLUGIN_PATH . '/views/frontend/restrict-content/login-modal.php';
+
+						}
+					);
+				}
+
+				// Output.
+				ob_start();
+				include CONVERTKIT_PLUGIN_PATH . '/views/frontend/restrict-content/form.php';
 				return trim( ob_get_clean() );
 
 			case 'tag':

--- a/includes/class-convertkit-output-restrict-content.php
+++ b/includes/class-convertkit-output-restrict-content.php
@@ -1003,7 +1003,7 @@ class ConvertKit_Output_Restrict_Content {
 		}
 
 		// Return if the subscriber is subscribed to the form or not.
-		return in_array( $tag_id, $result['forms'], true );
+		return in_array( $form_id, $result['forms'], true );
 
 	}
 

--- a/includes/class-convertkit-output-restrict-content.php
+++ b/includes/class-convertkit-output-restrict-content.php
@@ -467,6 +467,10 @@ class ConvertKit_Output_Restrict_Content {
 			// Show an error before the call to action, to tell the subscriber why they still cannot
 			// view the content.
 			switch ( $this->resource_type ) {
+				case 'form':
+					$message = $this->restrict_content_settings->get_by_key( 'no_access_text_form' );
+					break;
+
 				case 'tag':
 					$message = $this->restrict_content_settings->get_by_key( 'no_access_text_tag' );
 					break;

--- a/includes/class-convertkit-output-restrict-content.php
+++ b/includes/class-convertkit-output-restrict-content.php
@@ -186,45 +186,7 @@ class ConvertKit_Output_Restrict_Content {
 		// Run subscriber authentication / subscription depending on the resource type.
 		switch ( $this->resource_type ) {
 			case 'product':
-				// Send email to subscriber with a link to authenticate they have access to the email address submitted.
-				$result = $this->api->subscriber_authentication_send_code(
-					$email,
-					$this->get_url()
-				);
-
-				// Bail if an error occured.
-				if ( is_wp_error( $result ) ) {
-					$this->error = $result;
-					return;
-				}
-
-				// Clear any existing subscriber ID cookie, as the authentication flow has started by sending the email.
-				$subscriber = new ConvertKit_Subscriber();
-				$subscriber->forget();
-
-				// Store the token so it's included in the subscriber code form.
-				$this->token = $result;
-				break;
-
 			case 'form':
-				// Create subscriber.
-				$subscriber = $this->api->create_subscriber( $email );
-
-				// Bail if an error occured.
-				if ( is_wp_error( $subscriber ) ) {
-					$this->error = $subscriber;
-					return;
-				}
-
-				// Add subscriber to form.
-				$result = $this->api->add_subscriber_to_form( $form_id, $subscriber['subscriber']['id'] );
-
-				// Bail if an error occured.
-				if ( is_wp_error( $result ) ) {
-					$this->error = $result;
-					return;
-				}
-
 				// Send email to subscriber with a link to authenticate they have access to the email address submitted.
 				$result = $this->api->subscriber_authentication_send_code(
 					$email,
@@ -998,8 +960,8 @@ class ConvertKit_Output_Restrict_Content {
 	 * @since   2.7.3
 	 *
 	 * @param   string $signed_subscriber_id   Signed Subscriber ID.
-	 * @param   int    $form_id        		   Form ID.
-	 * @return  bool                		   Has access to form
+	 * @param   int    $form_id                Form ID.
+	 * @return  bool                           Has access to form
 	 */
 	private function subscriber_has_access_to_form_by_signed_subscriber_id( $signed_subscriber_id, $form_id ) {
 
@@ -1320,7 +1282,7 @@ class ConvertKit_Output_Restrict_Content {
 			case 'form':
 				// Display the Form.
 				$forms = new ConvertKit_Resource_Forms( 'restrict_content' );
-				$form = $forms->get_html( $this->resource_id );
+				$form  = $forms->get_html( $this->resource_id );
 
 				// If scripts are enabled, output the email login form in a modal, which will be displayed
 				// when the 'log in' link is clicked.

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -56,6 +56,44 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource_V4 {
 	}
 
 	/**
+	 * Returns all inline forms based on the sort order.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @return  bool|array
+	 */
+	public function get_inline() {
+
+		// If the ConvertKit WordPress Libraries are < 1.3.6 (e.g. loaded by an outdated
+		// addon), or a WordPress site updates this Plugin before other ConvertKit Plugins,
+		// get_by() won't be available and will cause an E_ERROR, crashing the site.
+		// @see https://wordpress.org/support/topic/error-1795/.
+		if ( ! method_exists( $this, 'get_by' ) ) { // @phpstan-ignore-line Older WordPress Libraries won't have this function.
+			return false;
+		}
+
+		return $this->get_by( 'format', array( 'inline' ) );
+
+	}
+
+	/**
+	 * Returns whether any inline forms exist in the options table.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @return  bool
+	 */
+	public function inline_exist() {
+
+		if ( ! $this->get_inline() ) {
+			return false;
+		}
+
+		return true;
+
+	}
+
+	/**
 	 * Returns all non-inline forms based on the sort order.
 	 *
 	 * @since   2.2.4
@@ -75,7 +113,6 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource_V4 {
 		return $this->get_by( 'format', array( 'modal', 'slide in', 'sticky bar' ) );
 
 	}
-
 
 	/**
 	 * Returns whether any non-inline forms exist in the options table.

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -85,11 +85,7 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource_V4 {
 	 */
 	public function inline_exist() {
 
-		if ( ! $this->get_inline() ) {
-			return false;
-		}
-
-		return true;
+		return (bool) $this->get_inline();
 
 	}
 

--- a/includes/class-convertkit-settings-restrict-content.php
+++ b/includes/class-convertkit-settings-restrict-content.php
@@ -208,6 +208,9 @@ class ConvertKit_Settings_Restrict_Content {
 			// Permit Crawlers.
 			'permit_crawlers'         => '',
 
+			// Restrict by Form.
+			'no_access_text_form'     => __( 'Your account does not have access to this content. Please use the form above to subscribe.', 'convertkit' ),
+
 			// Restrict by Product.
 			'subscribe_heading'       => __( 'Read this post with a premium subscription', 'convertkit' ),
 			'subscribe_text'          => __( 'This post is only available to premium subscribers. Join today to get access to all posts.', 'convertkit' ),

--- a/resources/frontend/css/restrict-content.css
+++ b/resources/frontend/css/restrict-content.css
@@ -34,7 +34,7 @@
 	color: #111;
 }
 
-/* Container */
+/* Overlay */
 #convertkit-restrict-content {
 	width: 100%;
 	background: #F9F7F4;
@@ -44,12 +44,6 @@
 	text-align: center;
 	box-sizing: border-box;
 	border-radius: 8px;
-}
-
-/* Container, no styling */
-#convertkit-restrict-content-no-styles {
-	width: 100%;
-	text-align: center;
 }
 
 /* Actions */

--- a/resources/frontend/css/restrict-content.css
+++ b/resources/frontend/css/restrict-content.css
@@ -34,7 +34,7 @@
 	color: #111;
 }
 
-/* Overlay */
+/* Container */
 #convertkit-restrict-content {
 	width: 100%;
 	background: #F9F7F4;
@@ -44,6 +44,12 @@
 	text-align: center;
 	box-sizing: border-box;
 	border-radius: 8px;
+}
+
+/* Container, no styling */
+#convertkit-restrict-content-no-styles {
+	width: 100%;
+	text-align: center;
 }
 
 /* Actions */

--- a/tests/_support/Helper/Acceptance/ConvertKitRestrictContent.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitRestrictContent.php
@@ -169,7 +169,7 @@ class ConvertKitRestrictContent extends \Codeception\Module
 				// Don't display a Form on this Page, so we test against Restrict Content's Form.
 				'meta_input'   => [
 					'_wp_convertkit_post_meta' => [
-						'form'             => '-1',
+						'form'             => '0',
 						'landing_page'     => '',
 						'tag'              => '',
 						'restrict_content' => $options['restrict_content_setting'],
@@ -491,6 +491,7 @@ class ConvertKitRestrictContent extends \Codeception\Module
 	 *
 	 * @param   AcceptanceTester $I                  Tester.
 	 * @param   string|int       $urlOrPageID        URL or ID of Restricted Content Page.
+	 * @param   int              $formID             Form ID that should be displayed.
 	 * @param   bool|array       $options {
 	 *           Optional. An array of settings.
 	 *
@@ -499,7 +500,7 @@ class ConvertKitRestrictContent extends \Codeception\Module
 	 *     @type array  $settings                   Restrict content settings. If not defined, uses expected defaults.
 	 * }
 	 */
-	public function testRestrictedContentByFormOnFrontendUsingLoginModal($I, $urlOrPageID, $options = false)
+	public function testRestrictedContentByFormOnFrontendUsingLoginModal($I, $urlOrPageID, $formID, $options = false)
 	{
 		// Setup test.
 		$options = $this->setupRestrictContentTest($I, $options, $urlOrPageID);
@@ -535,6 +536,9 @@ class ConvertKitRestrictContent extends \Codeception\Module
 		// as if we entered the code sent in the email.
 		$this->setRestrictContentCookieAndReload($I, $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID'], $urlOrPageID);
 		$this->testRestrictContentDisplaysContent($I, $options);
+
+		// Confirm that no Kit Form is displayed.
+		$I->dontSeeElementInDOM('form[data-sv-form]');
 	}
 
 	/**

--- a/tests/_support/Helper/Acceptance/ConvertKitRestrictContent.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitRestrictContent.php
@@ -455,7 +455,7 @@ class ConvertKitRestrictContent extends \Codeception\Module
 		// Check content is not displayed, and form displays.
 		$this->testRestrictContentByFormHidesContentWithCTA($I, $formID, $options);
 
-		// Login as a ConvertKit subscriber who has subscribed to the product.
+		// Login as a ConvertKit subscriber who has subscribed to the form.
 		$this->loginToRestrictContentWithEmail($I, $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']);
 
 		// Confirm that confirmation an email has been sent is displayed.
@@ -520,7 +520,7 @@ class ConvertKitRestrictContent extends \Codeception\Module
 		// Confirm an inline error message is displayed.
 		$this->seeRestrictContentError($I, 'invalid: Email address is invalid');
 
-		// Login as a ConvertKit subscriber who has subscribed to the product.
+		// Login as a ConvertKit subscriber who has subscribed to the form.
 		$this->loginToRestrictContentWithEmail($I, $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL'], true);
 
 		// Confirm that the subscriber code form dispays.

--- a/tests/acceptance/restrict-content/general/RestrictContentFilterCPTCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentFilterCPTCest.php
@@ -141,56 +141,6 @@ class RestrictContentFilterCPTCest
 	}
 
 	/**
-	 * Test that filtering by Tag works on the Articles screen.
-	 *
-	 * @since   2.7.3
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
-	public function testFilterByTag(AcceptanceTester $I)
-	{
-		// Setup Plugin.
-		$I->setupConvertKitPlugin($I);
-
-		// Create Article, set to restrict content to a Product.
-		$I->createRestrictedContentPage(
-			$I,
-			[
-				'post_type'                => 'article',
-				'post_title'               => 'Kit: Article: Restricted Content: Tag: Filter Test',
-				'restrict_content_setting' => 'tag_' . $_ENV['CONVERTKIT_API_TAG_ID'],
-			]
-		);
-
-		// Navigate to Articles.
-		$I->amOnAdminPage('edit.php?post_type=article');
-
-		// Wait for the WP_List_Table of Articles to load.
-		$I->waitForElementVisible('tbody#the-list');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm that the Article is listed, and has the 'Kit Member Content' label.
-		$I->see('Kit: Article: Restricted Content: Tag: Filter Test');
-		$I->see('Kit Member Content');
-
-		// Filter by Tag.
-		$I->selectOption('#wp-convertkit-restrict-content-filter', $_ENV['CONVERTKIT_API_TAG_NAME']);
-		$I->click('Filter');
-
-		// Wait for the WP_List_Table of Articles to load.
-		$I->waitForElementVisible('tbody#the-list');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm that the Article is still listed, and has the 'Kit Member Content' label.
-		$I->see('Kit: Article: Restricted Content: Product: Tag Test');
-		$I->see('Kit Member Content');
-	}
-
-	/**
 	 * Test that filtering by Form works on the Articles screen.
 	 *
 	 * @since   2.7.3

--- a/tests/acceptance/restrict-content/general/RestrictContentFilterCPTCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentFilterCPTCest.php
@@ -190,7 +190,7 @@ class RestrictContentFilterCPTCest
 		$I->see('Kit Member Content');
 	}
 
-/**
+	/**
 	 * Test that filtering by Form works on the Articles screen.
 	 *
 	 * @since   2.7.3

--- a/tests/acceptance/restrict-content/general/RestrictContentFilterCPTCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentFilterCPTCest.php
@@ -141,6 +141,106 @@ class RestrictContentFilterCPTCest
 	}
 
 	/**
+	 * Test that filtering by Tag works on the Articles screen.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFilterByTag(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Create Article, set to restrict content to a Product.
+		$I->createRestrictedContentPage(
+			$I,
+			[
+				'post_type'                => 'article',
+				'post_title'               => 'Kit: Article: Restricted Content: Tag: Filter Test',
+				'restrict_content_setting' => 'tag_' . $_ENV['CONVERTKIT_API_TAG_ID'],
+			]
+		);
+
+		// Navigate to Articles.
+		$I->amOnAdminPage('edit.php?post_type=article');
+
+		// Wait for the WP_List_Table of Articles to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Article is listed, and has the 'Kit Member Content' label.
+		$I->see('Kit: Article: Restricted Content: Tag: Filter Test');
+		$I->see('Kit Member Content');
+
+		// Filter by Tag.
+		$I->selectOption('#wp-convertkit-restrict-content-filter', $_ENV['CONVERTKIT_API_TAG_NAME']);
+		$I->click('Filter');
+
+		// Wait for the WP_List_Table of Articles to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Article is still listed, and has the 'Kit Member Content' label.
+		$I->see('Kit: Article: Restricted Content: Product: Tag Test');
+		$I->see('Kit Member Content');
+	}
+
+	/**
+	 * Test that filtering by Form works on the Articles screen.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFilterByForm(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Create Article, set to restrict content to a Product.
+		$I->createRestrictedContentPage(
+			$I,
+			[
+				'post_type'                => 'article',
+				'post_title'               => 'Kit: Article: Restricted Content: Form: Filter Test',
+				'restrict_content_setting' => 'form_' . $_ENV['CONVERTKIT_API_FORM_ID'],
+			]
+		);
+
+		// Navigate to Articles.
+		$I->amOnAdminPage('edit.php?post_type=article');
+
+		// Wait for the WP_List_Table of Articles to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Article is listed, and has the 'Kit Member Content' label.
+		$I->see('Kit: Article: Restricted Content: Form: Filter Test');
+		$I->see('Kit Member Content');
+
+		// Filter by Form.
+		$I->selectOption('#wp-convertkit-restrict-content-filter', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->click('Filter');
+
+		// Wait for the WP_List_Table of Articles to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Article is still listed, and has the 'Kit Member Content' label.
+		$I->see('Kit: Article: Restricted Content: Product: Form Test');
+		$I->see('Kit Member Content');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/acceptance/restrict-content/general/RestrictContentFilterCPTCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentFilterCPTCest.php
@@ -186,7 +186,7 @@ class RestrictContentFilterCPTCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the Article is still listed, and has the 'Kit Member Content' label.
-		$I->see('Kit: Article: Restricted Content: Product: Form Test');
+		$I->see('Kit: Article: Restricted Content: Form: Filter Test');
 		$I->see('Kit Member Content');
 	}
 

--- a/tests/acceptance/restrict-content/general/RestrictContentFilterPageCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentFilterPageCest.php
@@ -111,6 +111,104 @@ class RestrictContentFilterPageCest
 	}
 
 	/**
+	 * Test that filtering by Tag works on the Pages screen.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFilterByTag(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Create Page, set to restrict content to a Tag.
+		$I->createRestrictedContentPage(
+			$I,
+			[
+				'post_title'               => 'Kit: Page: Restricted Content: Tag: Filter Test',
+				'restrict_content_setting' => 'tag_' . $_ENV['CONVERTKIT_API_TAG_ID'],
+			]
+		);
+
+		// Navigate to Pages.
+		$I->amOnAdminPage('edit.php?post_type=page');
+
+		// Wait for the WP_List_Table of Pages to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Page is listed, and has the 'Kit Member Content' label.
+		$I->see('Kit: Page: Restricted Content: Tag: Filter Test');
+		$I->see('Kit Member Content');
+
+		// Filter by Tag.
+		$I->selectOption('#wp-convertkit-restrict-content-filter', $_ENV['CONVERTKIT_API_TAG_NAME']);
+		$I->click('Filter');
+
+		// Wait for the WP_List_Table of Pages to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Page is still listed, and has the 'Kit Member Content' label.
+		$I->see('Kit: Page: Restricted Content: Tag: Filter Test');
+		$I->see('Kit Member Content');
+	}
+
+	/**
+	 * Test that filtering by Form works on the Pages screen.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFilterByForm(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Create Page, set to restrict content to a Form.
+		$I->createRestrictedContentPage(
+			$I,
+			[
+				'post_title'               => 'Kit: Page: Restricted Content: Form: Filter Test',
+				'restrict_content_setting' => 'tag_' . $_ENV['CONVERTKIT_API_FORM_ID'],
+			]
+		);
+
+		// Navigate to Pages.
+		$I->amOnAdminPage('edit.php?post_type=page');
+
+		// Wait for the WP_List_Table of Pages to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Page is listed, and has the 'Kit Member Content' label.
+		$I->see('Kit: Page: Restricted Content: Form: Filter Test');
+		$I->see('Kit Member Content');
+
+		// Filter by Form.
+		$I->selectOption('#wp-convertkit-restrict-content-filter', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->click('Filter');
+
+		// Wait for the WP_List_Table of Pages to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Page is still listed, and has the 'Kit Member Content' label.
+		$I->see('Kit: Page: Restricted Content: Form: Filter Test');
+		$I->see('Kit Member Content');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/acceptance/restrict-content/general/RestrictContentFilterPageCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentFilterPageCest.php
@@ -111,55 +111,6 @@ class RestrictContentFilterPageCest
 	}
 
 	/**
-	 * Test that filtering by Tag works on the Pages screen.
-	 *
-	 * @since   2.7.3
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
-	public function testFilterByTag(AcceptanceTester $I)
-	{
-		// Setup Plugin.
-		$I->setupConvertKitPlugin($I);
-
-		// Create Page, set to restrict content to a Tag.
-		$I->createRestrictedContentPage(
-			$I,
-			[
-				'post_title'               => 'Kit: Page: Restricted Content: Tag: Filter Test',
-				'restrict_content_setting' => 'tag_' . $_ENV['CONVERTKIT_API_TAG_ID'],
-			]
-		);
-
-		// Navigate to Pages.
-		$I->amOnAdminPage('edit.php?post_type=page');
-
-		// Wait for the WP_List_Table of Pages to load.
-		$I->waitForElementVisible('tbody#the-list');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm that the Page is listed, and has the 'Kit Member Content' label.
-		$I->see('Kit: Page: Restricted Content: Tag: Filter Test');
-		$I->see('Kit Member Content');
-
-		// Filter by Tag.
-		$I->selectOption('#wp-convertkit-restrict-content-filter', $_ENV['CONVERTKIT_API_TAG_NAME']);
-		$I->click('Filter');
-
-		// Wait for the WP_List_Table of Pages to load.
-		$I->waitForElementVisible('tbody#the-list');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm that the Page is still listed, and has the 'Kit Member Content' label.
-		$I->see('Kit: Page: Restricted Content: Tag: Filter Test');
-		$I->see('Kit Member Content');
-	}
-
-	/**
 	 * Test that filtering by Form works on the Pages screen.
 	 *
 	 * @since   2.7.3

--- a/tests/acceptance/restrict-content/general/RestrictContentFilterPageCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentFilterPageCest.php
@@ -127,7 +127,7 @@ class RestrictContentFilterPageCest
 			$I,
 			[
 				'post_title'               => 'Kit: Page: Restricted Content: Form: Filter Test',
-				'restrict_content_setting' => 'tag_' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'restrict_content_setting' => 'form_' . $_ENV['CONVERTKIT_API_FORM_ID'],
 			]
 		);
 

--- a/tests/acceptance/restrict-content/general/RestrictContentFilterPostCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentFilterPostCest.php
@@ -112,6 +112,106 @@ class RestrictContentFilterPostCest
 	}
 
 	/**
+	 * Test that filtering by Tag works on the Posts screen.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFilterByTag(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Create Post, set to restrict content to a Tag.
+		$I->createRestrictedContentPage(
+			$I,
+			[
+				'post_type'                => 'post',
+				'post_title'               => 'Kit: Post: Restricted Content: Tag: Filter Test',
+				'restrict_content_setting' => 'tag_' . $_ENV['CONVERTKIT_API_TAG_ID'],
+			]
+		);
+
+		// Navigate to Posts.
+		$I->amOnAdminPage('edit.php?post_type=post');
+
+		// Wait for the WP_List_Table of Posts to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Post is listed, and has the 'Kit Member Content' label.
+		$I->see('Kit: Post: Restricted Content: Tag: Filter Test');
+		$I->see('Kit Member Content');
+
+		// Filter by Tag.
+		$I->selectOption('#wp-convertkit-restrict-content-filter', $_ENV['CONVERTKIT_API_TAG_NAME']);
+		$I->click('Filter');
+
+		// Wait for the WP_List_Table of Posts to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Post is still listed, and has the 'Kit Member Content' label.
+		$I->see('Kit: Post: Restricted Content: Tag: Filter Test');
+		$I->see('Kit Member Content');
+	}
+
+	/**
+	 * Test that filtering by Form works on the Posts screen.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFilterByForm(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Create Post, set to restrict content to a Form.
+		$I->createRestrictedContentPage(
+			$I,
+			[
+				'post_type'                => 'post',
+				'post_title'               => 'Kit: Post: Restricted Content: Form: Filter Test',
+				'restrict_content_setting' => 'form_' . $_ENV['CONVERTKIT_API_FORM_ID'],
+			]
+		);
+
+		// Navigate to Posts.
+		$I->amOnAdminPage('edit.php?post_type=post');
+
+		// Wait for the WP_List_Table of Posts to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Post is listed, and has the 'Kit Member Content' label.
+		$I->see('Kit: Post: Restricted Content: Form: Filter Test');
+		$I->see('Kit Member Content');
+
+		// Filter by Form.
+		$I->selectOption('#wp-convertkit-restrict-content-filter', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->click('Filter');
+
+		// Wait for the WP_List_Table of Posts to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Post is still listed, and has the 'Kit Member Content' label.
+		$I->see('Kit: Post: Restricted Content: Form: Filter Test');
+		$I->see('Kit Member Content');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/acceptance/restrict-content/general/RestrictContentFilterPostCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentFilterPostCest.php
@@ -112,56 +112,6 @@ class RestrictContentFilterPostCest
 	}
 
 	/**
-	 * Test that filtering by Tag works on the Posts screen.
-	 *
-	 * @since   2.7.3
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
-	public function testFilterByTag(AcceptanceTester $I)
-	{
-		// Setup Plugin.
-		$I->setupConvertKitPlugin($I);
-
-		// Create Post, set to restrict content to a Tag.
-		$I->createRestrictedContentPage(
-			$I,
-			[
-				'post_type'                => 'post',
-				'post_title'               => 'Kit: Post: Restricted Content: Tag: Filter Test',
-				'restrict_content_setting' => 'tag_' . $_ENV['CONVERTKIT_API_TAG_ID'],
-			]
-		);
-
-		// Navigate to Posts.
-		$I->amOnAdminPage('edit.php?post_type=post');
-
-		// Wait for the WP_List_Table of Posts to load.
-		$I->waitForElementVisible('tbody#the-list');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm that the Post is listed, and has the 'Kit Member Content' label.
-		$I->see('Kit: Post: Restricted Content: Tag: Filter Test');
-		$I->see('Kit Member Content');
-
-		// Filter by Tag.
-		$I->selectOption('#wp-convertkit-restrict-content-filter', $_ENV['CONVERTKIT_API_TAG_NAME']);
-		$I->click('Filter');
-
-		// Wait for the WP_List_Table of Posts to load.
-		$I->waitForElementVisible('tbody#the-list');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm that the Post is still listed, and has the 'Kit Member Content' label.
-		$I->see('Kit: Post: Restricted Content: Tag: Filter Test');
-		$I->see('Kit Member Content');
-	}
-
-	/**
 	 * Test that filtering by Form works on the Posts screen.
 	 *
 	 * @since   2.7.3

--- a/tests/acceptance/restrict-content/general/RestrictContentFormCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentFormCest.php
@@ -54,7 +54,7 @@ class RestrictContentFormCest
 		$url = $I->publishGutenbergPage($I);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentByTagOnFrontend($I, $url, $I->generateEmailAddress());
+		$I->testRestrictedContentByFormOnFrontend($I, $url, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -92,7 +92,7 @@ class RestrictContentFormCest
 		$url = $I->publishGutenbergPage($I);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentByTagOnFrontendUsingLoginModal($I, $url, $I->generateEmailAddress());
+		$I->testRestrictedContentByFormOnFrontendUsingLoginModal($I, $url, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -159,7 +159,7 @@ class RestrictContentFormCest
 		);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentByFormOnFrontend($I, $pageID, $I->generateEmailAddress());
+		$I->testRestrictedContentByFormOnFrontend($I, $pageID, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -204,7 +204,7 @@ class RestrictContentFormCest
 		// Iterate through Pages to run frontend tests.
 		foreach ($pageIDs as $pageID) {
 			// Test Restrict Content functionality.
-			$I->testRestrictedContentByFormOnFrontend($I, $pageID, $I->generateEmailAddress());
+			$I->testRestrictedContentByFormOnFrontend($I, $pageID, $_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 

--- a/tests/acceptance/restrict-content/general/RestrictContentFormCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentFormCest.php
@@ -1,0 +1,226 @@
+<?php
+/**
+ * Tests Restrict Content by Form functionality.
+ *
+ * @since   2.7.3
+ */
+class RestrictContentFormCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		// Activate ConvertKit plugin.
+		$I->activateConvertKitPlugin($I);
+	}
+
+	/**
+	 * Test that restricting content by a Form specified in the Page Settings works when
+	 * creating and viewing a new WordPress Page.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentByForm(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin, disabling JS.
+		$I->setupConvertKitPluginDisableJS($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'Kit: Page: Restrict Content: Form');
+
+		// Configure metabox's Restrict Content setting = Form name.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form'             => [ 'select2', 'None' ],
+				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+			]
+		);
+
+		// Add blocks.
+		$I->addGutenbergParagraphBlock($I, 'Visible content.');
+		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
+
+		// Publish Page.
+		$url = $I->publishGutenbergPage($I);
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentByTagOnFrontend($I, $url, $I->generateEmailAddress());
+	}
+
+	/**
+	 * Test that restricting content by a Form specified in the Page Settings works when
+	 * creating and viewing a new WordPress Page, using the login modal.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentByFormWithLoginModal(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'Kit: Page: Restrict Content: Form');
+
+		// Configure metabox's Restrict Content setting = Form name.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form'             => [ 'select2', 'None' ],
+				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+			]
+		);
+
+		// Add blocks.
+		$I->addGutenbergParagraphBlock($I, 'Visible content.');
+		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
+
+		// Publish Page.
+		$url = $I->publishGutenbergPage($I);
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentByTagOnFrontendUsingLoginModal($I, $url, $I->generateEmailAddress());
+	}
+
+	/**
+	 * Test that restricting content by a Form that does not exist does not output
+	 * a fatal error and instead displays all of the Page's content.
+	 *
+	 * This checks for when a Form is deleted in ConvertKit, but is still specified
+	 * as the Restrict Content setting for a Page.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentByInvalidForm(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin, disabling JS.
+		$I->setupConvertKitPluginDisableJS($I);
+
+		// Programmatically create a Page.
+		$pageID = $I->createRestrictedContentPage(
+			$I,
+			[
+				'post_title'               => 'Kit: Page: Restrict Content: Invalid Form',
+				'restrict_content_setting' => 'form_12345', // A fake Form that does not exist in Kit.
+			]
+		);
+
+		// Navigate to the page.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Confirm all content displays, with no errors, as the Form is invalid.
+		$I->testRestrictContentDisplaysContent($I);
+	}
+
+	/**
+	 * Test that restricting content by a Form specified in the Page Settings works when
+	 * using the Quick Edit functionality.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentByFormUsingQuickEdit(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin, disabling JS.
+		$I->setupConvertKitPluginDisableJS($I);
+
+		// Programmatically create a Page.
+		$pageID = $I->createRestrictedContentPage(
+			$I,
+			[
+				'post_title' => 'Kit: Page: Restrict Content: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
+			]
+		);
+
+		// Quick Edit the Page in the Pages WP_List_Table.
+		$I->quickEdit(
+			$I,
+			'page',
+			$pageID,
+			[
+				'restrict_content' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+			]
+		);
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentByFormOnFrontend($I, $pageID, $I->generateEmailAddress());
+	}
+
+	/**
+	 * Test that restricting content by a Form specified in the Page Settings works when
+	 * using the Bulk Edit functionality.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentByFormUsingBulkEdit(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin, disabling JS.
+		$I->setupConvertKitPluginDisableJS($I);
+
+		// Programmatically create two Pages.
+		$pageIDs = array(
+			$I->createRestrictedContentPage(
+				$I,
+				[
+					'post_title' => 'Kit: Page: Restrict Content: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
+				]
+			),
+			$I->createRestrictedContentPage(
+				$I,
+				[
+					'post_title' => 'Kit: Page: Restrict Content: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
+				]
+			),
+		);
+
+		// Bulk Edit the Pages in the Pages WP_List_Table.
+		$I->bulkEdit(
+			$I,
+			'page',
+			$pageIDs,
+			[
+				'restrict_content' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+			]
+		);
+
+		// Iterate through Pages to run frontend tests.
+		foreach ($pageIDs as $pageID) {
+			// Test Restrict Content functionality.
+			$I->testRestrictedContentByFormOnFrontend($I, $pageID, $I->generateEmailAddress());
+		}
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->resetCookie('ck_subscriber_id');
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}

--- a/tests/acceptance/restrict-content/general/RestrictContentSettingsCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentSettingsCest.php
@@ -84,6 +84,9 @@ class RestrictContentSettingsCest
 			// Permit Crawlers.
 			'permit_crawlers'         => '',
 
+			// Restrict by Form.
+			'no_access_text_form'     => '',
+
 			// Restrict by Product.
 			'subscribe_heading'       => '',
 			'subscribe_text'          => '',

--- a/views/backend/post/bulk-edit.php
+++ b/views/backend/post/bulk-edit.php
@@ -87,9 +87,12 @@
 					// Forms.
 					if ( $convertkit_forms->inline_exist() ) {
 						foreach ( $convertkit_forms->get_inline() as $convertkit_form ) {
-							?>
-							<option value="form_<?php echo esc_attr( $convertkit_form['id'] ); ?>"><?php echo esc_attr( $convertkit_form['name'] ); ?></option>
-							<?php
+							printf(
+								'<option value="form_%s">%s [%s]</option>',
+								esc_attr( $convertkit_form['id'] ),
+								esc_attr( $convertkit_form['name'] ),
+								( ! empty( $convertkit_form['format'] ) ? esc_attr( $convertkit_form['format'] ) : 'inline' )
+							);
 						}
 					}
 					?>

--- a/views/backend/post/bulk-edit.php
+++ b/views/backend/post/bulk-edit.php
@@ -82,6 +82,19 @@
 				<option value="-2" data-preserve-on-refresh="1"><?php esc_html_e( '— No Change —', 'convertkit' ); ?></option>
 				<option value="0" data-preserve-on-refresh="1"><?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?></option>
 
+				<optgroup label="<?php esc_attr_e( 'Forms', 'convertkit' ); ?>" data-resource="forms">
+					<?php
+					// Forms.
+					if ( $convertkit_forms->inline_exist() ) {
+						foreach ( $convertkit_forms->get_inline() as $convertkit_form ) {
+							?>
+							<option value="form_<?php echo esc_attr( $convertkit_form['id'] ); ?>"><?php echo esc_attr( $convertkit_form['name'] ); ?></option>
+							<?php
+						}
+					}
+					?>
+				</optgroup>
+
 				<optgroup label="<?php esc_attr_e( 'Tags', 'convertkit' ); ?>" data-resource="tags">
 					<?php
 					// Tags.

--- a/views/backend/post/meta-box.php
+++ b/views/backend/post/meta-box.php
@@ -150,9 +150,13 @@
 							// Forms.
 							if ( $convertkit_forms->inline_exist() ) {
 								foreach ( $convertkit_forms->get_inline() as $convertkit_form ) {
-									?>
-									<option value="form_<?php echo esc_attr( $convertkit_form['id'] ); ?>"<?php selected( 'form_' . $convertkit_form['id'], $convertkit_post->get_restrict_content() ); ?>><?php echo esc_attr( $convertkit_form['name'] ); ?></option>
-									<?php
+									printf(
+										'<option value="form_%s"%s>%s [%s]</option>',
+										esc_attr( $convertkit_form['id'] ),
+										selected( $convertkit_post->get_restrict_content(), 'form_' . $convertkit_form['id'], false ),
+										esc_attr( $convertkit_form['name'] ),
+										( ! empty( $convertkit_form['format'] ) ? esc_attr( $convertkit_form['format'] ) : 'inline' )
+									);
 								}
 							}
 							?>

--- a/views/backend/post/meta-box.php
+++ b/views/backend/post/meta-box.php
@@ -145,11 +145,11 @@
 					<select name="wp-convertkit[restrict_content]" id="wp-convertkit-restrict_content" class="convertkit-select2">
 						<option value="0"<?php selected( '', $convertkit_post->get_restrict_content() ); ?> data-preserve-on-refresh="1"><?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?></option>
 
-						<optgroup label="<?php esc_attr_e( 'Forms', 'convertkit' ); ?>" data-resource="tags">
+						<optgroup label="<?php esc_attr_e( 'Forms', 'convertkit' ); ?>" data-resource="forms">
 							<?php
 							// Forms.
-							if ( $convertkit_forms->exist() ) {
-								foreach ( $convertkit_forms->get() as $convertkit_form ) {
+							if ( $convertkit_forms->inline_exist() ) {
+								foreach ( $convertkit_forms->get_inline() as $convertkit_form ) {
 									?>
 									<option value="form_<?php echo esc_attr( $convertkit_form['id'] ); ?>"<?php selected( 'form_' . $convertkit_form['id'], $convertkit_post->get_restrict_content() ); ?>><?php echo esc_attr( $convertkit_form['name'] ); ?></option>
 									<?php
@@ -191,15 +191,14 @@
 						<?php esc_html_e( 'Select the Kit form, tag or product that the visitor must be subscribed to, permitting them access to view this members only content.', 'convertkit' ); ?>
 						<br />
 						<code><?php esc_html_e( 'Form', 'convertkit' ); ?></code>
-						<?php esc_html_e( ': Displays the Kit form. On submission, the email address will be subscribed to the selected tag, granting access to the members only content. Useful to gate content in return for an email address.', 'convertkit' ); ?>
+						<?php esc_html_e( ': Displays the Kit form. On submission, the email address will be subscribed to the selected form, granting access to the members only content. Useful to gate free content in return for an email address.', 'convertkit' ); ?>
 						<br />
 						<code><?php esc_html_e( 'Tag', 'convertkit' ); ?></code>
-						<?php esc_html_e( ': Displays a subscription form. On submission, the email address will be subscribed to the selected tag, granting access to the members only content. Useful to gate free content in return for an email address.', 'convertkit' ); ?>
+						<?php esc_html_e( ': Displays a WordPress styled subscription form. On submission, the email address will be subscribed to the selected tag, granting access to the members only content. Useful to gate free content in return for an email address.', 'convertkit' ); ?>
 						<br />
 						<code><?php esc_html_e( 'Product', 'convertkit' ); ?></code>
 						<?php esc_html_e( ': Displays a link to the Kit product, and a login form. Useful to gate content that can only be accessed by purchasing the Kit product.', 'convertkit' ); ?>
 					</p>
-
 				</div>
 			</td>
 		</tr>

--- a/views/backend/post/meta-box.php
+++ b/views/backend/post/meta-box.php
@@ -145,6 +145,19 @@
 					<select name="wp-convertkit[restrict_content]" id="wp-convertkit-restrict_content" class="convertkit-select2">
 						<option value="0"<?php selected( '', $convertkit_post->get_restrict_content() ); ?> data-preserve-on-refresh="1"><?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?></option>
 
+						<optgroup label="<?php esc_attr_e( 'Forms', 'convertkit' ); ?>" data-resource="tags">
+							<?php
+							// Forms.
+							if ( $convertkit_forms->exist() ) {
+								foreach ( $convertkit_forms->get() as $convertkit_form ) {
+									?>
+									<option value="form_<?php echo esc_attr( $convertkit_form['id'] ); ?>"<?php selected( 'form_' . $convertkit_form['id'], $convertkit_post->get_restrict_content() ); ?>><?php echo esc_attr( $convertkit_form['name'] ); ?></option>
+									<?php
+								}
+							}
+							?>
+						</optgroup>
+
 						<optgroup label="<?php esc_attr_e( 'Tags', 'convertkit' ); ?>" data-resource="tags">
 							<?php
 							// Tags.
@@ -175,10 +188,18 @@
 						<span class="dashicons dashicons-update"></span>
 					</button>
 					<p class="description">
-						<?php esc_html_e( 'Select the Kit tag or product that the visitor must be subscribed to, permitting them access to view this members only content.', 'convertkit' ); ?>
+						<?php esc_html_e( 'Select the Kit form, tag or product that the visitor must be subscribed to, permitting them access to view this members only content.', 'convertkit' ); ?>
 						<br />
-						<?php esc_html_e( 'If a tag is selected, a subscription form will be displayed. On submission, the email address will be subscribed to the selected tag, granting access to the members only content.', 'convertkit' ); ?>
+						<code><?php esc_html_e( 'Form', 'convertkit' ); ?></code>
+						<?php esc_html_e( ': Displays the Kit form. On submission, the email address will be subscribed to the selected tag, granting access to the members only content. Useful to gate content in return for an email address.', 'convertkit' ); ?>
+						<br />
+						<code><?php esc_html_e( 'Tag', 'convertkit' ); ?></code>
+						<?php esc_html_e( ': Displays a subscription form. On submission, the email address will be subscribed to the selected tag, granting access to the members only content. Useful to gate free content in return for an email address.', 'convertkit' ); ?>
+						<br />
+						<code><?php esc_html_e( 'Product', 'convertkit' ); ?></code>
+						<?php esc_html_e( ': Displays a link to the Kit product, and a login form. Useful to gate content that can only be accessed by purchasing the Kit product.', 'convertkit' ); ?>
 					</p>
+
 				</div>
 			</td>
 		</tr>

--- a/views/backend/post/quick-edit.php
+++ b/views/backend/post/quick-edit.php
@@ -65,9 +65,12 @@
 					// Forms.
 					if ( $convertkit_forms->inline_exist() ) {
 						foreach ( $convertkit_forms->get_inline() as $convertkit_form ) {
-							?>
-							<option value="form_<?php echo esc_attr( $convertkit_form['id'] ); ?>"><?php echo esc_attr( $convertkit_form['name'] ); ?></option>
-							<?php
+							printf(
+								'<option value="form_%s">%s [%s]</option>',
+								esc_attr( $convertkit_form['id'] ),
+								esc_attr( $convertkit_form['name'] ),
+								( ! empty( $convertkit_form['format'] ) ? esc_attr( $convertkit_form['format'] ) : 'inline' )
+							);
 						}
 					}
 					?>

--- a/views/backend/post/quick-edit.php
+++ b/views/backend/post/quick-edit.php
@@ -60,6 +60,19 @@
 			<select name="wp-convertkit[restrict_content]" id="wp-convertkit-quick-edit-restrict_content" size="1">
 				<option value="0" data-preserve-on-refresh="1"><?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?></option>
 
+				<optgroup label="<?php esc_attr_e( 'Forms', 'convertkit' ); ?>" data-resource="forms">
+					<?php
+					// Forms.
+					if ( $convertkit_forms->inline_exist() ) {
+						foreach ( $convertkit_forms->get_inline() as $convertkit_form ) {
+							?>
+							<option value="form_<?php echo esc_attr( $convertkit_form['id'] ); ?>"><?php echo esc_attr( $convertkit_form['name'] ); ?></option>
+							<?php
+						}
+					}
+					?>
+				</optgroup>
+				
 				<optgroup label="<?php esc_attr_e( 'Tags', 'convertkit' ); ?>" data-resource="tags">
 					<?php
 					// Tags.

--- a/views/backend/post/wp-list-table-filter.php
+++ b/views/backend/post/wp-list-table-filter.php
@@ -11,6 +11,21 @@
 	<option value="0"><?php esc_html_e( 'All content', 'convertkit' ); ?></option>
 
 	<?php
+	// Forms.
+	if ( $this->forms->inline_exist() ) {
+		?>
+		<optgroup label="<?php esc_attr_e( 'Forms', 'convertkit' ); ?>">
+			<?php
+			foreach ( $this->forms->get_inline() as $convertkit_form ) {
+				?>
+				<option value="form_<?php echo esc_attr( $convertkit_form['id'] ); ?>"<?php selected( 'form_' . $convertkit_form['id'], $this->restrict_content_filter ); ?>><?php echo esc_attr( $convertkit_form['name'] ); ?></option>
+				<?php
+			}
+			?>
+		</optgroup>
+		<?php
+	}
+
 	// Tags.
 	if ( $this->tags->exist() ) {
 		?>

--- a/views/backend/post/wp-list-table-filter.php
+++ b/views/backend/post/wp-list-table-filter.php
@@ -17,9 +17,13 @@
 		<optgroup label="<?php esc_attr_e( 'Forms', 'convertkit' ); ?>">
 			<?php
 			foreach ( $this->forms->get_inline() as $convertkit_form ) {
-				?>
-				<option value="form_<?php echo esc_attr( $convertkit_form['id'] ); ?>"<?php selected( 'form_' . $convertkit_form['id'], $this->restrict_content_filter ); ?>><?php echo esc_attr( $convertkit_form['name'] ); ?></option>
-				<?php
+				printf(
+					'<option value="form_%s"%s>%s [%s]</option>',
+					esc_attr( $convertkit_form['id'] ),
+					selected( $this->restrict_content_filter, 'form_' . $convertkit_form['id'], false ),
+					esc_attr( $convertkit_form['name'] ),
+					( ! empty( $convertkit_form['format'] ) ? esc_attr( $convertkit_form['format'] ) : 'inline' )
+				);
 			}
 			?>
 		</optgroup>

--- a/views/frontend/restrict-content/form.php
+++ b/views/frontend/restrict-content/form.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Outputs a form for the subscriber to enter their
+ * email address to subscribe to the form, granting
+ * them access.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+?>
+
+<div id="convertkit-restrict-content-no-styles">
+	<?php
+	echo $form;
+
+	// If scripts are disabled in the Plugin's settings, output the email login form now.
+	if ( $this->settings->scripts_disabled() ) {
+		?>
+		<p>
+			<?php echo esc_html( $this->restrict_content_settings->get_by_key( 'email_text' ) ); ?>
+		</p>
+		<?php
+		require 'login-email.php';
+	} else {
+		// Just output the paragraph with a link to login, which will trigger the modal to display.
+		?>
+		<p>
+			<?php echo esc_html( $this->restrict_content_settings->get_by_key( 'email_text' ) ); ?>
+			<a href="#" class="convertkit-restrict-content-modal-open"><?php echo esc_attr( $this->restrict_content_settings->get_by_key( 'email_button_label' ) ); ?></a>
+		</p>
+		<?php
+	}
+	?>
+</div>

--- a/views/frontend/restrict-content/form.php
+++ b/views/frontend/restrict-content/form.php
@@ -8,28 +8,11 @@
  * @author ConvertKit
  */
 
+echo $form; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 ?>
-
-<div id="convertkit-restrict-content-no-styles">
+<div id="convertkit-restrict-content">
 	<?php
-	echo $form;
-
-	// If scripts are disabled in the Plugin's settings, output the email login form now.
-	if ( $this->settings->scripts_disabled() ) {
-		?>
-		<p>
-			<?php echo esc_html( $this->restrict_content_settings->get_by_key( 'email_text' ) ); ?>
-		</p>
-		<?php
-		require 'login-email.php';
-	} else {
-		// Just output the paragraph with a link to login, which will trigger the modal to display.
-		?>
-		<p>
-			<?php echo esc_html( $this->restrict_content_settings->get_by_key( 'email_text' ) ); ?>
-			<a href="#" class="convertkit-restrict-content-modal-open"><?php echo esc_attr( $this->restrict_content_settings->get_by_key( 'email_button_label' ) ); ?></a>
-		</p>
-		<?php
-	}
+	// Output a login link or form, if require login enabled.
+	require 'login.php';
 	?>
 </div>


### PR DESCRIPTION
## Summary

Adds functionality to gate content by Kit form, as requested in some tickets, with the option to login for existing subscribers, who receive a magic link / code by email, in the same way gating content by Tag and Product functions.

![Screenshot 2025-02-11 at 15 14 15](https://github.com/user-attachments/assets/d219fb44-6b07-48c9-952c-e654349d33ea)
![Screenshot 2025-02-11 at 15 14 19](https://github.com/user-attachments/assets/2633ff7f-3fde-4acd-8895-5567ac4d2fdd)
![Screenshot 2025-02-11 at 15 14 29](https://github.com/user-attachments/assets/0868e39c-4129-491c-b8ff-33d4ff5a252c)

## Testing

- `RestrictContentFormCest`: Test that gating content by form works
- `testFilterByForm`: Test that filtering Pages, Posts and Custom Post Types by form works

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)