### PR TITLE
Default Forms (Site Wide): Honor `None` setting specified at Page / Post level

### DIFF
--- a/admin/section/class-convertkit-admin-section-general.php
+++ b/admin/section/class-convertkit-admin-section-general.php
@@ -59,12 +59,17 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 
 		// Define settings sections.
 		$this->settings_sections = array(
-			'general'  => array(
+			'general'   => array(
 				'title'    => $this->title,
 				'callback' => array( $this, 'print_section_info' ),
 				'wrap'     => true,
 			),
-			'advanced' => array(
+			'site-wide' => array(
+				'title'    => __( 'Site Wide', 'convertkit' ),
+				'callback' => array( $this, 'print_section_info_site_wide' ),
+				'wrap'     => true,
+			),
+			'advanced'  => array(
 				'title'    => __( 'Advanced', 'convertkit' ),
 				'callback' => array( $this, 'print_section_info_advanced' ),
 				'wrap'     => true,
@@ -350,14 +355,26 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 			}
 		}
 
+		// Site Wide.
 		add_settings_field(
 			'non_inline_form',
 			__( 'Default Forms (Site Wide)', 'convertkit' ),
 			array( $this, 'non_inline_form_callback' ),
 			$this->settings_key,
-			$this->name,
+			$this->name . '-site-wide',
 			array(
 				'label_for' => 'non_inline_form',
+			)
+		);
+
+		add_settings_field(
+			'non_inline_form_honor_none_setting',
+			__( 'Behavior', 'convertkit' ),
+			array( $this, 'non_inline_form_honor_none_setting_callback' ),
+			$this->settings_key,
+			$this->name . '-site-wide',
+			array(
+				'label_for' => 'non_inline_form_honor_none_setting',
 			)
 		);
 
@@ -414,6 +431,19 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 			);
 			?>
 		</p>
+		<?php
+
+	}
+
+	/**
+	 * Prints help info for the site wide section of the settings screen.
+	 *
+	 * @since   2.7.3
+	 */
+	public function print_section_info_site_wide() {
+
+		?>
+		<p class="description"><?php esc_html_e( 'Defines non-inline forms to display site wide, and if these forms should display on Pages / Posts that have the Kit Form setting = None.', 'convertkit' ); ?></p>
 		<?php
 
 	}
@@ -710,6 +740,23 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 
 		// Output field.
 		echo '<div class="convertkit-select2-container">' . $select_field . '</div>'; // phpcs:ignore WordPress.Security.EscapeOutput
+
+	}
+
+	/**
+	 * Renders the input for the Non-inline Form override setting.
+	 *
+	 * @since   2.7.3
+	 */
+	public function non_inline_form_honor_none_setting_callback() {
+
+		// Output field.
+		echo $this->get_checkbox_field( // phpcs:ignore WordPress.Security.EscapeOutput
+			'non_inline_form_honor_none_setting',
+			'on',
+			$this->settings->non_inline_form_honor_none_setting(), // phpcs:ignore WordPress.Security.EscapeOutput
+			esc_html__( 'If checked, do not display the site wide form(s) above on Pages / Posts that have their Kit Form setting = None.', 'convertkit' )
+		);
 
 	}
 

--- a/admin/section/class-convertkit-admin-section-general.php
+++ b/admin/section/class-convertkit-admin-section-general.php
@@ -686,7 +686,7 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 		$preview_url = WP_ConvertKit()->get_class( 'preview_output' )->get_preview_form_home_url();
 		$description = sprintf(
 			'%s %s %s',
-			esc_html__( 'Select one or more non-inline modal, slide in or sticky bar forms to automatically display site wide. Ignored if a non-inline form is specified in Default Form settings above, individual Post / Page settings, or any block / shortcode.', 'convertkit' ),
+			esc_html__( 'Automatically display one or more modal, slide-in, or sticky bar forms across your site. This setting is overridden if a default non-inline form is set above, a specific non-inline form or "None" option is chosen for a post/page, or a non-inline form is specified in a block/shortcode.', 'convertkit' ),
 			'<a href="' . esc_url( $preview_url ) . '" id="convertkit-preview-non-inline-form" target="_blank">' . esc_html__( 'Click here', 'convertkit' ) . '</a>',
 			esc_html__( 'to preview how this will display.', 'convertkit' )
 		);

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -60,6 +60,19 @@ class ConvertKit_Output {
 	private $landing_pages = false;
 
 	/**
+	 * Whether the request can display forms specified in the
+	 * Default Forms (Site Wide) setting.
+	 *
+	 * Set to false if a Page, Post or Custom Post Type has its
+	 * form setting = None.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @var     bool
+	 */
+	private $display_site_wide_non_inline_forms = true;
+
+	/**
 	 * Constructor. Registers actions and filters to output ConvertKit Forms and Landing Pages
 	 * on the frontend web site.
 	 *
@@ -280,6 +293,7 @@ class ConvertKit_Output {
 
 		// Return the Post Content, unedited, if the Form ID is false or zero.
 		if ( ! $form_id ) {
+			$this->display_site_wide_non_inline_forms = false;
 			return $content;
 		}
 
@@ -809,6 +823,12 @@ class ConvertKit_Output {
 	 * @since   2.3.3
 	 */
 	public function output_global_non_inline_form() {
+
+		// If the Page, Post or Custom Post Type's Form setting is set to 'None'
+		// in this request, don't output any global forms.
+		if ( ! $this->display_site_wide_non_inline_forms ) {
+			return;
+		}
 
 		// Get Settings, if they have not yet been loaded.
 		if ( ! $this->settings ) {

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -60,19 +60,6 @@ class ConvertKit_Output {
 	private $landing_pages = false;
 
 	/**
-	 * Whether the request can display forms specified in the
-	 * Default Forms (Site Wide) setting.
-	 *
-	 * Set to false if a Page, Post or Custom Post Type has its
-	 * form setting = None.
-	 *
-	 * @since   2.7.3
-	 *
-	 * @var     bool
-	 */
-	private $display_site_wide_non_inline_forms = true;
-
-	/**
 	 * Constructor. Registers actions and filters to output ConvertKit Forms and Landing Pages
 	 * on the frontend web site.
 	 *
@@ -293,7 +280,6 @@ class ConvertKit_Output {
 
 		// Return the Post Content, unedited, if the Form ID is false or zero.
 		if ( ! $form_id ) {
-			$this->display_site_wide_non_inline_forms = false;
 			return $content;
 		}
 
@@ -824,12 +810,6 @@ class ConvertKit_Output {
 	 */
 	public function output_global_non_inline_form() {
 
-		// If the Page, Post or Custom Post Type's Form setting is set to 'None'
-		// in this request, don't output any global forms.
-		if ( ! $this->display_site_wide_non_inline_forms ) {
-			return;
-		}
-
 		// Get Settings, if they have not yet been loaded.
 		if ( ! $this->settings ) {
 			$this->settings = new ConvertKit_Settings();
@@ -837,6 +817,12 @@ class ConvertKit_Output {
 
 		// Bail if no non-inline form setting is specified.
 		if ( ! $this->settings->has_non_inline_form() ) {
+			return;
+		}
+
+		// Bail if the Page, Post or Custom Post Type's Form setting is set to 'None'
+		// and the Plugin is set to honor this setting.
+		if ( $this->post_settings !== false && $this->post_settings->uses_no_form() && $this->settings->non_inline_form_honor_none_setting() ) {
 			return;
 		}
 

--- a/includes/class-convertkit-settings.php
+++ b/includes/class-convertkit-settings.php
@@ -395,6 +395,20 @@ class ConvertKit_Settings {
 	}
 
 	/**
+	 * Returns whether the Global non-inline Form setting should honor the Page / Post
+	 * None setting.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @return  bool
+	 */
+	public function non_inline_form_honor_none_setting() {
+
+		return ( $this->settings['non_inline_form_honor_none_setting'] === 'on' ? true : false );
+
+	}
+
+	/**
 	 * Returns whether debugging is enabled in the Plugin settings.
 	 *
 	 * @since   1.9.6
@@ -445,19 +459,22 @@ class ConvertKit_Settings {
 
 		$defaults = array(
 			// OAuth.
-			'access_token'    => '', // string.
-			'refresh_token'   => '', // string.
-			'token_expires'   => '', // integer.
+			'access_token'                       => '', // string.
+			'refresh_token'                      => '', // string.
+			'token_expires'                      => '', // integer.
 
 			// API Key. Retained if needed for backward compat.
-			'api_key'         => '', // string.
-			'api_secret'      => '', // string.
+			'api_key'                            => '', // string.
+			'api_secret'                         => '', // string.
 
-			// Settings.
-			'non_inline_form' => array(), // array.
-			'debug'           => '', // blank|on.
-			'no_scripts'      => '', // blank|on.
-			'no_css'          => '', // blank|on.
+			// Site Wide.
+			'non_inline_form'                    => array(), // array.
+			'non_inline_form_honor_none_setting' => '', // blank|on.
+
+			// Advanced.
+			'debug'                              => '', // blank|on.
+			'no_scripts'                         => '', // blank|on.
+			'no_css'                             => '', // blank|on.
 		);
 
 		// Add Post Type Default Forms.

--- a/tests/_support/Helper/Acceptance/ConvertKitPlugin.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitPlugin.php
@@ -60,15 +60,16 @@ class ConvertKitPlugin extends \Codeception\Module
 	{
 		// Define default options.
 		$defaults = [
-			'access_token'    => $_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
-			'refresh_token'   => $_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN'],
-			'debug'           => 'on',
-			'no_scripts'      => '',
-			'no_css'          => '',
-			'post_form'       => $_ENV['CONVERTKIT_API_FORM_ID'],
-			'page_form'       => $_ENV['CONVERTKIT_API_FORM_ID'],
-			'product_form'    => $_ENV['CONVERTKIT_API_FORM_ID'],
-			'non_inline_form' => array(),
+			'access_token'                       => $_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
+			'refresh_token'                      => $_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN'],
+			'debug'                              => 'on',
+			'no_scripts'                         => '',
+			'no_css'                             => '',
+			'post_form'                          => $_ENV['CONVERTKIT_API_FORM_ID'],
+			'page_form'                          => $_ENV['CONVERTKIT_API_FORM_ID'],
+			'product_form'                       => $_ENV['CONVERTKIT_API_FORM_ID'],
+			'non_inline_form'                    => array(),
+			'non_inline_form_honor_none_setting' => '',
 		];
 
 		// If supplied options are an array, merge them with the defaults.

--- a/tests/acceptance/forms/general/NonInlineFormCest.php
+++ b/tests/acceptance/forms/general/NonInlineFormCest.php
@@ -231,7 +231,7 @@ class NonInlineFormCest
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testDefaultNonInlineFormIgnoredWhenPageFormNoneSetting(AcceptanceTester $I)
+	public function testPageLevelNoneSettingIgnored(AcceptanceTester $I)
 	{
 		// Setup Plugin with a non-inline Default Form for Site Wide.
 		$I->setupConvertKitPlugin(
@@ -244,7 +244,48 @@ class NonInlineFormCest
 		);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Non-Inline Form: None');
+		$I->addGutenbergPage($I, 'page', 'Kit: Page: Non-Inline Form: None: Ignored');
+
+		// Configure metabox's Form setting = None.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that the sticky bar form displays.
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_ID'] . '"]');
+	}
+
+	/**
+	 * Test that the None option defined on a Page overrides the non-inline form defined
+	 * in the Default Forms (Site Wide) setting when a Page is viewed.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testPageLevelNoneSettingHonored(AcceptanceTester $I)
+	{
+		// Setup Plugin with a non-inline Default Form for Site Wide,
+		// and set to honor the None setting at Page / Post level.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'non_inline_form'                    => array(
+					$_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_ID'],
+				),
+				'non_inline_form_honor_none_setting' => 'on',
+			]
+		);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'Kit: Page: Non-Inline Form: None: Honored');
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
@@ -508,7 +549,7 @@ class NonInlineFormCest
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testDefaultNonInlineFormIgnoredWhenPostFormNoneSetting(AcceptanceTester $I)
+	public function testPostLevelNoneSettingIgnored(AcceptanceTester $I)
 	{
 		// Setup Plugin with a non-inline Default Form for Site Wide.
 		$I->setupConvertKitPlugin(
@@ -521,7 +562,48 @@ class NonInlineFormCest
 		);
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Non-Inline Form: None');
+		$I->addGutenbergPage($I, 'post', 'Kit: Post: Non-Inline Form: None: Ignored');
+
+		// Configure metabox's Form setting = None.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
+
+		// Publish and view the Post on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that the sticky bar form displays.
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_ID'] . '"]');
+	}
+
+	/**
+	 * Test that the None option defined on a Post overrides the non-inline form defined
+	 * in the Default Forms (Site Wide) setting when a Post is viewed.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testPostLevelNoneSettingHonored(AcceptanceTester $I)
+	{
+		// Setup Plugin with a non-inline Default Form for Site Wide,
+		// and set to honor the None setting at Page / Post level.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'non_inline_form'                    => array(
+					$_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_ID'],
+				),
+				'non_inline_form_honor_none_setting' => 'on',
+			]
+		);
+
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'post', 'Kit: Post: Non-Inline Form: None: Honored');
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(

--- a/tests/acceptance/forms/general/NonInlineFormCest.php
+++ b/tests/acceptance/forms/general/NonInlineFormCest.php
@@ -143,7 +143,7 @@ class NonInlineFormCest
 
 	/**
 	 * Test that the non-inline form defined as the Default Form for Pages overrides
-	 * the non-inline form defined in the Default Non-Inline Form (Global) setting
+	 * the non-inline form defined in the Default Forms (Site Wide) setting
 	 * when a Page is viewed.
 	 *
 	 * @since   2.3.9
@@ -185,7 +185,7 @@ class NonInlineFormCest
 
 	/**
 	 * Test that the non-inline form defined on a Page overrides the non-inline form defined
-	 * in the Default Non-Inline Form (Global) setting when a Page is viewed.
+	 * in the Default Forms (Site Wide) setting when a Page is viewed.
 	 *
 	 * @since   2.3.9
 	 *
@@ -224,8 +224,47 @@ class NonInlineFormCest
 	}
 
 	/**
+	 * Test that the None option defined on a Page overrides the non-inline form defined
+	 * in the Default Forms (Site Wide) setting when a Page is viewed.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testDefaultNonInlineFormIgnoredWhenPageFormNoneSetting(AcceptanceTester $I)
+	{
+		// Setup Plugin with a non-inline Default Form for Site Wide.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'non_inline_form' => array(
+					$_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_ID'],
+				),
+			]
+		);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'Kit: Page: Non-Inline Form: None');
+
+		// Configure metabox's Form setting = None.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that no sticky bar form displays.
+		$I->dontSeeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_ID'] . '"]');
+	}
+
+	/**
 	 * Test that the non-inline form output using the Form Block overrides the non-inline form defined
-	 * in the Default Non-Inline Form (Global) setting when a Page is viewed.
+	 * in the Default Forms (Site Wide) setting when a Page is viewed.
 	 *
 	 * @since   2.3.9
 	 *
@@ -275,7 +314,7 @@ class NonInlineFormCest
 
 	/**
 	 * Test that the non-inline form output using the Form shortcode overrides the non-inline form defined
-	 * in the Default Non-Inline Form (Global) setting when a Page is viewed.
+	 * in the Default Forms (Site Wide) setting when a Page is viewed.
 	 *
 	 * @since   2.3.9
 	 *
@@ -325,7 +364,7 @@ class NonInlineFormCest
 
 	/**
 	 * Test that the non-inline form defined as the Default Form for Posts overrides
-	 * the non-inline form defined in the Default Non-Inline Form (Global) setting
+	 * the non-inline form defined in the Default Forms (Site Wide) setting
 	 * when a Post is viewed.
 	 *
 	 * @since   2.3.9
@@ -367,7 +406,7 @@ class NonInlineFormCest
 
 	/**
 	 * Test that the non-inline form defined on a Post overrides the non-inline form defined
-	 * in the Default Non-Inline Form (Global) setting when a Post is viewed.
+	 * in the Default Forms (Site Wide) setting when a Post is viewed.
 	 *
 	 * @since   2.3.9
 	 *
@@ -407,7 +446,7 @@ class NonInlineFormCest
 
 	/**
 	 * Test that the non-inline form defined on a Category overrides the non-inline form defined
-	 * in the Default Non-Inline Form (Global) setting when a Post assigned to the Category is viewed.
+	 * in the Default Forms (Site Wide) setting when a Post assigned to the Category is viewed.
 	 *
 	 * @since   2.3.9
 	 *
@@ -458,6 +497,45 @@ class NonInlineFormCest
 
 		// Confirm that the modal form displays, and no sticky bar form displays.
 		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '"]');
+		$I->dontSeeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_ID'] . '"]');
+	}
+
+	/**
+	 * Test that the None option defined on a Post overrides the non-inline form defined
+	 * in the Default Forms (Site Wide) setting when a Post is viewed.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testDefaultNonInlineFormIgnoredWhenPostFormNoneSetting(AcceptanceTester $I)
+	{
+		// Setup Plugin with a non-inline Default Form for Site Wide.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'non_inline_form' => array(
+					$_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_ID'],
+				),
+			]
+		);
+
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'post', 'Kit: Post: Non-Inline Form: None');
+
+		// Configure metabox's Form setting = None.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
+
+		// Publish and view the Post on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that no sticky bar form displays.
 		$I->dontSeeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_ID'] . '"]');
 	}
 


### PR DESCRIPTION
## Summary

Adds an option to honor the 'None' setting at Page / Post level when form(s) are defined in the Plugin's `Default Forms (Site Wide)` setting. Requested in these tickets:
https://linear.app/kit/issue/WP-25/wordpress-p3-default-forms-site-wide-setting-seems-to-be-not-getting
https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263837959598?view=List
https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263837929550?view=List
https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263837935866?view=List

![Screenshot 2025-02-13 at 11 30 16](https://github.com/user-attachments/assets/df80ab02-8d86-4802-a8a2-4e49a39d6951)

## Testing

- `testPageLevelNoneSettingIgnored`: Test that the Page's 'None' setting is ignored when the Plugin's "do not display" setting is not checked.
- `testPageLevelNoneSettingHonored`: Test that the Page's 'None' setting is honored when the Plugin's "do not display" setting is checked.
- `testPostLevelNoneSettingIgnored`: Test that the Post's 'None' setting is ignored when the Plugin's "do not display" setting is not checked.
- `testPostLevelNoneSettingHonored`: Test that the Post's 'None' setting is honored when the Plugin's "do not display" setting is checked.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)