### PR TITLE
Use WordPress Libraries 2.0.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "dev-add-form-referrer-support"
+        "convertkit/convertkit-wordpress-libraries": "2.0.6"
     },
     "require-dev": {
         "lucatume/wp-browser": "<3.5",


### PR DESCRIPTION
## Summary

Use the latest WordPress Libraries, 2.0.6, instead of the `dev-add-form-referrer-support` branch.

Both are the same, but better to use the published version.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)