### PR TITLE
Use `WordPress` Coding Standards ruleset

### DIFF
--- a/admin/class-convertkit-admin-bulk-edit.php
+++ b/admin/class-convertkit-admin-bulk-edit.php
@@ -111,7 +111,7 @@ class ConvertKit_Admin_Bulk_Edit {
 
 		// Iterate through each Post, updating its settings.
 		foreach ( $post_ids as $post_id ) {
-			WP_ConvertKit()->get_class( 'admin_post' )->save_post_settings( $post_id, wp_unslash( $_REQUEST['wp-convertkit'] ) );
+			WP_ConvertKit()->get_class( 'admin_post' )->save_post_settings( $post_id, wp_unslash( $_REQUEST['wp-convertkit'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		}
 
 	}

--- a/admin/class-convertkit-admin-bulk-edit.php
+++ b/admin/class-convertkit-admin-bulk-edit.php
@@ -72,12 +72,18 @@ class ConvertKit_Admin_Bulk_Edit {
 		}
 
 		// Bail if the nonce verification fails.
-		if ( ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['wp-convertkit-save-meta-nonce'] ) ), 'wp-convertkit-save-meta' ) ) {
+		if ( ! wp_verify_nonce( sanitize_key( wp_unslash( $_REQUEST['wp-convertkit-save-meta-nonce'] ) ), 'wp-convertkit-save-meta' ) ) {
+			return;
+		}
+
+		// Bail if the Post Type or Post IDs are not specified.
+		if ( ! isset( $_REQUEST['post_type'] ) || ! isset( $_REQUEST['post'] ) ) {
 			return;
 		}
 
 		// Bail if the Post isn't a supported Post Type.
-		if ( ! in_array( sanitize_text_field( $_REQUEST['post_type'] ), convertkit_get_supported_post_types(), true ) ) {
+		$post_type = sanitize_text_field( wp_unslash( $_REQUEST['post_type'] ) );
+		if ( ! in_array( $post_type, convertkit_get_supported_post_types(), true ) ) {
 			return;
 		}
 
@@ -87,15 +93,15 @@ class ConvertKit_Admin_Bulk_Edit {
 		}
 
 		// Get Post Type object.
-		$post_type = get_post_type_object( $_REQUEST['post_type'] );
+		$post_type_object = get_post_type_object( $post_type );
 
 		// Bail if the logged in user cannot edit Pages/Posts.
-		if ( ! current_user_can( $post_type->cap->edit_posts ) ) {
+		if ( ! current_user_can( $post_type_object->cap->edit_posts ) ) {
 			wp_die(
 				sprintf(
 					/* translators: Post Type name */
 					esc_html__( 'Sorry, you are not allowed to edit %s.', 'convertkit' ),
-					esc_html( $post_type->name )
+					esc_html( $post_type_object->name )
 				)
 			);
 		}
@@ -105,7 +111,7 @@ class ConvertKit_Admin_Bulk_Edit {
 
 		// Iterate through each Post, updating its settings.
 		foreach ( $post_ids as $post_id ) {
-			WP_ConvertKit()->get_class( 'admin_post' )->save_post_settings( $post_id, $_REQUEST['wp-convertkit'] );
+			WP_ConvertKit()->get_class( 'admin_post' )->save_post_settings( $post_id, wp_unslash( $_REQUEST['wp-convertkit'] ) );
 		}
 
 	}

--- a/admin/class-convertkit-admin-category.php
+++ b/admin/class-convertkit-admin-category.php
@@ -196,7 +196,7 @@ class ConvertKit_Admin_Category {
 		// Build metadata.
 		$meta = array(
 			'form'          => ( isset( $_POST['wp-convertkit']['form'] ) ? intval( $_POST['wp-convertkit']['form'] ) : '' ),
-			'form_position' => ( isset( $_POST['wp-convertkit']['form_position'] ) ? $_POST['wp-convertkit']['form_position'] : '' ),
+			'form_position' => ( isset( $_POST['wp-convertkit']['form_position'] ) ? sanitize_text_field( wp_unslash( $_POST['wp-convertkit']['form_position'] ) ) : '' ),
 		);
 
 		// Save metadata.

--- a/admin/class-convertkit-admin-post.php
+++ b/admin/class-convertkit-admin-post.php
@@ -274,7 +274,7 @@ class ConvertKit_Admin_Post {
 		}
 
 		// Save Post's settings.
-		$this->save_post_settings( $post_id, $_POST['wp-convertkit'] );
+		$this->save_post_settings( $post_id, wp_unslash( $_POST['wp-convertkit'] ) );
 
 	}
 
@@ -304,7 +304,7 @@ class ConvertKit_Admin_Post {
 			}
 
 			// Sanitize value.
-			$new_value = sanitize_text_field( wp_unslash( $settings[ $key ] ) );
+			$new_value = sanitize_text_field( $settings[ $key ] );
 
 			// Skip if the setting value is -2, as this means it's a Bulk Edit request and this setting
 			// is set as 'No Change'.

--- a/admin/class-convertkit-admin-post.php
+++ b/admin/class-convertkit-admin-post.php
@@ -274,7 +274,7 @@ class ConvertKit_Admin_Post {
 		}
 
 		// Save Post's settings.
-		$this->save_post_settings( $post_id, wp_unslash( $_POST['wp-convertkit'] ) );
+		$this->save_post_settings( $post_id, wp_unslash( $_POST['wp-convertkit'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 	}
 

--- a/admin/class-convertkit-admin-refresh-resources.php
+++ b/admin/class-convertkit-admin-refresh-resources.php
@@ -38,7 +38,7 @@ class ConvertKit_Admin_Refresh_Resources {
 		check_ajax_referer( 'convertkit_admin_refresh_resources', 'nonce' );
 
 		// Get resource type.
-		$resource = sanitize_text_field( $_REQUEST['resource'] );
+		$resource = ( isset( $_REQUEST['resource'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['resource'] ) ) : '' );
 
 		// Fetch resources.
 		switch ( $resource ) {

--- a/admin/class-convertkit-admin-restrict-content.php
+++ b/admin/class-convertkit-admin-restrict-content.php
@@ -97,7 +97,7 @@ class ConvertKit_Admin_Restrict_Content {
 		if ( ! array_key_exists( 'convertkit_restrict_content', $_REQUEST ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return;
 		}
-		if ( ! $_REQUEST['convertkit_restrict_content'] ) { // phpcs:ignore WordPress.Security.NonceVerification
+		if ( ! sanitize_text_field( wp_unslash( $_REQUEST['convertkit_restrict_content'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return;
 		}
 
@@ -113,7 +113,7 @@ class ConvertKit_Admin_Restrict_Content {
 		// setting name and value, to be as accurate as possible.
 		$value = maybe_serialize(
 			array(
-				'restrict_content' => sanitize_text_field( $_REQUEST['convertkit_restrict_content'] ), // phpcs:ignore WordPress.Security.NonceVerification
+				'restrict_content' => sanitize_text_field( wp_unslash( $_REQUEST['convertkit_restrict_content'] ) ), // phpcs:ignore WordPress.Security.NonceVerification
 			)
 		);
 
@@ -139,7 +139,7 @@ class ConvertKit_Admin_Restrict_Content {
 		}
 
 		// Store Restrict Content filter value.
-		$this->restrict_content_filter = sanitize_text_field( $_REQUEST['convertkit_restrict_content'] ); // phpcs:ignore WordPress.Security.NonceVerification
+		$this->restrict_content_filter = sanitize_text_field( wp_unslash( $_REQUEST['convertkit_restrict_content'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
 
 	}
 

--- a/admin/class-convertkit-admin-setup-wizard.php
+++ b/admin/class-convertkit-admin-setup-wizard.php
@@ -406,7 +406,7 @@ class ConvertKit_Admin_Setup_Wizard {
 		if ( ! isset( $_GET['page'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return false;
 		}
-		if ( sanitize_text_field( $_GET['page'] ) !== $this->page_name ) { // phpcs:ignore WordPress.Security.NonceVerification
+		if ( sanitize_text_field( wp_unslash( $_GET['page'] ) ) !== $this->page_name ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return false;
 		}
 

--- a/admin/class-convertkit-admin-tinymce.php
+++ b/admin/class-convertkit-admin-tinymce.php
@@ -47,9 +47,15 @@ class ConvertKit_Admin_TinyMCE {
 		// Get shortcodes.
 		$shortcodes = convertkit_get_shortcodes();
 
+		// Bail if no shortcode or editor type is specified.
+		if ( ! isset( $_REQUEST['shortcode'] ) || ! isset( $_REQUEST['editor_type'] ) ) {
+			require_once CONVERTKIT_PLUGIN_PATH . '/views/backend/tinymce/modal-missing.php';
+			die();
+		}
+
 		// Get requested shortcode name.
-		$shortcode_name = sanitize_text_field( $_REQUEST['shortcode'] );
-		$editor_type    = sanitize_text_field( $_REQUEST['editor_type'] );
+		$shortcode_name = sanitize_text_field( wp_unslash( $_REQUEST['shortcode'] ) );
+		$editor_type    = sanitize_text_field( wp_unslash( $_REQUEST['editor_type'] ) );
 
 		// If the shortcode is not registered, return a view in the modal to tell the user.
 		if ( ! isset( $shortcodes[ $shortcode_name ] ) ) {

--- a/admin/section/class-convertkit-admin-section-base.php
+++ b/admin/section/class-convertkit-admin-section-base.php
@@ -110,13 +110,13 @@ abstract class ConvertKit_Admin_Section_Base {
 		if ( ! array_key_exists( 'page', $_REQUEST ) ) {
 			return false;
 		}
-		if ( sanitize_text_field( $_REQUEST['page'] ) !== '_wp_convertkit_settings' ) {
+		if ( sanitize_text_field( wp_unslash( $_REQUEST['page'] ) ) !== '_wp_convertkit_settings' ) {
 			return false;
 		}
 
 		// Define current settings tab.
 		// General screen won't always be loaded with a `tab` parameter.
-		$current_tab = ( array_key_exists( 'tab', $_REQUEST ) ? sanitize_text_field( $_REQUEST['tab'] ) : 'general' );
+		$current_tab = ( array_key_exists( 'tab', $_REQUEST ) ? sanitize_text_field( wp_unslash( $_REQUEST['tab'] ) ) : 'general' );
 
 		// Return whether the request is for the current settings tab.
 		return ( $current_tab === $tab );
@@ -200,17 +200,17 @@ abstract class ConvertKit_Admin_Section_Base {
 
 		// Output the verbose error description if supplied (e.g. OAuth).
 		if ( isset( $_REQUEST['error_description'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$this->output_error( sanitize_text_field( $_REQUEST['error_description'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+			$this->output_error( sanitize_text_field( wp_unslash( $_REQUEST['error_description'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification
 		}
 
 		// Output error notification if defined.
-		if ( isset( $_REQUEST['error'] ) && array_key_exists( sanitize_text_field( $_REQUEST['error'] ), $notices ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$this->output_error( $notices[ sanitize_text_field( $_REQUEST['error'] ) ] ); // phpcs:ignore WordPress.Security.NonceVerification
+		if ( isset( $_REQUEST['error'] ) && array_key_exists( sanitize_text_field( wp_unslash( $_REQUEST['error'] ) ), $notices ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			$this->output_error( $notices[ sanitize_text_field( wp_unslash( $_REQUEST['error'] ) ) ] ); // phpcs:ignore WordPress.Security.NonceVerification
 		}
 
 		// Output success notification if defined.
-		if ( isset( $_REQUEST['success'] ) && array_key_exists( sanitize_text_field( $_REQUEST['success'] ), $notices ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$this->output_success( $notices[ sanitize_text_field( $_REQUEST['success'] ) ] ); // phpcs:ignore WordPress.Security.NonceVerification
+		if ( isset( $_REQUEST['success'] ) && array_key_exists( sanitize_text_field( wp_unslash( $_REQUEST['success'] ) ), $notices ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			$this->output_success( $notices[ sanitize_text_field( wp_unslash( $_REQUEST['success'] ) ) ] ); // phpcs:ignore WordPress.Security.NonceVerification
 		}
 
 	}

--- a/admin/section/class-convertkit-admin-section-oauth.php
+++ b/admin/section/class-convertkit-admin-section-oauth.php
@@ -61,7 +61,7 @@ class ConvertKit_Admin_Section_OAuth extends ConvertKit_Admin_Section_Base {
 		}
 
 		// Sanitize token.
-		$authorization_code = sanitize_text_field( $_REQUEST['code'] ); // phpcs:ignore WordPress.Security.NonceVerification
+		$authorization_code = sanitize_text_field( wp_unslash( $_REQUEST['code'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
 
 		// Exchange the authorization code and verifier for an access token.
 		$api    = new ConvertKit_API_V4( CONVERTKIT_OAUTH_CLIENT_ID, CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI );

--- a/admin/section/class-convertkit-admin-section-tools.php
+++ b/admin/section/class-convertkit-admin-section-tools.php
@@ -229,12 +229,17 @@ class ConvertKit_Admin_Section_Tools extends ConvertKit_Admin_Section_Base {
 		}
 
 		// Bail if no configuration file was supplied.
-		if ( $_FILES['import']['error'] !== 0 ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		if ( isset( $_FILES['import']['error'] ) && $_FILES['import']['error'] !== 0 ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			$this->redirect_with_error_notice( 'import_configuration_upload_error' );
+		}
+
+		// Bail if the file cannot be read.
+		if ( ! isset( $_FILES['import']['tmp_name'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			$this->redirect_with_error_notice( 'import_configuration_upload_error' );
 		}
 
 		// Read file.
-		$json = $wp_filesystem->get_contents( $_FILES['import']['tmp_name'] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$json = $wp_filesystem->get_contents( $_FILES['import']['tmp_name'] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		// Decode.
 		$import = json_decode( $json, true );

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-landing-page.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-landing-page.php
@@ -130,8 +130,8 @@ class ConvertKit_Admin_Setup_Wizard_Landing_Page extends ConvertKit_Admin_Setup_
 
 		// Sanitize configuration.
 		$configuration = array(
-			'landing_page' => ( isset( $_POST['landing_page'] ? sanitize_text_field( wp_unslash( $_POST['landing_page'] ) ) : '' ),
-			'post_name'    => ( isset( $_POST['post_name'] ? sanitize_text_field( wp_unslash( $_POST['post_name'] ) ) : '' ),
+			'landing_page' => ( isset( $_POST['landing_page'] ) ? sanitize_text_field( wp_unslash( $_POST['landing_page'] ) ) : '' ),
+			'post_name'    => ( isset( $_POST['post_name'] ) ? sanitize_text_field( wp_unslash( $_POST['post_name'] ) ) : '' ),
 			'post_type'    => $this->post_type,
 		);
 

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-landing-page.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-landing-page.php
@@ -130,8 +130,8 @@ class ConvertKit_Admin_Setup_Wizard_Landing_Page extends ConvertKit_Admin_Setup_
 
 		// Sanitize configuration.
 		$configuration = array(
-			'landing_page' => sanitize_text_field( stripslashes( $_POST['landing_page'] ) ),
-			'post_name'    => sanitize_text_field( stripslashes( $_POST['post_name'] ) ),
+			'landing_page' => ( isset( $_POST['landing_page'] ? sanitize_text_field( wp_unslash( $_POST['landing_page'] ) ) : '' ),
+			'post_name'    => ( isset( $_POST['post_name'] ? sanitize_text_field( wp_unslash( $_POST['post_name'] ) ) : '' ),
 			'post_type'    => $this->post_type,
 		);
 
@@ -168,7 +168,7 @@ class ConvertKit_Admin_Setup_Wizard_Landing_Page extends ConvertKit_Admin_Setup_
 		}
 
 		// Bail if the Post Type isn't supported.
-		$this->post_type = isset( $_REQUEST['ck_post_type'] ) ? sanitize_text_field( $_REQUEST['ck_post_type'] ) : 'page'; // phpcs:ignore WordPress.Security.NonceVerification
+		$this->post_type = isset( $_REQUEST['ck_post_type'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['ck_post_type'] ) ) : 'page'; // phpcs:ignore WordPress.Security.NonceVerification
 		if ( ! in_array( $this->post_type, convertkit_get_supported_post_types(), true ) ) {
 			wp_die(
 				sprintf(

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
@@ -215,7 +215,7 @@ class ConvertKit_Admin_Setup_Wizard_Plugin extends ConvertKit_Admin_Setup_Wizard
 				if ( array_key_exists( 'error', $_REQUEST ) && array_key_exists( 'error_description', $_REQUEST ) ) {
 					// Decrement the step.
 					$this->step  = ( $this->step - 1 );
-					$this->error = sanitize_text_field( $_REQUEST['error_description'] );
+					$this->error = sanitize_text_field( wp_unslash( $_REQUEST['error_description'] ) );
 					return;
 				}
 
@@ -225,7 +225,7 @@ class ConvertKit_Admin_Setup_Wizard_Plugin extends ConvertKit_Admin_Setup_Wizard
 				}
 
 				// Sanitize token.
-				$authorization_code = sanitize_text_field( $_REQUEST['code'] ); // phpcs:ignore WordPress.Security.NonceVerification
+				$authorization_code = sanitize_text_field( wp_unslash( $_REQUEST['code'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
 
 				// Exchange the authorization code and verifier for an access token.
 				$result = $this->api->get_access_token( $authorization_code );
@@ -262,8 +262,8 @@ class ConvertKit_Admin_Setup_Wizard_Plugin extends ConvertKit_Admin_Setup_Wizard
 				$settings = new ConvertKit_Settings();
 				$settings->save(
 					array(
-						'post_form' => sanitize_text_field( $_POST['post_form'] ),
-						'page_form' => sanitize_text_field( $_POST['page_form'] ),
+						'post_form' => ( isset( $_POST['post_form'] ) ? sanitize_text_field( wp_unslash( $_POST['post_form'] ) ) : '0' ),
+						'page_form' => ( isset( $_POST['page_form'] ) ? sanitize_text_field( wp_unslash( $_POST['page_form'] ) ) : '0' ),
 					)
 				);
 				break;

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
@@ -176,11 +176,11 @@ class ConvertKit_Admin_Setup_Wizard_Restrict_Content extends ConvertKit_Admin_Se
 			case 3:
 				// Sanitize configuration.
 				$configuration = array(
-					'type'             => sanitize_text_field( stripslashes( $_POST['type'] ) ),
-					'title'            => sanitize_text_field( stripslashes( $_POST['title'] ) ),
-					'description'      => sanitize_textarea_field( stripslashes( $_POST['description'] ) ),
+					'type'             => ( isset( $_POST['type'] ) ? sanitize_text_field( wp_unslash( $_POST['type'] ) ) : 'download' ),
+					'title'            => ( isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ), : '' ),
+					'description'      => ( isset( $_POST['description'] ) ? sanitize_textarea_field( wp_unslash( $_POST['description'] ) ) : '' ),
 					'number_of_pages'  => ( isset( $_POST['number_of_pages'] ) ? absint( $_POST['number_of_pages'] ) : 0 ),
-					'restrict_content' => sanitize_text_field( stripslashes( $_POST['restrict_content'] ) ),
+					'restrict_content' => ( isset( $_POST['restrict_content'] ) ? sanitize_text_field( wp_unslash( $_POST['restrict_content'] ) ) : '' ),
 					'post_type'        => $this->post_type,
 				);
 
@@ -234,7 +234,7 @@ class ConvertKit_Admin_Setup_Wizard_Restrict_Content extends ConvertKit_Admin_Se
 		}
 
 		// Bail if the Post Type isn't supported.
-		$this->post_type = isset( $_REQUEST['ck_post_type'] ) ? sanitize_text_field( $_REQUEST['ck_post_type'] ) : 'page'; // phpcs:ignore WordPress.Security.NonceVerification
+		$this->post_type = isset( $_REQUEST['ck_post_type'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['ck_post_type'] ) ) : 'page'; // phpcs:ignore WordPress.Security.NonceVerification
 		if ( ! in_array( $this->post_type, convertkit_get_supported_post_types(), true ) ) {
 			wp_die(
 				sprintf(
@@ -303,7 +303,7 @@ class ConvertKit_Admin_Setup_Wizard_Restrict_Content extends ConvertKit_Admin_Se
 
 			case 2:
 				// Define Member Content Type.
-				$this->type = sanitize_text_field( $_REQUEST['type'] ); // phpcs:ignore WordPress.Security.NonceVerification
+				$this->type = ( isset( $_REQUEST['type'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['type'] ) ) : 'download' ); // phpcs:ignore WordPress.Security.NonceVerification
 
 				// Define Label for Title.
 				switch ( $this->type ) {

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
@@ -177,7 +177,7 @@ class ConvertKit_Admin_Setup_Wizard_Restrict_Content extends ConvertKit_Admin_Se
 				// Sanitize configuration.
 				$configuration = array(
 					'type'             => ( isset( $_POST['type'] ) ? sanitize_text_field( wp_unslash( $_POST['type'] ) ) : 'download' ),
-					'title'            => ( isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ), : '' ),
+					'title'            => ( isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : '' ),
 					'description'      => ( isset( $_POST['description'] ) ? sanitize_textarea_field( wp_unslash( $_POST['description'] ) ) : '' ),
 					'number_of_pages'  => ( isset( $_POST['number_of_pages'] ) ? absint( $_POST['number_of_pages'] ) : 0 ),
 					'restrict_content' => ( isset( $_POST['restrict_content'] ) ? sanitize_text_field( wp_unslash( $_POST['restrict_content'] ) ) : '' ),

--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -502,17 +502,17 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 
 		// Build attributes array.
 		$atts = array(
-			'date_format'         => stripslashes( sanitize_text_field( $_REQUEST['date_format'] ) ),
-			'display_image'       => absint( $_REQUEST['display_image'] ),
-			'display_description' => absint( $_REQUEST['display_description'] ),
-			'display_read_more'   => absint( $_REQUEST['display_read_more'] ),
-			'read_more_label'     => stripslashes( sanitize_text_field( $_REQUEST['read_more_label'] ) ),
-			'limit'               => absint( $_REQUEST['limit'] ),
-			'page'                => absint( $_REQUEST['page'] ),
-			'paginate'            => absint( $_REQUEST['paginate'] ),
-			'paginate_label_next' => stripslashes( sanitize_text_field( $_REQUEST['paginate_label_next'] ) ),
-			'paginate_label_prev' => stripslashes( sanitize_text_field( $_REQUEST['paginate_label_prev'] ) ),
-			'link_color'          => stripslashes( sanitize_text_field( $_REQUEST['link_color'] ) ),
+			'date_format'         => ( isset( $_REQUEST['date_format'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['date_format'] ) ) : $this->get_default_value( 'date_format' ) ),
+			'display_image'       => ( isset( $_REQUEST['display_image'] ) ? absint( $_REQUEST['display_image'] ) : $this->get_default_value( 'display_image' ) ),
+			'display_description' => ( isset( $_REQUEST['display_description'] ) ? absint( $_REQUEST['display_description'] ) : $this->get_default_value( 'display_description' ) ),
+			'display_read_more'   => ( isset( $_REQUEST['display_read_more'] ) ? absint( $_REQUEST['display_read_more'] ) : $this->get_default_value( 'display_read_more' ) ),
+			'read_more_label'     => ( isset( $_REQUEST['read_more_label'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['read_more_label'] ) ) : $this->get_default_value( 'read_more_label' ) ),
+			'limit'               => ( isset( $_REQUEST['limit'] ) ? absint( $_REQUEST['limit'] ) : $this->get_default_value( 'limit' ) ),
+			'page'                => ( isset( $_REQUEST['page'] ) ? absint( $_REQUEST['page'] ) : $this->get_default_value( 'page' ) ),
+			'paginate'            => ( isset( $_REQUEST['paginate'] ) ? absint( $_REQUEST['paginate'] ) : $this->get_default_value( 'paginate' ) ),
+			'paginate_label_next' => ( isset( $_REQUEST['paginate_label_next'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['paginate_label_next'] ) ) : $this->get_default_value( 'paginate_label_next' ) ),
+			'paginate_label_prev' => ( isset( $_REQUEST['paginate_label_prev'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['paginate_label_prev'] ) ) : $this->get_default_value( 'paginate_label_prev' ) ),
+			'link_color'          => ( isset( $_REQUEST['link_color'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['link_color'] ) ) : $this->get_default_value( 'link_color' ) ),
 		);
 
 		// Parse attributes, defining fallback defaults if required

--- a/includes/blocks/class-convertkit-block.php
+++ b/includes/blocks/class-convertkit-block.php
@@ -369,7 +369,7 @@ class ConvertKit_Block {
 		if ( ! array_key_exists( 'context', $_GET ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return false;
 		}
-		if ( sanitize_text_field( $_GET['context'] ) !== 'edit' ) { // phpcs:ignore WordPress.Security.NonceVerification
+		if ( sanitize_text_field( wp_unslash( $_GET['context'] ) ) !== 'edit' ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return false;
 		}
 

--- a/includes/class-convertkit-ajax.php
+++ b/includes/class-convertkit-ajax.php
@@ -85,7 +85,7 @@ class ConvertKit_AJAX {
 		}
 
 		// Bail if no subscriber ID provided.
-		$id = absint( sanitize_text_field( $_REQUEST['subscriber_id'] ) );
+		$id = absint( sanitize_text_field( wp_unslash( $_REQUEST['subscriber_id'] ) ) );
 		if ( empty( $id ) ) {
 			wp_send_json_error( __( 'Kit: Required parameter `subscriber_id` empty in AJAX request.', 'convertkit' ) );
 		}
@@ -125,7 +125,7 @@ class ConvertKit_AJAX {
 		if ( ! isset( $_REQUEST['email'] ) ) {
 			wp_send_json_error( __( 'Kit: Required parameter `email` not included in AJAX request.', 'convertkit' ) );
 		}
-		$email = sanitize_text_field( $_REQUEST['email'] );
+		$email = sanitize_text_field( wp_unslash( $_REQUEST['email'] ) );
 
 		// Bail if the email address is empty.
 		if ( empty( $email ) ) {

--- a/includes/class-convertkit-broadcasts-exporter.php
+++ b/includes/class-convertkit-broadcasts-exporter.php
@@ -88,17 +88,20 @@ class ConvertKit_Broadcasts_Exporter {
 		if ( ! array_key_exists( 'nonce', $_REQUEST ) ) {
 			return;
 		}
-		if ( ! wp_verify_nonce( $_REQUEST['nonce'], 'action-convertkit-' . $this->action_name ) ) {
+		if ( ! wp_verify_nonce( sanitize_key( wp_unslash( $_REQUEST['nonce'] ) ), 'action-convertkit-' . $this->action_name ) ) {
 			return;
 		}
 
-		// If no action specified, return.
+		// If no action or ID specified, return.
 		if ( ! isset( $_REQUEST['convertkit-action'] ) ) {
+			return;
+		}
+		if ( ! isset( $_REQUEST['id'] ) ) {
 			return;
 		}
 
 		// Fetch action and post ID.
-		$action  = sanitize_text_field( $_REQUEST['convertkit-action'] );
+		$action  = sanitize_text_field( wp_unslash( $_REQUEST['convertkit-action'] ) );
 		$post_id = absint( $_REQUEST['id'] );
 
 		// Bail if the action isn't for exporting a post.

--- a/includes/class-convertkit-preview-output.php
+++ b/includes/class-convertkit-preview-output.php
@@ -64,7 +64,7 @@ class ConvertKit_Preview_Output {
 		}
 
 		// Determine the form to preview.
-		$preview_form_id = (int) ( isset( $_REQUEST['convertkit_form_id'] ) ? sanitize_text_field( $_REQUEST['convertkit_form_id'] ) : 0 );
+		$preview_form_id = ( isset( $_REQUEST['convertkit_form_id'] ) ? absint( wp_unslash( $_REQUEST['convertkit_form_id'] ) ) : 0 );
 
 		// Return.
 		return $preview_form_id;
@@ -106,7 +106,7 @@ class ConvertKit_Preview_Output {
 
 		// Determine form ID(s) to preview.
 		$convertkit_forms = new ConvertKit_Resource_Forms();
-		$preview_form_ids = explode( ',', sanitize_text_field( $_REQUEST['convertkit_form_id'] ) );
+		$preview_form_ids = explode( ',', sanitize_text_field( wp_unslash( $_REQUEST['convertkit_form_id'] ) ) );
 
 		foreach ( $preview_form_ids as $preview_form_id ) {
 			// Get form.

--- a/includes/class-convertkit-subscriber.php
+++ b/includes/class-convertkit-subscriber.php
@@ -35,7 +35,7 @@ class ConvertKit_Subscriber {
 
 		// If the subscriber ID is in the request URI, use it.
 		if ( isset( $_REQUEST[ $this->key ] ) && is_numeric( $_REQUEST[ $this->key ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			return $this->validate_and_store_subscriber_id( sanitize_text_field( $_REQUEST[ $this->key ] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+			return $this->validate_and_store_subscriber_id( sanitize_text_field( wp_unslash( $_REQUEST[ $this->key ] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification
 		}
 
 		// If the subscriber ID is in a cookie, return it.
@@ -154,10 +154,16 @@ class ConvertKit_Subscriber {
 	 * Gets the subscriber ID from the `ck_subscriber_id` cookie.
 	 *
 	 * @since   2.0.0
+	 *
+	 * @return  string
 	 */
 	private function get_subscriber_id_from_cookie() {
 
-		return $_COOKIE[ $this->key ];
+		if ( ! isset( $_COOKIE[ $this->key ] ) ) {
+			return '';
+		}
+
+		return sanitize_text_field( wp_unslash( $_COOKIE[ $this->key ] ) );
 
 	}
 

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -230,13 +230,13 @@ class WP_ConvertKit {
 
 		// Pro.
 		if ( array_key_exists( 'REQUEST_URI', $_SERVER ) ) {
-			if ( strpos( sanitize_text_field( $_SERVER['REQUEST_URI'] ), '/pro/' ) !== false ) {
+			if ( strpos( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), '/pro/' ) !== false ) {
 				return true;
 			}
-			if ( strpos( sanitize_text_field( $_SERVER['REQUEST_URI'] ), '/x/' ) !== false ) {
+			if ( strpos( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), '/x/' ) !== false ) {
 				return true;
 			}
-			if ( strpos( sanitize_text_field( $_SERVER['REQUEST_URI'] ), 'cornerstone-endpoint' ) !== false ) {
+			if ( strpos( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), 'cornerstone-endpoint' ) !== false ) {
 				return true;
 			}
 		}
@@ -270,7 +270,7 @@ class WP_ConvertKit {
 		}
 
 		// Elementor.
-		if ( array_key_exists( 'action', $_REQUEST ) && sanitize_text_field( $_REQUEST['action'] ) === 'elementor' ) {
+		if ( array_key_exists( 'action', $_REQUEST ) && sanitize_text_field( wp_unslash( $_REQUEST['action'] ) ) === 'elementor' ) {
 			return true;
 		}
 
@@ -300,7 +300,7 @@ class WP_ConvertKit {
 		}
 
 		// Zion Builder.
-		if ( array_key_exists( 'action', $_REQUEST ) && sanitize_text_field( $_REQUEST['action'] ) === 'zion_builder_active' ) {
+		if ( array_key_exists( 'action', $_REQUEST ) && sanitize_text_field( wp_unslash( $_REQUEST['action'] ) ) === 'zion_builder_active' ) {
 			return true;
 		}
 

--- a/includes/integrations/forminator/class-convertkit-forminator.php
+++ b/includes/integrations/forminator/class-convertkit-forminator.php
@@ -213,13 +213,13 @@ class ConvertKit_Forminator {
 		// as it will include any UTM parameters.
 		if ( array_key_exists( '_wp_http_referer', $_REQUEST ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			// referrer is a relative path, so use home_url() to return a fully qualified URL.
-			return esc_url( home_url( $_REQUEST['_wp_http_referer'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return esc_url( home_url( sanitize_text_field( wp_unslash( $_REQUEST['_wp_http_referer'] ) ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		}
 
 		// If the request includes the current_url, return that URL.
 		// It won't include any UTM parameters, but is still an accurate URL.
 		if ( array_key_exists( 'current_url', $_REQUEST ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			return esc_url( $_REQUEST['current_url'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return esc_url( sanitize_text_field( wp_unslash( $_REQUEST['current_url'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		}
 
 		// Return the AJAX URL.

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,8 +10,8 @@
 	<!-- Exclude minified Javascript files. -->
 	<exclude-pattern>*.min.js</exclude-pattern>
 
-	<!-- Check that code meets WordPress-Extra standards. -->
-	<rule ref="WordPress-Extra">
+	<!-- Check that code meets WordPress standards - this includes core, docs and extra. -->
+	<rule ref="WordPress">
 		<!--
 		We may want a middle ground though. The best way to do this is add the
 		entire ruleset, then rule by rule, remove ones that don't suit a project.
@@ -32,9 +32,6 @@
 		<exclude name="PSR2.Methods.FunctionClosingBrace.SpacingBeforeClose" />
 		<exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody" />
 	</rule>
-
-	<!-- Check that code is documented to WordPress Standards. -->
-	<rule ref="WordPress-Docs"/>
 
 	<!-- Add in some extra rules from other standards. -->
 	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -29,6 +29,7 @@
 		<exclude name="WordPress.Security.EscapeOutput"/>
 		-->
 		<exclude name="WordPress.PHP.YodaConditions" />
+		<exclude name="WordPress.DB.SlowDBQuery.slow_db_query_meta_query" />
 		<exclude name="PSR2.Methods.FunctionClosingBrace.SpacingBeforeClose" />
 		<exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody" />
 	</rule>

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires at least: 5.0
 Tested up to: 6.7.2
 Requires PHP: 5.6.20
 Stable tag: 2.7.3
-License: GPLv2 or later
+License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 Build your email subscriber lists, send email marketing newsletters, sell more products and build your membership site with Kit (formerly ConvertKit).

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Tested up to: 6.7.2
 Requires PHP: 5.6.20
 Stable tag: 2.7.3
 License: GPLv3 or later
-License URI: http://www.gnu.org/licenses/gpl-2.0.html
+License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
 Build your email subscriber lists, send email marketing newsletters, sell more products and build your membership site with Kit (formerly ConvertKit).
 

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -13,7 +13,7 @@
  * Author: Kit
  * Author URI: https://kit.com/
  * Text Domain: convertkit
- * License:     GPLv2 or later
+ * License:     GPLv3 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  */
 

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -13,6 +13,8 @@
  * Author: Kit
  * Author URI: https://kit.com/
  * Text Domain: convertkit
+ * License:     GPLv2 or later
+ * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  */
 
 // Bail if Kit is alread loaded.

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -14,7 +14,7 @@
  * Author URI: https://kit.com/
  * Text Domain: convertkit
  * License:     GPLv3 or later
- * License URI: http://www.gnu.org/licenses/gpl-2.0.html
+ * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  */
 
 // Bail if Kit is alread loaded.


### PR DESCRIPTION
## Summary

Currently, we implement `WordPress-Docs` and `WordPress-Extra` (which, in turn implements `WordPress-Core`) coding standards.

However, switching this to the complete [`WordPress` ruleset](https://github.com/WordPress/WordPress-Coding-Standards?tab=readme-ov-file#standards-subsets) (which lists itself as comprising of `WordPress-Core`, `WordPress-Docs` and `WordPress-Extra`) introduces some additional rulesets.

This PR updates code to meet these coding standards, primarily covering checking and unslashing superglobals in PHP.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)