### PR TITLE
Tools: Import / Export: Include Broadcasts Settings

### DIFF
--- a/admin/section/class-convertkit-admin-section-tools.php
+++ b/admin/section/class-convertkit-admin-section-tools.php
@@ -190,14 +190,14 @@ class ConvertKit_Admin_Section_Tools extends ConvertKit_Admin_Section_Base {
 		// Initialize classes that hold settings.
 		$settings                  = new ConvertKit_Settings();
 		$restrict_content_settings = new ConvertKit_Settings_Restrict_Content();
-		$broadcasts_settings 	   = new ConvertKit_Settings_Broadcasts();
+		$broadcasts_settings       = new ConvertKit_Settings_Broadcasts();
 
 		// Define configuration data to include in the export file.
 		$json = wp_json_encode(
 			array(
 				'settings'         => $settings->get(),
 				'restrict_content' => $restrict_content_settings->get(),
-				'broadcasts'	   => $broadcasts_settings->get(),
+				'broadcasts'       => $broadcasts_settings->get(),
 			)
 		);
 

--- a/admin/section/class-convertkit-admin-section-tools.php
+++ b/admin/section/class-convertkit-admin-section-tools.php
@@ -190,12 +190,14 @@ class ConvertKit_Admin_Section_Tools extends ConvertKit_Admin_Section_Base {
 		// Initialize classes that hold settings.
 		$settings                  = new ConvertKit_Settings();
 		$restrict_content_settings = new ConvertKit_Settings_Restrict_Content();
+		$broadcasts_settings 	   = new ConvertKit_Settings_Broadcasts();
 
 		// Define configuration data to include in the export file.
 		$json = wp_json_encode(
 			array(
 				'settings'         => $settings->get(),
 				'restrict_content' => $restrict_content_settings->get(),
+				'broadcasts'	   => $broadcasts_settings->get(),
 			)
 		);
 
@@ -259,6 +261,12 @@ class ConvertKit_Admin_Section_Tools extends ConvertKit_Admin_Section_Base {
 		if ( array_key_exists( 'restrict_content', $import ) ) {
 			$restrict_content_settings = new ConvertKit_Settings_Restrict_Content();
 			update_option( $restrict_content_settings::SETTINGS_NAME, $import['restrict_content'] );
+		}
+
+		// Import: Broadcasts Settings.
+		if ( array_key_exists( 'broadcasts', $import ) ) {
+			$broadcasts_settings = new ConvertKit_Settings_Broadcasts();
+			update_option( $broadcasts_settings::SETTINGS_NAME, $import['broadcasts'] );
 		}
 
 		// Redirect to Tools screen.

--- a/tests/_support/Helper/Acceptance/KitRestrictContent.php
+++ b/tests/_support/Helper/Acceptance/KitRestrictContent.php
@@ -96,6 +96,7 @@ class KitRestrictContent extends \Codeception\Module
 		foreach ( $settings as $key => $value ) {
 			switch ( $key ) {
 				case 'permit_crawlers':
+				case 'require_tag_login':
 					if ( $value ) {
 						$I->seeCheckboxIsChecked('_wp_convertkit_settings_restrict_content[' . $key . ']');
 					} else {

--- a/tests/_support/Helper/Acceptance/KitRestrictContent.php
+++ b/tests/_support/Helper/Acceptance/KitRestrictContent.php
@@ -71,6 +71,7 @@ class KitRestrictContent extends \Codeception\Module
 			'subscribe_heading_tag'   => 'Subscribe to keep reading',
 			'subscribe_text_tag'      => 'This post is free to read but only available to subscribers. Join today to get access to all posts.',
 			'no_access_text_tag'      => 'Your account does not have access to this content. Please use the form above to subscribe.',
+			'require_tag_login'       => '',
 
 			// All.
 			'subscribe_button_label'  => 'Subscribe',


### PR DESCRIPTION
## Summary

Includes broadcast settings in the export JSON file generated at `Settings > Kit > Tools`, and imports those settings when a JSON export file is used.

## Testing

- `testExportAndImportValidConfiguration`: Updated to include testing broadcast settings are exported and imported, and directly checks the database table on import for quicker test time.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)