### PR TITLE
Broadcasts to Posts: Add CSS class to 'body' tag

### DIFF
--- a/includes/class-convertkit-output-broadcasts.php
+++ b/includes/class-convertkit-output-broadcasts.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * ConvertKit Output Broadcasts class.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Applies a body CSS class to Posts, Pages and Custom Posts
+ * that were imported from Kit's Broadcasts, to allow
+ * CSS to target common themes that may override some
+ * broadcast styling.
+ *
+ * @since   2.7.4
+ */
+class ConvertKit_Output_Broadcasts {
+
+	/**
+	 * Constructor.
+	 *
+	 * @since   2.7.4
+	 */
+	public function __construct() {
+
+		add_filter( 'body_class', array( $this, 'maybe_add_body_class' ) );
+
+	}
+
+	/**
+	 * Adds a .convertkit-broadcast CSS class to Posts, Pages and Custom Posts
+	 * <body> tag where the content was imported from a Kit Broadcast.
+	 *
+	 * @since   2.7.4
+	 *
+	 * @param   array $css_classes    CSS classes for body tag.
+	 * @return  array
+	 */
+	public function maybe_add_body_class( $css_classes ) {
+
+		// Don't add a CSS class if the request isn't for an imported Broadcast.
+		if ( ! is_singular() ) {
+			return $css_classes;
+		}
+
+		if ( empty( get_post_meta( get_the_ID(), '_convertkit_broadcast_id', true ) ) ) {
+			return $css_classes;
+		}
+
+		$css_classes[] = 'convertkit-broadcast';
+		return $css_classes;
+
+	}
+
+}

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -143,8 +143,9 @@ class WP_ConvertKit {
 			return;
 		}
 
-		$this->classes['cache_plugins'] = new ConvertKit_Cache_Plugins();
-		$this->classes['output']        = new ConvertKit_Output();
+		$this->classes['cache_plugins']     = new ConvertKit_Cache_Plugins();
+		$this->classes['output']            = new ConvertKit_Output();
+		$this->classes['output_broadcasts'] = new ConvertKit_Output_Broadcasts();
 
 		/**
 		 * Initialize integration classes for the frontend web site.

--- a/resources/frontend/css/broadcasts.css
+++ b/resources/frontend/css/broadcasts.css
@@ -146,3 +146,18 @@
 		margin-bottom: 30px;
 	}
 }
+
+/**
+ * Imported Broadcasts to Posts
+ * - Styles here are designed to override common themes that may interfere
+ * with an imported Kit Broadcast, such as Elementor.
+ */
+body.convertkit-broadcast.elementor-default table,
+body.convertkit-broadcast.elementor-default table tbody,
+body.convertkit-broadcast.elementor-default table tbody td {
+	border: none;
+}
+body.convertkit-broadcast.elementor-default table tbody>tr:nth-child(odd)>td,
+body.convertkit-broadcast.elementor-default table tbody>tr:nth-child(odd)>th {
+	background: none;
+}

--- a/tests/acceptance/broadcasts/import-export/BroadcastsToPostsCest.php
+++ b/tests/acceptance/broadcasts/import-export/BroadcastsToPostsCest.php
@@ -173,11 +173,17 @@ class BroadcastsToPostsCest
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
+		// Confirm a body CSS class is applied.
+		$I->seeElementInDOM('body.convertkit-broadcast');
+
 		// Set cookie with signed subscriber ID, as if we completed the Restrict Content authentication flow.
 		$I->setCookie('ck_subscriber_id', $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID']);
 
 		// Reload the post.
 		$I->reloadPage();
+
+		// Confirm a body CSS class is applied.
+		$I->seeElementInDOM('body.convertkit-broadcast');
 
 		// Confirm inline styles exist in the imported Broadcast.
 		$I->seeElementInDOM('div.ck-inner-section');
@@ -252,11 +258,17 @@ class BroadcastsToPostsCest
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
+		// Confirm a body CSS class is applied.
+		$I->seeElementInDOM('body.convertkit-broadcast');
+
 		// Set cookie with signed subscriber ID, as if we completed the Restrict Content authentication flow.
 		$I->setCookie('ck_subscriber_id', $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID']);
 
 		// Reload the post.
 		$I->reloadPage();
+
+		// Confirm a body CSS class is applied.
+		$I->seeElementInDOM('body.convertkit-broadcast');
 
 		// Confirm inline styles exist in the imported Broadcast.
 		$I->seeElementInDOM('div.ck-inner-section');
@@ -703,11 +715,17 @@ class BroadcastsToPostsCest
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
+		// Confirm a body CSS class is applied.
+		$I->seeElementInDOM('body.convertkit-broadcast');
+
 		// Set cookie with signed subscriber ID, as if we completed the Restrict Content authentication flow.
 		$I->setCookie('ck_subscriber_id', $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID']);
 
 		// Reload the post.
 		$I->reloadPage();
+
+		// Confirm a body CSS class is applied.
+		$I->seeElementInDOM('body.convertkit-broadcast');
 
 		// Confirm no inline styles exist in the imported Broadcast.
 		$I->dontSeeElementInDOM('div.ck-inner-section');

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -58,6 +58,7 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-cron.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-gutenberg.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-media-library.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-output.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-output-broadcasts.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-output-restrict-content.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-post.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-preview-output.php';


### PR DESCRIPTION
## Summary

Adds a CSS class to the `<body>` tag of WordPress Posts, Pages and Custom Posts that were created/imported using the Kit Plugin's Broadcasts to Posts functionality.

This allows us and creators to provide CSS to override styling from some common themes that interferes with broadcast content, such as Elementor ([reported here](https://linear.app/kit/issue/WP-29/wp-medium-styling-issues-with-imported-broadcasts)).

Original Broadcast:
![Screenshot 2025-02-24 at 14 34 35](https://github.com/user-attachments/assets/f5e820da-1b47-4939-a7fa-cfe79d69ee9c)

Before:
![image](https://github.com/user-attachments/assets/24f49e96-3a13-49f5-b910-21630a5c6a02)

After:
![Screenshot 2025-02-24 at 09 57 45](https://github.com/user-attachments/assets/2520b37c-0284-4c95-a3fb-9a3c37233269)

## Testing

- Updated existing tests to confirm CSS class is added to the body tag.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)