### PR TITLE
Member Content: Add `wordpress_ck_subscriber_id` cookie

### DIFF
--- a/includes/class-convertkit-subscriber.php
+++ b/includes/class-convertkit-subscriber.php
@@ -168,7 +168,8 @@ class ConvertKit_Subscriber {
 	}
 
 	/**
-	 * Stores the given subscriber ID in the `ck_subscriber_id` cookie.
+	 * Stores the given subscriber ID in the `ck_subscriber_id` cookie
+	 * and a prefixed `wordpress_ck_subscriber_id` cookie.
 	 *
 	 * @since   2.0.0
 	 *
@@ -177,6 +178,7 @@ class ConvertKit_Subscriber {
 	public function set( $subscriber_id ) {
 
 		setcookie( $this->key, (string) $subscriber_id, time() + ( 365 * DAY_IN_SECONDS ), '/' );
+		setcookie( 'wordpress_' . $this->key, (string) $subscriber_id, time() + ( 365 * DAY_IN_SECONDS ), '/' );
 
 	}
 
@@ -188,6 +190,7 @@ class ConvertKit_Subscriber {
 	public function forget() {
 
 		setcookie( $this->key, '', time() - ( 365 * DAY_IN_SECONDS ), '/' );
+		setcookie( 'wordpress_' . $this->key, '', time() - ( 365 * DAY_IN_SECONDS ), '/' );
 
 	}
 

--- a/tests/_support/Helper/Acceptance/KitRestrictContent.php
+++ b/tests/_support/Helper/Acceptance/KitRestrictContent.php
@@ -783,7 +783,7 @@ class KitRestrictContent extends \Codeception\Module
 		$options = $this->_getRestrictedContentOptionsWithDefaultsMerged($options);
 
 		// Clear any existing cookie from a previous test and reload.
-		$I->resetCookie('ck_subscriber_id');
+		$I->clearRestrictContentCookie($I);
 
 		// Navigate to the page.
 		if ( is_numeric( $urlOrPageID ) ) {

--- a/tests/_support/Helper/Acceptance/KitRestrictContent.php
+++ b/tests/_support/Helper/Acceptance/KitRestrictContent.php
@@ -926,8 +926,8 @@ class KitRestrictContent extends \Codeception\Module
 	 */
 	public function clearRestrictContentCookie($I)
 	{
-		$I->deleteCookie('ck_subscriber_id');
-		$I->deleteCookie('wordpress_ck_subscriber_id');
+		$I->resetCookie('ck_subscriber_id');
+		$I->resetCookie('wordpress_ck_subscriber_id');
 	}
 
 	/**

--- a/tests/_support/Helper/Acceptance/KitRestrictContent.php
+++ b/tests/_support/Helper/Acceptance/KitRestrictContent.php
@@ -894,12 +894,40 @@ class KitRestrictContent extends \Codeception\Module
 	 */
 	public function setRestrictContentCookieAndReload($I, $subscriberID, $urlOrPageID)
 	{
-		$I->setCookie('ck_subscriber_id', $subscriberID);
+		$I->setRestrictContentCookie($I, $subscriberID);
+
 		if ( is_numeric( $urlOrPageID ) ) {
 			$I->amOnPage('?p=' . $urlOrPageID . '&ck-cache-bust=' . microtime() );
 		} else {
 			$I->amOnUrl($urlOrPageID . '?ck-cache-bust=' . microtime() );
 		}
+	}
+
+	/**
+	 * Clear the restrict content cookie.
+	 *
+	 * @since   2.7.4
+	 *
+	 * @param   AcceptanceTester $I                  Tester.
+	 * @param   string|int       $subscriberID       Signed subscriber ID or subscriber ID.
+	 */
+	public function setRestrictContentCookie($I, $subscriberID)
+	{
+		$I->setCookie('ck_subscriber_id', $subscriberID);
+		$I->setCookie('wordpress_ck_subscriber_id', $subscriberID);
+	}
+
+	/**
+	 * Clear the restrict content cookie.
+	 *
+	 * @since   2.7.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function clearRestrictContentCookie($I)
+	{
+		$I->deleteCookie('ck_subscriber_id');
+		$I->deleteCookie('wordpress_ck_subscriber_id');
 	}
 
 	/**

--- a/tests/acceptance/broadcasts/import-export/BroadcastsToPostsCest.php
+++ b/tests/acceptance/broadcasts/import-export/BroadcastsToPostsCest.php
@@ -262,7 +262,7 @@ class BroadcastsToPostsCest
 		$I->seeElementInDOM('body.convertkit-broadcast');
 
 		// Set cookie with signed subscriber ID, as if we completed the Restrict Content authentication flow.
-		$I->setCookie('ck_subscriber_id', $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID']);
+		$I->setRestrictContentCookie($I, $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID']);
 
 		// Reload the post.
 		$I->reloadPage();
@@ -566,7 +566,7 @@ class BroadcastsToPostsCest
 		];
 
 		// Set cookie with signed subscriber ID, so Member Content broadcasts can be viewed.
-		$I->setCookie('ck_subscriber_id', $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID']);
+		$I->setRestrictContentCookie($I, $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID']);
 
 		// View the first post.
 		$I->amOnPage('?p=' . $postIDs[0]);
@@ -719,7 +719,7 @@ class BroadcastsToPostsCest
 		$I->seeElementInDOM('body.convertkit-broadcast');
 
 		// Set cookie with signed subscriber ID, as if we completed the Restrict Content authentication flow.
-		$I->setCookie('ck_subscriber_id', $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID']);
+		$I->setRestrictContentCookie($I, $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID']);
 
 		// Reload the post.
 		$I->reloadPage();

--- a/tests/acceptance/broadcasts/import-export/BroadcastsToPostsCest.php
+++ b/tests/acceptance/broadcasts/import-export/BroadcastsToPostsCest.php
@@ -177,7 +177,7 @@ class BroadcastsToPostsCest
 		$I->seeElementInDOM('body.convertkit-broadcast');
 
 		// Set cookie with signed subscriber ID, as if we completed the Restrict Content authentication flow.
-		$I->setCookie('ck_subscriber_id', $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID']);
+		$I->setRestrictContentCookie($I, $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID']);
 
 		// Reload the post.
 		$I->reloadPage();

--- a/tests/acceptance/general/SubscriberIDURLCest.php
+++ b/tests/acceptance/general/SubscriberIDURLCest.php
@@ -137,7 +137,7 @@ class SubscriberIDURLCest
 		);
 
 		// Set the ck_subscriber_id cookie.
-		$I->setCookie('ck_subscriber_id', $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']);
+		$I->setRestrictContentCookie($I, $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID']);
 
 		// Confirm that no query parameters does not append a separator/question mark.
 		$I->amOnPage('/kit-subscriber-id-url');
@@ -166,7 +166,7 @@ class SubscriberIDURLCest
 		);
 
 		// Set the ck_subscriber_id cookie.
-		$I->setCookie('ck_subscriber_id', $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']);
+		$I->setRestrictContentCookie($I, $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID']);
 
 		// Confirm that no query parameters does not append a separator/question mark.
 		$I->amOnPage('/kit-subscriber-id-url#hash');
@@ -187,7 +187,7 @@ class SubscriberIDURLCest
 	 */
 	public function _passed(AcceptanceTester $I)
 	{
-		$I->resetCookie('ck_subscriber_id');
+		$I->clearRestrictContentCookie($I);
 		$I->deactivateKitPlugin($I);
 		$I->resetKitPlugin($I);
 	}

--- a/tests/acceptance/restrict-content/general/RestrictContentCacheCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentCacheCest.php
@@ -22,7 +22,7 @@ class RestrictContentCacheCest
 
 		// Clear up any cache configuration files that might exist from previous tests.
 		$I->deleteWPCacheConfigFiles($I);
-		$I->resetCookie('ck_subscriber_id');
+		$I->clearRestrictContentCookie($I);
 	}
 
 	/**
@@ -316,7 +316,7 @@ class RestrictContentCacheCest
 	 */
 	public function _passed(AcceptanceTester $I)
 	{
-		$I->resetCookie('ck_subscriber_id');
+		$I->clearRestrictContentCookie($I);
 		$I->deactivateKitPlugin($I);
 		$I->resetKitPlugin($I);
 	}

--- a/tests/acceptance/restrict-content/general/RestrictContentFormCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentFormCest.php
@@ -219,7 +219,7 @@ class RestrictContentFormCest
 	 */
 	public function _passed(AcceptanceTester $I)
 	{
-		$I->resetCookie('ck_subscriber_id');
+		$I->clearRestrictContentCookie($I);
 		$I->deactivateKitPlugin($I);
 		$I->resetKitPlugin($I);
 	}

--- a/tests/acceptance/restrict-content/general/RestrictContentSetupCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentSetupCest.php
@@ -497,7 +497,7 @@ class RestrictContentSetupCest
 	public function _passed(AcceptanceTester $I)
 	{
 		// Clear cookies for next request.
-		$I->resetCookie('ck_subscriber_id');
+		$I->clearRestrictContentCookie($I);
 		$I->deactivateKitPlugin($I);
 		$I->resetKitPlugin($I);
 	}

--- a/tests/acceptance/restrict-content/general/RestrictContentTagCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentTagCest.php
@@ -446,7 +446,7 @@ class RestrictContentTagCest
 	 */
 	public function _passed(AcceptanceTester $I)
 	{
-		$I->resetCookie('ck_subscriber_id');
+		$I->clearRestrictContentCookie($I);
 		$I->deactivateKitPlugin($I);
 		$I->resetKitPlugin($I);
 	}

--- a/tests/acceptance/restrict-content/post-types/RestrictContentProductCPTCest.php
+++ b/tests/acceptance/restrict-content/post-types/RestrictContentProductCPTCest.php
@@ -317,7 +317,7 @@ class RestrictContentProductCPTCest
 		foreach ($postIDs as $postID) {
 			// Test Restrict Content functionality.
 			$I->testRestrictedContentByProductOnFrontend($I, $postID);
-			$I->resetCookie('ck_subscriber_id');
+			$I->clearRestrictContentCookie($I);
 		}
 	}
 
@@ -334,7 +334,7 @@ class RestrictContentProductCPTCest
 	{
 		$I->unregisterCustomPostType($I, 'article');
 		$I->unregisterCustomPostType($I, 'private');
-		$I->resetCookie('ck_subscriber_id');
+		$I->clearRestrictContentCookie($I);
 		$I->deactivateKitPlugin($I);
 		$I->resetKitPlugin($I);
 	}

--- a/tests/acceptance/restrict-content/post-types/RestrictContentProductPageCest.php
+++ b/tests/acceptance/restrict-content/post-types/RestrictContentProductPageCest.php
@@ -391,7 +391,7 @@ class RestrictContentProductPageCest
 		foreach ($pageIDs as $pageID) {
 			// Test Restrict Content functionality.
 			$I->testRestrictedContentByProductOnFrontend($I, $pageID);
-			$I->resetCookie('ck_subscriber_id');
+			$I->clearRestrictContentCookie($I);
 		}
 	}
 
@@ -406,7 +406,7 @@ class RestrictContentProductPageCest
 	 */
 	public function _passed(AcceptanceTester $I)
 	{
-		$I->resetCookie('ck_subscriber_id');
+		$I->clearRestrictContentCookie($I);
 		$I->deactivateThirdPartyPlugin($I, 'convertkit-actions-and-filters-tests');
 		$I->deactivateKitPlugin($I);
 		$I->resetKitPlugin($I);

--- a/tests/acceptance/restrict-content/post-types/RestrictContentProductPostCest.php
+++ b/tests/acceptance/restrict-content/post-types/RestrictContentProductPostCest.php
@@ -351,7 +351,7 @@ class RestrictContentProductPostCest
 		foreach ($postIDs as $postID) {
 			// Test Restrict Content functionality.
 			$I->testRestrictedContentByProductOnFrontend($I, $postID);
-			$I->resetCookie('ck_subscriber_id');
+			$I->clearRestrictContentCookie($I);
 		}
 	}
 
@@ -366,7 +366,7 @@ class RestrictContentProductPostCest
 	 */
 	public function _passed(AcceptanceTester $I)
 	{
-		$I->resetCookie('ck_subscriber_id');
+		$I->clearRestrictContentCookie($I);
 		$I->deactivateKitPlugin($I);
 		$I->resetKitPlugin($I);
 	}


### PR DESCRIPTION
## Summary

Creators using this plugin on WP Engine have reported that content remains cached when using the Member Content functionality, even after logging in as a Kit subscriber:
- [Issue WP-28: Member Content Access Issues on WP via Kit Plugin](https://linear.app/kit/issue/WP-28/wp-p3-member-content-access-issues-on-wp-via-kit-plugin)
- [Issue WP-21: Medium Member Content Not Unlocking for Subscribers](https://linear.app/kit/issue/WP-21/wp-medium-member-content-not-unlocking-when-a-subscriber-enters-their)

To address this, we’ve advised creators to exclude the `ck_subscriber_id cookie` from caching in WP Engine:
[WP Engine Custom Cache Exclusions](https://wpengine.com/support/cache/#Custom_Cache_Exclusions)

By default, however, WP Engine does not cache pages when a cookie starting with `wordpress_` is present:
[WP Engine Default Cache Exclusions](https://wpengine.com/support/cache/#Default_Cache_Exclusions)

This PR introduces a `wordpress_ck_subscriber_id` cookie in addition to `ck_subscriber_id`. Since WP Engine automatically excludes cookies prefixed with `wordpress_` from caching, this change ensures Member Content functions correctly without requiring manual configuration.

We continue to set and check `ck_subscriber_id` to maintain compatibility with third-party integrations. In the future, we may consider migrating fully to `wordpress_ck_subscriber_id`.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)