### PR TITLE
Append Form to Content: Check Post Type of main Post

### DIFF
--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -261,8 +261,15 @@ class ConvertKit_Output {
 			return $content;
 		}
 
-		// Get Post ID and ConvertKit Form ID for the Post.
+		// Get Post ID.
 		$post_id = get_the_ID();
+
+		// Bail if Post Type is not supported by Kit.
+		if ( ! in_array( get_post_type( $post_id ), convertkit_get_supported_post_types(), true ) ) {
+			return $content;
+		}
+
+		// Get Form ID for the Post.
 		$form_id = $this->get_post_form_id( $post_id );
 
 		/**


### PR DESCRIPTION
## Summary

This PR resolves [WP-31](https://linear.app/kit/issue/WP-31/wordpress-conflict-with-feast-plugin-possible-to-resolve-on-our-end), where third-party plugins using custom post types and the `the_content` filter inadvertently trigger the `append_form_to_content` method.

Previously, the existing `is_singular` check did not account for the actual post ID within the current filter context, causing the main post/page settings to be ignored.

This update ensures that the correct post ID is used, preserving expected behavior even when custom post types are involved.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)