### PR TITLE
Remove `load_plugin_textdomain`

### DIFF
--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -47,9 +47,6 @@ class WP_ConvertKit {
 		$this->initialize_frontend();
 		$this->initialize_global();
 
-		// Load language files.
-		add_action( 'init', array( $this, 'load_language_files' ) );
-
 	}
 
 	/**
@@ -363,20 +360,6 @@ class WP_ConvertKit {
 		}
 
 		return true;
-
-	}
-
-	/**
-	 * Loads the plugin's translated strings, if available.
-	 *
-	 * @since   1.0.0
-	 */
-	public function load_language_files() {
-
-		// If the .mo file for a given language is available in WP_LANG_DIR/convertkit
-		// i.e. it's available as a translation at https://translate.wordpress.org/projects/wp-plugins/convertkit/,
-		// it will be used instead of the .mo file in convertkit/languages.
-		load_plugin_textdomain( 'convertkit', false, 'convertkit/languages' );
 
 	}
 


### PR DESCRIPTION
## Summary

Removes the call to `load_plugin_textdomain`, as [it's not needed since WordPress 4.6](https://make.wordpress.org/core/2024/10/21/i18n-improvements-6-7/#Enhanced-support-for-only-using-PHP-translation-files):

> Reminder: if your plugin or theme is hosted on WordPress.org and is still using load_*_textdomain(), you can remove this call. Since WordPress 4.6, plugins and themes no longer need load_plugin_textdomain() or load_theme_textdomain(). WordPress automatically loads the translations for you when needed. If you still support older WordPress versions or do not host your plugin/theme on WordPress.org, move the function call to a later hook such as init.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)