### PR TITLE
Remove duplicate `array_key_exists` check for `convertkit_post_id`

### DIFF
--- a/includes/class-convertkit-output-restrict-content.php
+++ b/includes/class-convertkit-output-restrict-content.php
@@ -349,9 +349,6 @@ class ConvertKit_Output_Restrict_Content {
 		if ( ! array_key_exists( 'subscriber_code', $_REQUEST ) ) {
 			return;
 		}
-		if ( ! array_key_exists( 'convertkit_post_id', $_REQUEST ) ) {
-			return;
-		}
 
 		// If a nonce was specified, validate it now.
 		// It won't be provided if clicking the link in the magic link email.
@@ -367,7 +364,6 @@ class ConvertKit_Output_Restrict_Content {
 		}
 
 		// Store the token so it's included in the subscriber code form if verification fails.
-
 		$this->token = sanitize_text_field( wp_unslash( $_REQUEST['token'] ) );
 
 		// Store the post ID if this is an AJAX request.


### PR DESCRIPTION
## Summary

[PHPStan 2.1.10](https://github.com/phpstan/phpstan/releases/tag/2.1.10), released Sunday 23rd March, now correctly detects a duplicate `array_key_exists` check that isn't necessary, which is removed in this PR.

![Screenshot 2025-03-24 at 12 40 06](https://github.com/user-attachments/assets/9fce9450-e64a-4a24-8875-48d742aa22f8)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)