### PR TITLE
Exclude Default Forms (Site Wide) on Search and 404

### DIFF
--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -873,6 +873,11 @@ class ConvertKit_Output {
 	 */
 	public function output_scripts_footer() {
 
+		// Don't output scripts if the request is for a search page or 404.
+		if ( is_search() || is_404() ) {
+			return;
+		}
+
 		// Define array of scripts.
 		$scripts = array();
 

--- a/tests/EndToEnd/forms/general/NonInlineFormCest.php
+++ b/tests/EndToEnd/forms/general/NonInlineFormCest.php
@@ -60,6 +60,7 @@ class NonInlineFormCest
 		$I->havePostInDatabase(
 			[
 				'post_title'  => 'Kit: Default Non Inline Global',
+				'post_name'   => 'kit-default-non-inline-global',
 				'post_type'   => 'page',
 				'post_status' => 'publish',
 			]
@@ -78,6 +79,18 @@ class NonInlineFormCest
 		// Confirm that one Kit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
 		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_ID'] . '"]', 1);
+
+		// View a search page.
+		$I->amOnPage('/?s=test');
+
+		// Confirm that no Kit Form is output in the DOM.
+		$I->dontSeeElementInDOM('form[data-sv-form]');
+
+		// View a 404 page.
+		$I->amOnPage('/non-existent-page');
+
+		// Confirm that no Kit Form is output in the DOM.
+		$I->dontSeeElementInDOM('form[data-sv-form]');
 	}
 
 	/**
@@ -106,6 +119,7 @@ class NonInlineFormCest
 		$I->havePostInDatabase(
 			[
 				'post_title'  => 'Kit: Default Non Inline Global Forms',
+				'post_name'   => 'kit-default-non-inline-global-forms',
 				'post_type'   => 'page',
 				'post_status' => 'publish',
 			]
@@ -124,6 +138,18 @@ class NonInlineFormCest
 		// Confirm that two Kit Forms are output in the DOM.
 		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_ID'] . '"]', 1);
 		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '"]', 1);
+
+		// View a search page.
+		$I->amOnPage('/?s=test');
+
+		// Confirm that no Kit Form is output in the DOM.
+		$I->dontSeeElementInDOM('form[data-sv-form]');
+
+		// View a 404 page.
+		$I->amOnPage('/non-existent-page');
+
+		// Confirm that no Kit Form is output in the DOM.
+		$I->dontSeeElementInDOM('form[data-sv-form]');
 	}
 
 	/**

--- a/tests/EndToEnd/forms/general/NonInlineFormCest.php
+++ b/tests/EndToEnd/forms/general/NonInlineFormCest.php
@@ -678,6 +678,7 @@ class NonInlineFormCest
 		$I->havePostInDatabase(
 			[
 				'post_title'  => 'Kit: Default Non Inline Global Upgrade',
+				'post_name'   => 'kit-default-non-inline-global-upgrade',
 				'post_type'   => 'page',
 				'post_status' => 'publish',
 			]


### PR DESCRIPTION
## Summary

Excludes non-inline forms defined in the Plugin's  `Default Forms (Site Wide)` setting from displaying on Search and 404, as this [wasn't intended to happen](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263838646672?view=List).

## Testing

- Updated `NonInlineFormCest` to confirm non-inline site wide forms are not displayed on search and 404 screens.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)