### PR TITLE
Improve Gutenberg / Block Editor Detection

### DIFF
--- a/resources/backend/js/gutenberg-block-formatters.js
+++ b/resources/backend/js/gutenberg-block-formatters.js
@@ -11,7 +11,7 @@
 // This prevents JS errors if this script is accidentally enqueued on a non-
 // Gutenberg editor screen, or the Classic Editor Plugin is active.
 if ( typeof wp !== 'undefined' &&
-	typeof wp.blocks !== 'undefined' ) {
+	typeof wp.blockEditor !== 'undefined' ) {
 
 	// Register each ConvertKit formatter in Gutenberg.
 	for ( const formatter in convertkit_block_formatters ) {

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -11,7 +11,7 @@
 // This prevents JS errors if this script is accidentally enqueued on a non-
 // Gutenberg editor screen, or the Classic Editor Plugin is active.
 if ( typeof wp !== 'undefined' &&
-	typeof wp.blocks !== 'undefined' ) {
+	typeof wp.blockEditor !== 'undefined' ) {
 
 	// Register each ConvertKit Block in Gutenberg.
 	for ( const block in convertkit_blocks ) {

--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -211,7 +211,7 @@ function convertKitRefreshResources( button ) {
 function convertKitRefreshResourcesRemoveNotices() {
 
 	// If we're editing a Page, Post or Custom Post Type in Gutenberg, use wp.data.dispatch to remove the error.
-	if (typeof wp !== 'undefined' && typeof wp.blocks !== 'undefined') {
+	if (typeof wp !== 'undefined' && typeof wp.blockEditor !== 'undefined') {
 		// Gutenberg Editor.
 		wp.data.dispatch( 'core/notices' ).removeNotice( 'convertkit-error' );
 		return;
@@ -240,7 +240,7 @@ function convertKitRefreshResourcesOutputErrorNotice( message ) {
 	message = 'ConvertKit: ' + message;
 
 	// If we're editing a Page, Post or Custom Post Type in Gutenberg, use wp.data.dispatch to show the error.
-	if ( typeof wp !== 'undefined' && typeof wp.blocks !== 'undefined' ) {
+	if ( typeof wp !== 'undefined' && typeof wp.blockEditor !== 'undefined' ) {
 		// Gutenberg Editor.
 		wp.data.dispatch( 'core/notices' ).createErrorNotice( message, { id: 'convertkit-error' } );
 		return;


### PR DESCRIPTION
## Summary

Improves Gutenberg / block editor detection by checking if `wp.blockEditor` is undefined, instead of `wp.blocks`.

Page builders that don't use Gutenberg will typically result in `wp.blockEditor` being undefined, resulting in JS errors at present:

![Screenshot 2025-03-26 at 16 47 09](https://github.com/user-attachments/assets/b984fc99-340c-4370-b32d-681ba75338a1)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)