### PR TITLE
Member Content: Use subscriber ID for tagging

### DIFF
--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -137,6 +137,21 @@ class ConvertKit_Output {
 			'output'
 		);
 
+		// If the subscriber ID is not numeric, it's a signed subscriber ID, set
+		// when using the Member Content functionality.
+		// Fetch the underlying subscriber ID for the tag_subscriber() method.
+		if ( ! is_numeric( $this->subscriber_id ) ) {
+			$result = $api->profile( $this->subscriber_id );
+
+			// If an error occured, the subscriber ID is invalid.
+			if ( is_wp_error( $result ) ) {
+				return;
+			}
+
+			// Set the subscriber ID.
+			$this->subscriber_id = $result['id'];
+		}
+
 		// Tag subscriber.
 		$api->tag_subscriber( $this->post_settings->get_tag(), $this->subscriber_id );
 

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -137,8 +137,8 @@ class ConvertKit_Output {
 			'output'
 		);
 
-		// If the subscriber ID is not numeric, it's a signed subscriber ID, set
-		// when using the Member Content functionality.
+		// If the subscriber ID is not numeric, it's a cryptographically-signed subscriber ID, set
+		// when using the Member Content functionality by Kit's API.
 		// Fetch the underlying subscriber ID for the tag_subscriber() method.
 		if ( ! is_numeric( $this->subscriber_id ) ) {
 			$result = $api->profile( $this->subscriber_id );

--- a/tests/EndToEnd/restrict-content/post-types/RestrictContentProductCPTCest.php
+++ b/tests/EndToEnd/restrict-content/post-types/RestrictContentProductCPTCest.php
@@ -119,6 +119,46 @@ class RestrictContentProductCPTCest
 
 	/**
 	 * Test that restricting content by a Product specified in the CPT Settings works when
+	 * creating and viewing a new WordPress Page, and the "Add a Tag" CPT setting does
+	 * not result in a critical error due to the use of a signed subscriber ID.
+	 *
+	 * @since   2.7.7
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testRestrictContentByProductWithAddTag(EndToEndTester $I)
+	{
+		// Setup Kit Plugin, disabling JS.
+		$I->setupKitPluginDisableJS($I);
+
+		// Add a CPT using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'article', 'Kit: Article: Restrict Content: Product');
+
+		// Configure metabox's Restrict Content setting = Product name.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form'             => [ 'select2', 'None' ],
+				'tag'              => [ 'select2', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
+				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+			]
+		);
+
+		// Add blocks.
+		$I->addGutenbergParagraphBlock($I, 'Visible content.');
+		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
+
+		// Publish Article.
+		$url = $I->publishGutenbergPage($I);
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentByProductOnFrontend($I, $url);
+	}
+
+	/**
+	 * Test that restricting content by a Product specified in the CPT Settings works when
 	 * creating and viewing a new WordPress CPT, and that the WordPress generated CPT Excerpt
 	 * is displayed when no more tag exists.
 	 *

--- a/tests/EndToEnd/restrict-content/post-types/RestrictContentProductPageCest.php
+++ b/tests/EndToEnd/restrict-content/post-types/RestrictContentProductPageCest.php
@@ -93,6 +93,46 @@ class RestrictContentProductPageCest
 
 	/**
 	 * Test that restricting content by a Product specified in the Page Settings works when
+	 * creating and viewing a new WordPress Page, and the "Add a Tag" Page setting does
+	 * not result in a critical error due to the use of a signed subscriber ID.
+	 *
+	 * @since   2.7.7
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testRestrictContentByProductWithAddTag(EndToEndTester $I)
+	{
+		// Setup Kit Plugin, disabling JS.
+		$I->setupKitPluginDisableJS($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'Kit: Page: Restrict Content: Product');
+
+		// Configure metabox's Restrict Content setting = Product name.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form'             => [ 'select2', 'None' ],
+				'tag'              => [ 'select2', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
+				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+			]
+		);
+
+		// Add blocks.
+		$I->addGutenbergParagraphBlock($I, 'Visible content.');
+		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
+
+		// Publish Page.
+		$url = $I->publishGutenbergPage($I);
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentByProductOnFrontend($I, $url);
+	}
+
+	/**
+	 * Test that restricting content by a Product specified in the Page Settings works when
 	 * creating and viewing a new WordPress Page, and that the WordPress generated Page Excerpt
 	 * is displayed when no more tag exists.
 	 *

--- a/tests/EndToEnd/restrict-content/post-types/RestrictContentProductPostCest.php
+++ b/tests/EndToEnd/restrict-content/post-types/RestrictContentProductPostCest.php
@@ -93,6 +93,46 @@ class RestrictContentProductPostCest
 
 	/**
 	 * Test that restricting content by a Product specified in the Post Settings works when
+	 * creating and viewing a new WordPress Page, and the "Add a Tag" Post setting does
+	 * not result in a critical error due to the use of a signed subscriber ID.
+	 *
+	 * @since   2.7.7
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testRestrictContentByProductWithAddTag(EndToEndTester $I)
+	{
+		// Setup Kit Plugin, disabling JS.
+		$I->setupKitPluginDisableJS($I);
+
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'post', 'Kit: Post: Restrict Content: Product');
+
+		// Configure metabox's Restrict Content setting = Product name.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form'             => [ 'select2', 'None' ],
+				'tag'              => [ 'select2', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
+				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+			]
+		);
+
+		// Add blocks.
+		$I->addGutenbergParagraphBlock($I, 'Visible content.');
+		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
+
+		// Publish Post.
+		$url = $I->publishGutenbergPage($I);
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentByProductOnFrontend($I, $url);
+	}
+
+	/**
+	 * Test that restricting content by a Product specified in the Post Settings works when
 	 * creating and viewing a new WordPress Post, and that the WordPress generated Post Excerpt
 	 * is displayed when no more tag exists.
 	 *


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/mentions/conversation/12263838349736?view=List), where defining the `Add a Tag` setting on a Page that is also enabled for Member Content would result in a fatal error, due to the call to `tag_subscriber()` passing a signed subscriber ID, instead of the subscriber ID integer:

```
[25-Mar-2025 17:12:06 UTC] PHP Fatal error:  Uncaught TypeError: ConvertKit_API_V4::tag_subscriber(): Argument #2 ($subscriber_id) must be of type int, string given, called in /var/www/wp-content/plugins/convertkit/includes/class-convertkit-output.php on line 141 and defined in /var/www/wp-content/plugins/convertkit-for-woocommerce/vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-api-traits.php:622
Stack trace:
#0 /var/www/wp-content/plugins/convertkit/includes/class-convertkit-output.php(141): ConvertKit_API_V4->tag_subscriber(6266343, 'eyJfcmFpbHMiOns...')
#1 /var/www/wp-includes/class-wp-hook.php(324): ConvertKit_Output->maybe_tag_subscriber(Object(WP))
#2 /var/www/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#3 /var/www/wp-includes/plugin.php(565): WP_Hook->do_action(Array)
#4 /var/www/wp-includes/class-wp.php(830): do_action_ref_array('wp', Array)
#5 /var/www/wp-includes/functions.php(1336): WP->main('')
#6 /var/www/wp-blog-header.php(16): wp()
#7 /var/www/index.php(17): require('/var/www/wp-blo...')
#8 {main}
```

## Testing

- `testRestrictContentByProductWithAddTag`: Test that restricting content by a Product specified in the settings works when creating and viewing a new WordPress Page, and the "Add a Tag" setting does not result in a critical error due to the use of a signed subscriber ID.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)