### PR TITLE
Tests: Fix Jetpack Boost test failures

### DIFF
--- a/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormCest.php
+++ b/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormCest.php
@@ -699,6 +699,7 @@ class PageBlockFormCest
 		$I->setupKitPluginResources($I);
 
 		// Activate Jetpack Boost Plugin.
+		$I->activateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
 		$I->activateThirdPartyPlugin($I, 'jetpack-boost');
 
 		// Enable Jetpack Boost's "Defer Non-Essential JavaScript" setting.
@@ -737,6 +738,7 @@ class PageBlockFormCest
 
 		// Deactivate Jetpack Boost Plugin.
 		$I->deactivateThirdPartyPlugin($I, 'jetpack-boost');
+		$I->deactivateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
 	}
 
 	/**

--- a/tests/EndToEnd/forms/blocks-shortcodes/PageShortcodeFormCest.php
+++ b/tests/EndToEnd/forms/blocks-shortcodes/PageShortcodeFormCest.php
@@ -548,6 +548,7 @@ class PageShortcodeFormCest
 		$I->setupKitPluginResources($I);
 
 		// Activate Jetpack Boost Plugin.
+		$I->activateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
 		$I->activateThirdPartyPlugin($I, 'jetpack-boost');
 
 		// Enable Jetpack Boost's "Defer Non-Essential JavaScript" setting.
@@ -586,6 +587,7 @@ class PageShortcodeFormCest
 
 		// Deactivate Jetpack Boost Plugin.
 		$I->deactivateThirdPartyPlugin($I, 'jetpack-boost');
+		$I->deactivateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
 	}
 
 	/**

--- a/tests/EndToEnd/forms/post-types/PageFormCest.php
+++ b/tests/EndToEnd/forms/post-types/PageFormCest.php
@@ -590,6 +590,7 @@ class PageFormCest
 		$I->setupKitPluginResources($I);
 
 		// Activate Jetpack Boost Plugin.
+		$I->activateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
 		$I->activateThirdPartyPlugin($I, 'jetpack-boost');
 
 		// Enable Jetpack Boost's "Defer Non-Essential JavaScript" setting.
@@ -618,6 +619,7 @@ class PageFormCest
 
 		// Deactivate Jetpack Boost Plugin.
 		$I->deactivateThirdPartyPlugin($I, 'jetpack-boost');
+		$I->deactivateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

The Jetpack Boost Plugin's latest update loads translations incorrectly, resulting in a PHP warning, which causes tests to fail due to checks the tests perform:

![Tests EndToEnd PageBlockFormCest testFormBlockWithJetpackBoostPlugin fail](https://github.com/user-attachments/assets/f93331d4-b59a-49ad-a494-5c50ec134727)

This PR resolves by suppressing the specific PHP notice, using the same method in #747

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)