### PR TITLE
Restrict Content: Allow Themes to register own content filter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,8 @@ jobs:
       DB_PASS: root
       DB_HOST: localhost
       INSTALL_PLUGINS: "admin-menu-editor autoptimize beaver-builder-lite-version block-visibility contact-form-7 classic-editor custom-post-type-ui elementor forminator jetpack-boost woocommerce wordpress-seo wpforms-lite litespeed-cache wp-crontrol wp-super-cache w3-total-cache wp-fastest-cache wp-optimize sg-cachepress" # Don't include this repository's Plugin here.
-      INSTALL_PLUGINS_URLS: "https://downloads.wordpress.org/plugin/convertkit-for-woocommerce.1.6.4.zip http://cktestplugins.wpengine.com/wp-content/uploads/2024/01/convertkit-action-filter-tests.zip http://cktestplugins.wpengine.com/wp-content/uploads/2024/11/disable-doing-it-wrong-notices.zip" # URLs to specific third party Plugins
+      INSTALL_PLUGINS_URLS: "https://downloads.wordpress.org/plugin/convertkit-for-woocommerce.1.6.4.zip http://cktestplugins.wpengine.com/wp-content/uploads/2024/01/convertkit-action-filter-tests.zip http://cktestplugins.wpengine.com/wp-content/uploads/2024/11/disable-doing-it-wrong-notices.zip http://cktestplugins.wpengine.com/wp-content/uploads/2025/03/uncode-js_composer.7.8.zip http://cktestplugins.wpengine.com/wp-content/uploads/2025/03/uncode-core.zip" # URLs to specific third party Plugins
+      INSTALL_THEMES_URLS: "http://cktestplugins.wpengine.com/wp-content/uploads/2025/03/uncode.zip"
       CONVERTKIT_API_KEY: ${{ secrets.CONVERTKIT_API_KEY }} # ConvertKit API Key, stored in the repository's Settings > Secrets
       CONVERTKIT_API_SECRET: ${{ secrets.CONVERTKIT_API_SECRET }} # ConvertKit API Secret, stored in the repository's Settings > Secrets
       CONVERTKIT_API_KEY_NO_DATA: ${{ secrets.CONVERTKIT_API_KEY_NO_DATA }} # ConvertKit API Key for ConvertKit account with no data, stored in the repository's Settings > Secrets
@@ -59,21 +60,7 @@ jobs:
 
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
-          'EndToEnd/broadcasts/blocks-shortcodes',
-          'EndToEnd/broadcasts/import-export',
-          'EndToEnd/forms/blocks-shortcodes',
-          'EndToEnd/forms/general',
-          'EndToEnd/forms/post-types',
-          'EndToEnd/general/other',
-          'EndToEnd/general/plugin-screens',
-          'EndToEnd/integrations/other',
-          'EndToEnd/integrations/wlm',
-          'EndToEnd/integrations/woocommerce',
-          'EndToEnd/landing-pages',
-          'EndToEnd/products',
-          'EndToEnd/restrict-content/general',
           'EndToEnd/restrict-content/post-types',
-          'EndToEnd/tags'
         ]
 
     # Steps to install, configure and run tests
@@ -138,10 +125,15 @@ jobs:
         working-directory: ${{ env.ROOT_DIR }}
         run: wp-cli plugin install ${{ env.INSTALL_PLUGINS }}
 
-      # env.INSTALL_PLUGINS_URLS is a list of Plugin URLs, space separated, to install specific versions ot third party Plugins.
+      # env.INSTALL_PLUGINS_URLS is a list of Plugin URLs, space separated, to install specific versions of third party Plugins.
       - name: Install Free Third Party WordPress Specific Version Plugins
         working-directory: ${{ env.ROOT_DIR }}
         run: wp-cli plugin install ${{ env.INSTALL_PLUGINS_URLS }}
+
+      # env.INSTALL_THEMES_URLS is a list of Theme URLs, space separated, to install specific versions of third party Themes.
+      - name: Install Free Third Party WordPress Specific Version Themes
+        working-directory: ${{ env.ROOT_DIR }}
+        run: wp-cli theme install ${{ env.INSTALL_THEMES_URLS }}
 
       # These should be stored as a separated list of URLs in the repository Settings > Secrets > Repository Secret > CONVERTKIT_PAID_PLUGIN_URLS.
       # We cannot include the URLs in this file, as they're not Plugins we are permitted to distribute.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,21 @@ jobs:
 
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
+          'EndToEnd/broadcasts/blocks-shortcodes',
+          'EndToEnd/broadcasts/import-export',
+          'EndToEnd/forms/blocks-shortcodes',
+          'EndToEnd/forms/general',
+          'EndToEnd/forms/post-types',
+          'EndToEnd/general/other',
+          'EndToEnd/general/plugin-screens',
+          'EndToEnd/integrations/other',
+          'EndToEnd/integrations/wlm',
+          'EndToEnd/integrations/woocommerce',
+          'EndToEnd/landing-pages',
+          'EndToEnd/products',
+          'EndToEnd/restrict-content/general',
           'EndToEnd/restrict-content/post-types',
+          'EndToEnd/tags'
         ]
 
     # Steps to install, configure and run tests

--- a/includes/class-convertkit-output-restrict-content.php
+++ b/includes/class-convertkit-output-restrict-content.php
@@ -119,7 +119,7 @@ class ConvertKit_Output_Restrict_Content {
 
 		add_action( 'init', array( $this, 'maybe_run_subscriber_authentication' ), 1 );
 		add_action( 'wp', array( $this, 'maybe_run_subscriber_verification' ), 2 );
-		add_filter( 'the_content', array( $this, 'maybe_restrict_content' ) );
+		add_action( 'wp', array( $this, 'register_content_filter' ), 3 );
 		add_filter( 'get_previous_post_where', array( $this, 'maybe_change_previous_post_where_clause' ), 10, 5 );
 		add_filter( 'get_next_post_where', array( $this, 'maybe_change_next_post_where_clause' ), 10, 5 );
 		add_filter( 'get_previous_post_sort', array( $this, 'maybe_change_previous_next_post_order_by_clause' ), 10, 3 );
@@ -404,6 +404,33 @@ class ConvertKit_Output_Restrict_Content {
 		if ( ! wp_doing_ajax() ) {
 			$this->redirect();
 		}
+
+	}
+
+	/**
+	 * Registers the applicable content filter for maybe restricting content, depending
+	 * on the Theme or Page Builder used.
+	 *
+	 * @since   2.7.7
+	 */
+	public function register_content_filter() {
+
+		// Use the standard `the_content` filter, which works for most Themes
+		// and Page Builders.
+		add_filter( 'the_content', array( $this, 'maybe_restrict_content' ) );
+
+		// Fetch some information about the current Page.
+		$id = get_the_ID();
+
+		/**
+		 * Allow specific Themes and Page Builders to use a different filter
+		 * for Restrict Content functionality.
+		 *
+		 * @since   2.7.7
+		 *
+		 * @param   int $id    Current Page / Post ID.
+		 */
+		do_action( 'convertkit_restrict_content_register_content_filter', $id );
 
 	}
 

--- a/includes/class-convertkit-output-restrict-content.php
+++ b/includes/class-convertkit-output-restrict-content.php
@@ -427,10 +427,8 @@ class ConvertKit_Output_Restrict_Content {
 		 * for Restrict Content functionality.
 		 *
 		 * @since   2.7.7
-		 *
-		 * @param   int $id    Current Page / Post ID.
 		 */
-		do_action( 'convertkit_restrict_content_register_content_filter', $id );
+		do_action( 'convertkit_restrict_content_register_content_filter' );
 
 	}
 

--- a/includes/integrations/class-convertkit-uncode.php
+++ b/includes/integrations/class-convertkit-uncode.php
@@ -46,7 +46,7 @@ class ConvertKit_Uncode {
 		}
 
 		// Don't register a different filter if the Page is not using the Visual Composer Page Builder.
-		$the_content = uncode_get_the_content();
+		$the_content = uncode_get_the_content(); // @phpstan-ignore-line
 		if ( strpos( $the_content, '[vc_row' ) === false ) {
 			return;
 		}

--- a/includes/integrations/class-convertkit-uncode.php
+++ b/includes/integrations/class-convertkit-uncode.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * ConvertKit Uncode Theme Integration.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Adds compatibility with the Uncode theme by using
+ * Uncode's specific hooks for outputting Forms and
+ * Restrict Content functionality.
+ *
+ * @since   2.7.7
+ */
+class ConvertKit_Uncode {
+
+	/**
+	 * Constructor. Registers actions and filters to possibly limit output of a Page/Post/CPT's
+	 * content on the frontend site.
+	 *
+	 * @since   2.7.7
+	 */
+	public function __construct() {
+
+		add_action( 'convertkit_restrict_content_register_content_filter', array( $this, 'maybe_register_restrict_content_filter' ) );
+
+	}
+
+	/**
+	 * Registers the content filter if the Uncode theme is active
+	 * and the Page is using the Visual Composer Page Builder.
+	 *
+	 * @since   2.7.7
+	 *
+	 * @param   int $id  Page ID.
+	 */
+	public function maybe_register_restrict_content_filter( $id ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+
+		// Don't register a different filter if the Uncode theme is not active.
+		if ( ! function_exists( 'uncode_the_content' ) ) {
+			return;
+		}
+		if ( ! function_exists( 'vc_is_page_editable' ) ) {
+			return;
+		}
+
+		// Don't register a different filter if the Page is not using the Visual Composer Page Builder.
+		$the_content = uncode_get_the_content();
+		if ( strpos( $the_content, '[vc_row' ) === false ) {
+			return;
+		}
+
+		// If here, the Page is using the Visual Composer Page Builder, so we need to use a different content filter
+		// to correctly restrict content.
+		add_filter( 'uncode_the_content', array( WP_ConvertKit()->get_class( 'output_restrict_content' ), 'maybe_restrict_content' ) );
+		remove_filter( 'the_content', array( WP_ConvertKit()->get_class( 'output_restrict_content' ), 'maybe_restrict_content' ) );
+
+	}
+
+}
+
+new ConvertKit_Uncode();

--- a/includes/integrations/class-convertkit-uncode.php
+++ b/includes/integrations/class-convertkit-uncode.php
@@ -32,10 +32,8 @@ class ConvertKit_Uncode {
 	 * and the Page is using the Visual Composer Page Builder.
 	 *
 	 * @since   2.7.7
-	 *
-	 * @param   int $id  Page ID.
 	 */
-	public function maybe_register_restrict_content_filter( $id ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+	public function maybe_register_restrict_content_filter() {
 
 		// Don't register a different filter if the Uncode theme is not active.
 		if ( ! function_exists( 'uncode_the_content' ) ) {

--- a/tests/EndToEnd/restrict-content/post-types/RestrictContentProductActionHookCest.php
+++ b/tests/EndToEnd/restrict-content/post-types/RestrictContentProductActionHookCest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Tests\EndToEnd;
+
+use Tests\Support\EndToEndTester;
+
+/**
+ * Tests Restrict Content by Product functionality on WordPress Pages when
+ * using a third party Theme or Page Builder that the Kit Plugin supports
+ * by using the `convertkit_restrict_content_register_content_filter` hook.
+ *
+ * @since   2.7.7
+ */
+class RestrictContentProductActionHookCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   2.7.7
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function _before(EndToEndTester $I)
+	{
+		// Activate Kit plugin.
+		$I->activateKitPlugin($I);
+	}
+
+	/**
+	 * Test that restricting content by a Product specified in the Page Settings works when
+	 * creating and viewing a new WordPress Page using the Uncode theme with
+	 * the Visual Composer Page Builder.
+	 *
+	 * @since   2.7.7
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testRestrictContentByProductWithUncodeThemeAndVisualComposer(EndToEndTester $I)
+	{
+		// Setup Kit Plugin, disabling JS.
+		$I->setupKitPluginDisableJS($I);
+
+		// Activate Uncode theme and Plugins.
+		$I->useTheme('uncode');
+		$I->activateThirdPartyPlugin($I, 'uncode-core');
+		$I->activateThirdPartyPlugin($I, 'uncode-wpbakery-page-builder');
+
+		// Programmatically create a Page using the Visual Composer Page Builder.
+		$pageID = $I->havePostInDatabase(
+			[
+				'post_type'    => 'page',
+				'post_title'   => 'Kit: Page: Restrict Content: Product: Uncode Theme with Visual Composer',
+
+				// Emulate Visual Composer content.
+				'post_content' => '[vc_row][vc_column width="1/1"][vc_column_text uncode_shortcode_id="998876"]Member-only content.[/vc_column_text][/vc_column][/vc_row]',
+
+				// Don't display a Form on this Page, so we test against Restrict Content's Form.
+				'meta_input'   => [
+					'_wp_convertkit_post_meta' => [
+						'form'             => '0',
+						'landing_page'     => '',
+						'tag'              => '',
+						'restrict_content' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+					],
+					'_wpb_vc_js_status'        => 'true',
+				],
+			]
+		);
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentByProductOnFrontend(
+			$I,
+			$pageID,
+			[
+				'visible_content' => '',
+				'member_content'  => 'Member-only content.',
+			]
+		);
+
+		// Deactivate Uncode theme and Plugins.
+		$I->deactivateThirdPartyPlugin($I, 'uncode-wpbakery-page-builder');
+		$I->deactivateThirdPartyPlugin($I, 'uncode-core');
+		$I->useTheme('twentytwentyfive');
+	}
+
+	/**
+	 * Test that restricting content by a Product specified in the Page Settings works when
+	 * creating and viewing a new WordPress Page using the Uncode theme without
+	 * the Visual Composer Page Builder.
+	 *
+	 * @since   2.7.7
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testRestrictContentByProductWithUncodeTheme(EndToEndTester $I)
+	{
+		// Setup Kit Plugin, disabling JS.
+		$I->setupKitPluginDisableJS($I);
+
+		// Activate Uncode theme and Plugins.
+		$I->useTheme('uncode');
+		$I->activateThirdPartyPlugin($I, 'uncode-core');
+
+		// Programmatically create a Page using the Visual Composer Page Builder.
+		$pageID = $I->havePostInDatabase(
+			[
+				'post_type'    => 'page',
+				'post_title'   => 'Kit: Page: Restrict Content: Product: Uncode Theme without Visual Composer',
+
+				// Emulate non-Visual Composer content.
+				'post_content' => 'Member-only content.',
+
+				// Don't display a Form on this Page, so we test against Restrict Content's Form.
+				'meta_input'   => [
+					'_wp_convertkit_post_meta' => [
+						'form'             => '0',
+						'landing_page'     => '',
+						'tag'              => '',
+						'restrict_content' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+					],
+				],
+			]
+		);
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentByProductOnFrontend(
+			$I,
+			$pageID,
+			[
+				'visible_content' => '',
+				'member_content'  => 'Member-only content.',
+			]
+		);
+
+		// Deactivate Uncode theme and Plugins.
+		$I->deactivateThirdPartyPlugin($I, 'uncode-core');
+		$I->useTheme('twentytwentyfive');
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   2.7.7
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function _passed(EndToEndTester $I)
+	{
+		$I->clearRestrictContentCookie($I);
+		$I->deactivateKitPlugin($I);
+		$I->resetKitPlugin($I);
+	}
+}

--- a/tests/EndToEnd/restrict-content/post-types/RestrictContentProductPageCest.php
+++ b/tests/EndToEnd/restrict-content/post-types/RestrictContentProductPageCest.php
@@ -180,63 +180,6 @@ class RestrictContentProductPageCest
 	}
 
 	/**
-	 * Test that restricting content by a Product specified in the Page Settings works when
-	 * creating and viewing a new WordPress Page using the Uncode theme with and without
-	 * the Visual Composer Page Builder.
-	 *
-	 * @since   2.7.7
-	 *
-	 * @param   EndToEndTester $I  Tester.
-	 */
-	public function testRestrictContentByProductWithUncodeThemeAndVisualComposer(EndToEndTester $I)
-	{
-		// Setup Kit Plugin, disabling JS.
-		$I->setupKitPluginDisableJS($I);
-
-		// Activate Uncode theme and Plugins.
-		$I->useTheme('uncode');
-		$I->activateThirdPartyPlugin($I, 'uncode-core');
-		$I->activateThirdPartyPlugin($I, 'uncode-wpbakery-page-builder');
-
-		// Programmatically create a Page using the Visual Composer Page Builder.
-		$pageID = $I->havePostInDatabase(
-			[
-				'post_type'    => 'page',
-				'post_title'   => 'Kit: Page: Restrict Content: Product: Uncode Theme with Visual Composer',
-
-				// Emulate Visual Composer content.
-				'post_content' => '[vc_row][vc_column width="1/1"][vc_column_text uncode_shortcode_id="998876"]Member-only content.[/vc_column_text][/vc_column][/vc_row]',
-
-				// Don't display a Form on this Page, so we test against Restrict Content's Form.
-				'meta_input'   => [
-					'_wp_convertkit_post_meta' => [
-						'form'             => '0',
-						'landing_page'     => '',
-						'tag'              => '',
-						'restrict_content' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
-					],
-					'_wpb_vc_js_status'        => 'true',
-				],
-			]
-		);
-
-		// Test Restrict Content functionality.
-		$I->testRestrictedContentByProductOnFrontend(
-			$I,
-			$pageID,
-			[
-				'visible_content' => '',
-				'member_content'  => 'Member-only content.',
-			]
-		);
-
-		// Deactivate Uncode theme and Plugins.
-		$I->deactivateThirdPartyPlugin($I, 'uncode-wpbakery-page-builder');
-		$I->deactivateThirdPartyPlugin($I, 'uncode-core');
-		$I->useTheme('twentytwentyfive');
-	}
-
-	/**
 	 * Test that restricting content by a Product that does not exist does not output
 	 * a fatal error and instead displays all of the Page's content.
 	 *

--- a/tests/EndToEnd/restrict-content/post-types/RestrictContentProductPageCest.php
+++ b/tests/EndToEnd/restrict-content/post-types/RestrictContentProductPageCest.php
@@ -188,7 +188,7 @@ class RestrictContentProductPageCest
 	 *
 	 * @param   EndToEndTester $I  Tester.
 	 */
-	public function testRestrictContentByProductWithUncodeTheme(EndToEndTester $I)
+	public function testRestrictContentByProductWithUncodeThemeAndVisualComposer(EndToEndTester $I)
 	{
 		// Setup Kit Plugin, disabling JS.
 		$I->setupKitPluginDisableJS($I);

--- a/tests/EndToEnd/restrict-content/post-types/RestrictContentProductThirdPartyThemeOrPageBuilderCest.php
+++ b/tests/EndToEnd/restrict-content/post-types/RestrictContentProductThirdPartyThemeOrPageBuilderCest.php
@@ -11,7 +11,7 @@ use Tests\Support\EndToEndTester;
  *
  * @since   2.7.7
  */
-class RestrictContentProductActionHookCest
+class RestrictContentProductThirdPartyThemeOrPageBuilderCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.

--- a/tests/Support/Helper/KitRestrictContent.php
+++ b/tests/Support/Helper/KitRestrictContent.php
@@ -644,7 +644,10 @@ class KitRestrictContent extends \Codeception\Module
 		$I->seeInSource('<a href="' . $_ENV['CONVERTKIT_API_PRODUCT_URL'] . '" class="wp-block-button__link');
 
 		$I->see($options['settings']['email_text']);
-		$I->seeInSource('<input type="submit" class="wp-block-button__link wp-block-button__link" value="' . $options['settings']['email_button_label'] . '"');
+
+		// Some Themes may append a CSS class to the button, so we split assertions.
+		$I->seeInSource('<input type="submit" class="wp-block-button__link wp-block-button__link');
+		$I->seeInSource('value="' . $options['settings']['email_button_label'] . '"');
 		$I->seeInSource('<small>' . $options['settings']['email_description_text'] . '</small>');
 	}
 

--- a/tests/Support/Helper/ThirdPartyPlugin.php
+++ b/tests/Support/Helper/ThirdPartyPlugin.php
@@ -58,6 +58,12 @@ class ThirdPartyPlugin extends \Codeception\Module
 				// Go to the Plugins screen again.
 				$I->amOnPluginsPage();
 				break;
+
+			case 'uncode-wpbakery-page-builder':
+				// Go to the Plugins screen again.
+				$I->waitForElementVisible('body.toplevel_page_vc-general');
+				$I->amOnPluginsPage();
+				break;
 		}
 
 		// Wait for the Plugins page to load with the Plugin activated, to confirm it activated.

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -107,6 +107,9 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/elementor/class-co
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/forminator/class-convertkit-forminator.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/forminator/class-convertkit-forminator-settings.php';
 
+// Uncode Integration.
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/class-convertkit-uncode.php';
+
 // WishList Member Integration.
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/wishlist/class-convertkit-wishlist.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/wishlist/class-convertkit-wishlist-settings.php';


### PR DESCRIPTION
## Summary

Most Themes will run a Page / Post's content through WordPress' `the_content` filter, which the Kit Member Content functionality also uses to determine whether to display the gated login or not.

[Some Themes (such as Uncode) don't use this filter.](https://linear.app/kit/issue/WP-33/wp-p4-member-content-feature-not-working-with-uncode-theme) As a result, gated Page / Post content is incorrectly displayed.

This PR resolves by:
- adding the `convertkit_restrict_content_register_content_filter` action, allowing us to register Theme-specific logic for Member Content functionality,
- uses this new action when the Uncode theme is active

## Testing

- `RestrictContentProductThirdPartyThemeOrPageBuilderCest`:  Tests Restrict Content by Product functionality on WordPress Pages when using a third party Theme or Page Builder that the Kit Plugin supports, by using the `convertkit_restrict_content_register_content_filter` hook.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)