### PR TITLE
Restrict Content: Uncode Theme: Use `uncode_single_content_final_output` filter

### DIFF
--- a/includes/integrations/class-convertkit-uncode.php
+++ b/includes/integrations/class-convertkit-uncode.php
@@ -51,7 +51,7 @@ class ConvertKit_Uncode {
 
 		// If here, the Page is using the Visual Composer Page Builder, so we need to use a different content filter
 		// to correctly restrict content.
-		add_filter( 'uncode_the_content', array( WP_ConvertKit()->get_class( 'output_restrict_content' ), 'maybe_restrict_content' ) );
+		add_filter( 'uncode_single_content_final_output', array( WP_ConvertKit()->get_class( 'output_restrict_content' ), 'maybe_restrict_content' ) );
 		remove_filter( 'the_content', array( WP_ConvertKit()->get_class( 'output_restrict_content' ), 'maybe_restrict_content' ) );
 
 	}


### PR DESCRIPTION
## Summary

Following #804, the creator experienced duplicate Member Content gating on their Posts.
![image](https://github.com/user-attachments/assets/1706971f-8e05-4e5e-98b5-0fdc2f36a286)

Switching to using the `uncode_single_content_final_output` provides better results:

![Screenshot 2025-04-02 at 10 51 54](https://github.com/user-attachments/assets/9da9aaef-58bf-416e-a8cf-47930021c915)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)