### PR TITLE
Tests: Set WooCommerce Store in Live Mode

### DIFF
--- a/tests/EndToEnd/integrations/woocommerce/WooCommerceProductFormCest.php
+++ b/tests/EndToEnd/integrations/woocommerce/WooCommerceProductFormCest.php
@@ -23,6 +23,9 @@ class WooCommerceProductFormCest
 		$I->activateKitPlugin($I);
 		$I->activateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
 		$I->activateThirdPartyPlugin($I, 'woocommerce');
+
+		// Set Store in Live mode i.e. not in "Coming Soon" mode.
+		$I->haveOptionInDatabase( 'woocommerce_coming_soon', 'no' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

WooCommerce 9.8.0 introduces a PHP deprecated notice due to their own Plugin using a method they've deprecated"

![Screenshot 2025-04-10 at 15 46 38](https://github.com/user-attachments/assets/7e34b6fd-fa16-4004-9737-8e9f2e7afed7)

This PR resolves, ensuring tests pass, by setting the WooCommerce store in live mode, therefore bypassing the `is_store_page` check.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)