### PR TITLE
Use `add_filter` for `convertkit_admin_settings_register_sections`

### DIFF
--- a/admin/section/class-convertkit-admin-section-broadcasts.php
+++ b/admin/section/class-convertkit-admin-section-broadcasts.php
@@ -650,7 +650,7 @@ class ConvertKit_Admin_Section_Broadcasts extends ConvertKit_Admin_Section_Base 
 }
 
 // Bootstrap.
-add_action(
+add_filter(
 	'convertkit_admin_settings_register_sections',
 	function ( $sections ) {
 

--- a/admin/section/class-convertkit-admin-section-restrict-content.php
+++ b/admin/section/class-convertkit-admin-section-restrict-content.php
@@ -560,7 +560,7 @@ class ConvertKit_Admin_Section_Restrict_Content extends ConvertKit_Admin_Section
 }
 
 // Bootstrap.
-add_action(
+add_filter(
 	'convertkit_admin_settings_register_sections',
 	function ( $sections ) {
 


### PR DESCRIPTION
## Summary

`add_action` shouldn't be used when hooking on a filter that returns data (in this case, `convertkit_admin_settings_register_sections`).

There [isn't a coding standard sniff](https://github.com/WordPress/WordPress-Coding-Standards/issues/713) to detect correct usage, and functionality has worked because `add_action` passes the request to `add_filter` anyway.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)