### PR TITLE
Require all Plugin Files

### DIFF
--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -93,7 +93,33 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/pre-publish-actions/class-conve
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/pre-publish-actions/class-convertkit-pre-publish-action-broadcast-export.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/widgets/class-ck-widget-form.php';
 
+// Admin classes.
+require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-bulk-edit.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-quick-edit.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-cache-plugins.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-category.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-landing-page.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-notices.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-post.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-refresh-resources.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-restrict-content.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-settings.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-tinymce.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-user.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-setup-wizard.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-multi-value-field-table.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-base.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-broadcasts.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-general.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-oauth.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-restrict-content.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-tools.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/admin/setup-wizard/class-convertkit-admin-setup-wizard-landing-page.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php';
+
 // Contact Form 7 Integration.
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/contactform7/class-convertkit-contactform7-admin-section.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/contactform7/class-convertkit-contactform7.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/contactform7/class-convertkit-contactform7-settings.php';
 
@@ -104,6 +130,7 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/divi/class-convert
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/elementor/class-convertkit-elementor.php';
 
 // Forminator Integration.
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/forminator/class-convertkit-forminator-admin-section.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/forminator/class-convertkit-forminator.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/forminator/class-convertkit-forminator-settings.php';
 
@@ -111,53 +138,12 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/forminator/class-c
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/class-convertkit-uncode.php';
 
 // WishList Member Integration.
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/wishlist/class-convertkit-wishlist-admin-section.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/wishlist/class-convertkit-wishlist.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/wishlist/class-convertkit-wishlist-settings.php';
 
 // WooCommerce Integration.
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/woocommerce/class-convertkit-woocommerce-product-form.php';
-
-// Load files that are only used in the WordPress Administration interface.
-if ( is_admin() ) {
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-bulk-edit.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-quick-edit.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-cache-plugins.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-category.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-notices.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-post.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-refresh-resources.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-settings.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-tinymce.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-user.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-setup-wizard.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-multi-value-field-table.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-base.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-general.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-oauth.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-tools.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php';
-
-	// Contact Form 7 Integration.
-	require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/contactform7/class-convertkit-contactform7-admin-section.php';
-
-	// Forminator Integration.
-	require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/forminator/class-convertkit-forminator-admin-section.php';
-
-	// WishList Member Integration.
-	require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/wishlist/class-convertkit-wishlist-admin-section.php';
-
-	// Restrict Content Integration.
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-restrict-content.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-restrict-content.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php';
-
-	// Landing Page Integration.
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-landing-page.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/setup-wizard/class-convertkit-admin-setup-wizard-landing-page.php';
-
-	// Broadcasts Integration.
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-broadcasts.php';
-}
 
 // Register Plugin activation and deactivation functions.
 register_activation_hook( __FILE__, 'convertkit_plugin_activate' );


### PR DESCRIPTION
## Summary

Fixes these reported errors ([here](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/mentions/conversation/12263839025810?view=List) and [here](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263839057483?view=List)) in 2.7.8, where a fatal error occurs:

`An error of type E_ERROR was caused in line 79 of the file /home/customer/www/laurasteward.com/public_html/wp-content/plugins/convertkit/includes/class-wp-convertkit.php. Error message: Uncaught Error: Class "ConvertKit_Admin_Bulk_Edit" not found`

This is due to:
- both sites using SolidWP (previously iThemes Sync).  We had the same issue in Kit for WooCommerce in December 2022, which was fixed in [this PR](https://github.com/Kit/convertkit-woocommerce/pull/129),
- moving class initialization to WordPress' `init` hook in #803, to ensure translation strings are not loaded too early.

The error occurs on sites specifically using SolidWP (previously iThemes Sync), due to the following request life cycle:
1. `is_admin()` is false [here](https://github.com/Kit/convertkit-wordpress/blob/main/wp-convertkit.php#L121), therefore the Plugin does not include WordPress Admin specific PHP files,
2. The iThemes Sync Plugin (which listens for inbound requests from https://sync.ithemes.com/ for e.g. updating a Plugin) determines that this is a WordPress Admin request, changing `is_admin()` to `true`,
3. `is_admin()` is true [here](https://github.com/Kit/convertkit-wordpress/blob/main/includes/class-wp-convertkit.php#L79), because we deliberately initialize our Plugin classes using the `init` hook in 2.7.8, to ensure that translations load correctly (#803). Similarly, in the Kit for WooCommerce Plugin, we used the `woocommerce_init` hook
4. Classes, such as `ConvertKit_Admin_Bulk_Edit` fail to initialize because they weren't loaded in step 1

Including the WordPress Admin specific PHP files won't affect performance, as they are still only conditionally initialized in step 4.

## Testing

iThemes Sync is a remote service that connects WordPress sites that are web accessible and have the iThemes Sync plugin installed and authenticated.  It's not possible to write a test, because GitHub Actions spin up WordPress instances that are not web accessible.

Manual testing was performed, to confirm the change resolves.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)