### PR TITLE
Tests: Fix Delete Cron Test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
       DB_HOST: localhost
       INSTALL_PLUGINS: "admin-menu-editor autoptimize beaver-builder-lite-version block-visibility contact-form-7 classic-editor custom-post-type-ui elementor forminator jetpack-boost woocommerce wordpress-seo wpforms-lite litespeed-cache wp-crontrol wp-super-cache w3-total-cache wp-fastest-cache wp-optimize sg-cachepress" # Don't include this repository's Plugin here.
       INSTALL_PLUGINS_URLS: "https://downloads.wordpress.org/plugin/convertkit-for-woocommerce.1.6.4.zip http://cktestplugins.wpengine.com/wp-content/uploads/2024/01/convertkit-action-filter-tests.zip http://cktestplugins.wpengine.com/wp-content/uploads/2024/11/disable-doing-it-wrong-notices.zip http://cktestplugins.wpengine.com/wp-content/uploads/2025/03/uncode-js_composer.7.8.zip http://cktestplugins.wpengine.com/wp-content/uploads/2025/03/uncode-core.zip" # URLs to specific third party Plugins
-      INSTALL_THEMES_URLS: "http://cktestplugins.wpengine.com/wp-content/uploads/2025/03/uncode.zip"
+      INSTALL_THEMES_URLS: "http://cktestplugins.wpengine.com/wp-content/uploads/2025/03/uncode.zip http://cktestplugins.wpengine.com/wp-content/uploads/2025/04/Divi.zip"
       CONVERTKIT_API_KEY: ${{ secrets.CONVERTKIT_API_KEY }} # ConvertKit API Key, stored in the repository's Settings > Secrets
       CONVERTKIT_API_SECRET: ${{ secrets.CONVERTKIT_API_SECRET }} # ConvertKit API Secret, stored in the repository's Settings > Secrets
       CONVERTKIT_API_KEY_NO_DATA: ${{ secrets.CONVERTKIT_API_KEY_NO_DATA }} # ConvertKit API Key for ConvertKit account with no data, stored in the repository's Settings > Secrets
@@ -67,6 +67,8 @@ jobs:
           'EndToEnd/forms/post-types',
           'EndToEnd/general/other',
           'EndToEnd/general/plugin-screens',
+          'EndToEnd/integrations/divi-builder',
+          'EndToEnd/integrations/divi-theme',
           'EndToEnd/integrations/other',
           'EndToEnd/integrations/wlm',
           'EndToEnd/integrations/woocommerce',
@@ -166,9 +168,9 @@ jobs:
         run: mv /home/runner/work/convertkit-wordpress/convertkit-wordpress/convertkit ${{ env.PLUGIN_DIR }}
       
       # WP_DEBUG = true is required so all PHP errors are output and caught by tests (E_ALL).
-      # WP_DEBUG = false for Elementor and WishList Member tests, as WLM is not yet updated with WordPress 6.4 deprecated functions.
+      # WP_DEBUG = false for Divi, Elementor and WishList Member tests, as they throw PHP warnings, deprecations and notices.
       - name: Enable WP_DEBUG
-        if: ${{ matrix.test-groups != 'EndToEnd/integrations/wlm' && matrix.test-groups != 'EndToEnd/integrations/elementor' }}
+        if: ${{ matrix.test-groups != 'EndToEnd/integrations/wlm' && matrix.test-groups != 'EndToEnd/integrations/elementor' && matrix.test-groups != 'EndToEnd/integrations/divi' }}
         working-directory: ${{ env.ROOT_DIR }}
         run: |
           wp-cli config set WP_DEBUG true --raw

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -41,6 +41,9 @@ class WP_ConvertKit {
 	public function __construct() {
 
 		// Initialize classes that have hooks prior to the `init` hook.
+		// Divi Theme requires us to do this, although the Divi Builder Plugin works fine when loading
+		// our integration on `init`.
+		$this->classes['divi']    = new ConvertKit_Divi();
 		$this->classes['widgets'] = new ConvertKit_Widgets();
 
 		// Initialize Plugin classes on init, so the `_load_textdomain_just_in_time` warning isn't triggered.
@@ -187,7 +190,6 @@ class WP_ConvertKit {
 		$this->classes['pre_publish_action_broadcast_export'] = new ConvertKit_Pre_Publish_Action_Broadcast_Export();
 		$this->classes['broadcasts_exporter']                 = new ConvertKit_Broadcasts_Exporter();
 		$this->classes['broadcasts_importer']                 = new ConvertKit_Broadcasts_Importer();
-		$this->classes['divi']                                = new ConvertKit_Divi();
 		$this->classes['elementor']                           = new ConvertKit_Elementor();
 		$this->classes['gutenberg']                           = new ConvertKit_Gutenberg();
 		$this->classes['media_library']                       = new ConvertKit_Media_Library();

--- a/includes/integrations/divi/class-convertkit-divi-extension.php
+++ b/includes/integrations/divi/class-convertkit-divi-extension.php
@@ -54,13 +54,30 @@ class ConvertKit_Divi_Extension extends DiviExtension {
 		$this->plugin_dir     = CONVERTKIT_PLUGIN_PATH . '/includes/integrations/divi/';
 		$this->plugin_dir_url = CONVERTKIT_PLUGIN_URL . 'includes/integrations/divi/';
 
-		// Store any JS data that can be accessed by builder-bundle.min.js using window.ConvertkitDiviBuilderData.
+		// Divi Builder Plugin calls `divi_extensions_init` later, resulting in convertkit_get_blocks() containing data.
+		// Using `init` to populate _builder_js_data is too late, so we do this now.
 		$this->_builder_js_data = convertkit_get_blocks();
+
+		// Divi Theme calls `divi_extensions_init` earlier, resulting in convertkit_get_blocks() not containing any data.
+		// Using `init` to repopulate _builder_js_data resolves.
+		add_action( 'init', array( $this, 'init' ) );
 
 		// Call parent construct.
 		parent::__construct( $name, $args );
 
 	}
+
+	/**
+	 * Store any JS data that can be accessed by builder-bundle.min.js using window.ConvertkitDiviBuilderData.
+	 *
+	 * @since   2.8.0
+	 */
+	public function init() {
+
+		$this->_builder_js_data = convertkit_get_blocks();
+
+	}
+
 }
 
 new ConvertKit_Divi_Extension();

--- a/tests/EndToEnd/integrations/divi-builder/DiviPluginBroadcastsCest.php
+++ b/tests/EndToEnd/integrations/divi-builder/DiviPluginBroadcastsCest.php
@@ -5,11 +5,11 @@ namespace Tests\EndToEnd;
 use Tests\Support\EndToEndTester;
 
 /**
- * Tests for the Kit Broadcasts Divi Module.
+ * Tests for the Kit Broadcasts Divi Module using the Divi Builder Plugin.
  *
  * @since   2.5.7
  */
-class DiviBroadcastsCest
+class DiviPluginBroadcastsCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.

--- a/tests/EndToEnd/integrations/divi-builder/DiviPluginFormCest.php
+++ b/tests/EndToEnd/integrations/divi-builder/DiviPluginFormCest.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace Tests\EndToEnd;
+
+use Tests\Support\EndToEndTester;
+
+/**
+ * Tests for the Kit Form's Divi Module using the Divi Builder Plugin.
+ *
+ * @since   2.5.6
+ */
+class DiviPluginFormCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   2.5.6
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function _before(EndToEndTester $I)
+	{
+		$I->activateKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
+		$I->activateThirdPartyPlugin($I, 'divi-builder');
+	}
+
+	/**
+	 * Test the Form module works when a valid Form is selected
+	 * using Divi's backend editor.
+	 *
+	 * @since   2.5.6
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormModuleInBackendEditor(EndToEndTester $I)
+	{
+		// Setup Plugin, without defining default Forms.
+		$I->setupKitPluginNoDefaultForms($I);
+		$I->setupKitPluginResources($I);
+
+		// Create a Divi Page in the backend editor.
+		$I->createDiviPageInBackendEditor($I, 'Kit: Page: Form: Divi: Backend Editor');
+
+		// Insert the Form module.
+		$I->insertDiviRowWithModule(
+			$I,
+			'Kit Form',
+			'convertkit_form',
+			'form',
+			$_ENV['CONVERTKIT_API_FORM_ID']
+		);
+
+		// Save Divi module and view the page on the frontend site.
+		$I->saveDiviModuleInBackendEditorAndViewPage($I);
+
+		// Confirm that one Kit Form is output in the DOM.
+		// This confirms that there is only one script on the page for this form, which renders the form.
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
+
+		// Deactivate Classic Editor.
+		$I->deactivateThirdPartyPlugin($I, 'classic-editor');
+	}
+
+	/**
+	 * Test the Form module works when a valid Form is selected
+	 * using Divi's backend editor.
+	 *
+	 * @since   2.5.6
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormModuleInFrontendEditor(EndToEndTester $I)
+	{
+		// Setup Plugin, without defining default Forms.
+		$I->setupKitPluginNoDefaultForms($I);
+		$I->setupKitPluginResources($I);
+
+		// Create a Divi Page in the frontend editor.
+		$url = $I->createDiviPageInFrontendEditor($I, 'Kit: Page: Form: Divi: Frontend Editor');
+
+		// Insert the Form module.
+		$I->insertDiviRowWithModule(
+			$I,
+			'Kit Form',
+			'convertkit_form',
+			'form',
+			$_ENV['CONVERTKIT_API_FORM_ID']
+		);
+
+		// Save Divi module and view the page on the frontend site.
+		$I->saveDiviModuleInFrontendEditorAndViewPage($I, $url);
+
+		// Confirm that one Kit Form is output in the DOM.
+		// This confirms that there is only one script on the page for this form, which renders the form.
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
+	}
+
+	/**
+	 * Test the Form module displays the expected message when the Plugin has no credentials
+	 *
+	 * @since   2.5.7
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormModuleInFrontendEditorWhenNoCredentials(EndToEndTester $I)
+	{
+		// Create a Divi Page in the frontend editor.
+		$I->createDiviPageInFrontendEditor($I, 'Kit: Page: Form: Divi: Frontend: No Credentials', false);
+
+		// Insert the Form module.
+		$I->insertDiviRowWithModule(
+			$I,
+			'Kit Form',
+			'convertkit_form'
+		);
+
+		// Confirm the on screen message displays.
+		$I->seeInSource('Not connected to Kit');
+		$I->seeInSource('Connect your Kit account at Settings > Kit, and then refresh this page to select a form.');
+	}
+
+	/**
+	 * Test the Form module displays the expected message when the Kit account
+	 * has no forms.
+	 *
+	 * @since   2.5.7
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormModuleInFrontendEditorWhenNoForms(EndToEndTester $I)
+	{
+		// Setup Plugin.
+		$I->setupKitPluginCredentialsNoData($I);
+		$I->setupKitPluginResourcesNoData($I);
+
+		// Create a Divi Page in the frontend editor.
+		$I->createDiviPageInFrontendEditor($I, 'Kit: Page: Form: Divi: Frontend: No Forms');
+
+		// Insert the Form module.
+		$I->insertDiviRowWithModule(
+			$I,
+			'Kit Form',
+			'convertkit_form'
+		);
+
+		// Confirm the on screen message displays.
+		$I->seeInSource('No forms exist in Kit');
+		$I->seeInSource('Add a form to your Kit account, and then refresh this page to select a form.');
+	}
+
+	/**
+	 * Test the Form module works when a valid Legacy Form is selected.
+	 *
+	 * @since   2.5.6
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormModuleWithValidLegacyFormParameter(EndToEndTester $I)
+	{
+		// Setup Plugin with API Key and Secret, which is required for Legacy Forms to work.
+		$I->setupKitPlugin(
+			$I,
+			[
+				'api_key'      => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret'   => $_ENV['CONVERTKIT_API_SECRET'],
+				'post_form'    => '',
+				'page_form'    => '',
+				'product_form' => '',
+			]
+		);
+		$I->setupKitPluginResources($I);
+
+		// Create Page with Form module in Divi.
+		$pageID = $I->createPageWithDiviModuleProgrammatically(
+			$I,
+			'Kit: Legacy Form: Divi Module: Valid Form Param',
+			'convertkit_form',
+			'form',
+			$_ENV['CONVERTKIT_API_LEGACY_FORM_ID']
+		);
+
+		// Load Page.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Kit Form is displayed.
+		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.kit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
+	}
+
+	/**
+	 * Test the Form module works when no Form is selected.
+	 *
+	 * @since   2.5.6
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormModuleWithNoFormParameter(EndToEndTester $I)
+	{
+		// Setup Plugin, without defining default Forms.
+		$I->setupKitPluginNoDefaultForms($I);
+		$I->setupKitPluginResources($I);
+
+		// Create Page with Form module in Divi.
+		$pageID = $I->createPageWithDiviModuleProgrammatically(
+			$I,
+			'Kit: Legacy Form: Divi Module: No Form Param',
+			'convertkit_form',
+			'form',
+			''
+		);
+
+		// Load Page.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that no Kit Form is displayed.
+		$I->dontSeeElementInDOM('form[data-sv-form]');
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   2.5.6
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function _passed(EndToEndTester $I)
+	{
+		$I->deactivateThirdPartyPlugin($I, 'divi-builder');
+		$I->deactivateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
+		$I->deactivateKitPlugin($I);
+		$I->resetKitPlugin($I);
+	}
+}

--- a/tests/EndToEnd/integrations/divi-builder/DiviPluginFormTriggerCest.php
+++ b/tests/EndToEnd/integrations/divi-builder/DiviPluginFormTriggerCest.php
@@ -5,11 +5,11 @@ namespace Tests\EndToEnd;
 use Tests\Support\EndToEndTester;
 
 /**
- * Tests for the Kit Form's Divi Module.
+ * Tests for the Kit Form's Divi Module using the Divi Builder Plugin.
  *
  * @since   2.5.7
  */
-class DiviFormTriggerCest
+class DiviPluginFormTriggerCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.

--- a/tests/EndToEnd/integrations/divi-builder/DiviPluginProductCest.php
+++ b/tests/EndToEnd/integrations/divi-builder/DiviPluginProductCest.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Tests\EndToEnd;
+
+use Tests\Support\EndToEndTester;
+
+/**
+ * Tests for the Kit Product's Divi Module using the Divi Builder Plugin.
+ *
+ * @since   2.5.7
+ */
+class DiviPluginProductCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   2.5.7
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function _before(EndToEndTester $I)
+	{
+		$I->activateKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
+		$I->activateThirdPartyPlugin($I, 'divi-builder');
+	}
+
+	/**
+	 * Test the Product module works when a valid Product is selected
+	 * using Divi's backend editor.
+	 *
+	 * @since   2.5.7
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testProductModuleInBackendEditor(EndToEndTester $I)
+	{
+		// Setup Plugin, without defining default Forms.
+		$I->setupKitPluginNoDefaultForms($I);
+		$I->setupKitPluginResources($I);
+
+		// Create a Divi Page in the backend editor.
+		$I->createDiviPageInBackendEditor($I, 'Kit: Page: Product: Divi: Backend Editor');
+
+		// Insert the Product module.
+		$I->insertDiviRowWithModule(
+			$I,
+			'Kit Product',
+			'convertkit_product',
+			'product',
+			$_ENV['CONVERTKIT_API_PRODUCT_ID']
+		);
+
+		// Save Divi module and view the page on the frontend site.
+		$I->saveDiviModuleInBackendEditorAndViewPage($I);
+
+		// Confirm that the module displays.
+		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
+
+		// Deactivate Classic Editor.
+		$I->deactivateThirdPartyPlugin($I, 'classic-editor');
+	}
+
+	/**
+	 * Test the Product module works when a valid Product is selected
+	 * using Divi's backend editor.
+	 *
+	 * @since   2.5.7
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testProductModuleInFrontendEditor(EndToEndTester $I)
+	{
+		// Setup Plugin, without defining default Forms.
+		$I->setupKitPluginNoDefaultForms($I);
+		$I->setupKitPluginResources($I);
+
+		// Create a Divi Page in the frontend editor.
+		$url = $I->createDiviPageInFrontendEditor($I, 'Kit: Page: Product: Divi: Frontend Editor');
+
+		// Insert the Product module.
+		$I->insertDiviRowWithModule(
+			$I,
+			'Kit Product',
+			'convertkit_product',
+			'product',
+			$_ENV['CONVERTKIT_API_PRODUCT_ID']
+		);
+
+		// Save Divi module and view the page on the frontend site.
+		$I->saveDiviModuleInFrontendEditorAndViewPage($I, $url);
+
+		// Confirm that the module displays.
+		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
+	}
+
+	/**
+	 * Test the Product module displays the expected message when the Plugin has no credentials
+	 *
+	 * @since   2.5.7
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testProductModuleInFrontendEditorWhenNoCredentials(EndToEndTester $I)
+	{
+		// Create a Divi Page in the frontend editor.
+		$I->createDiviPageInFrontendEditor($I, 'Kit: Page: Product: Divi: Frontend: No Credentials', false);
+
+		// Insert the Product module.
+		$I->insertDiviRowWithModule(
+			$I,
+			'Kit Product',
+			'convertkit_product'
+		);
+
+		// Confirm the on screen message displays.
+		$I->seeInSource('Not connected to Kit');
+		$I->seeInSource('Connect your Kit account at Settings > Kit, and then refresh this page to select a product.');
+	}
+
+	/**
+	 * Test the Product module displays the expected message when the Kit account
+	 * has no products.
+	 *
+	 * @since   2.5.7
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testProductModuleInFrontendEditorWhenNoProducts(EndToEndTester $I)
+	{
+		// Setup Plugin.
+		$I->setupKitPluginCredentialsNoData($I);
+		$I->setupKitPluginResourcesNoData($I);
+
+		// Create a Divi Page in the frontend editor.
+		$I->createDiviPageInFrontendEditor($I, 'Kit: Page: Product: Divi: Product: No Products');
+
+		// Insert the Product module.
+		$I->insertDiviRowWithModule(
+			$I,
+			'Kit Product',
+			'convertkit_product'
+		);
+
+		// Confirm the on screen message displays.
+		$I->seeInSource('No products exist in Kit');
+		$I->seeInSource('Add a product to your Kit account, and then refresh this page to select a product.');
+	}
+
+	/**
+	 * Test the Product module works when no Product is selected.
+	 *
+	 * @since   2.5.7
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testProductModuleWithNoProductParameter(EndToEndTester $I)
+	{
+		// Setup Plugin, without defining default Forms.
+		$I->setupKitPluginNoDefaultForms($I);
+		$I->setupKitPluginResources($I);
+
+		// Create Page with Product module in Divi.
+		$pageID = $I->createPageWithDiviModuleProgrammatically(
+			$I,
+			'Kit: Product: Divi Module: No Product Param',
+			'convertkit_product',
+			'product',
+			''
+		);
+
+		// Load Page.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that no Kit Product is displayed.
+		$I->dontSeeProductOutput($I);
+	}
+
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   2.5.7
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function _passed(EndToEndTester $I)
+	{
+		$I->deactivateThirdPartyPlugin($I, 'divi-builder');
+		$I->deactivateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
+		$I->deactivateKitPlugin($I);
+		$I->resetKitPlugin($I);
+	}
+}

--- a/tests/EndToEnd/integrations/divi-theme/DiviThemeBroadcastsCest.php
+++ b/tests/EndToEnd/integrations/divi-theme/DiviThemeBroadcastsCest.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Tests\EndToEnd;
+
+use Tests\Support\EndToEndTester;
+
+/**
+ * Tests for the Kit Broadcasts Divi Module using the Divi Theme.
+ *
+ * @since   2.8.0
+ */
+class DiviThemeBroadcastsCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   2.8.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function _before(EndToEndTester $I)
+	{
+		$I->activateKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
+		$I->useTheme('Divi');
+	}
+
+	/**
+	 * Test the Broadcasts module works when added
+	 * using Divi's backend editor.
+	 *
+	 * @since   2.8.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testBroadcastsModuleInBackendEditor(EndToEndTester $I)
+	{
+		// Setup Plugin, without defining default Forms.
+		$I->setupKitPluginNoDefaultForms($I);
+		$I->setupKitPluginResources($I);
+
+		$I->amOnAdminPage('themes.php');
+
+		// Create a Divi Page in the backend editor.
+		$I->createDiviPageInBackendEditor($I, 'Kit: Page: Broadcasts: Divi: Backend Editor');
+
+		// Insert the Broadcasts module.
+		$I->insertDiviRowWithModule(
+			$I,
+			'Kit Broadcasts',
+			'convertkit_broadcasts'
+		);
+
+		// Save Divi module and view the page on the frontend site.
+		$I->saveDiviModuleInBackendEditorAndViewPage($I);
+
+		// Confirm that the block displays.
+		$I->seeBroadcastsOutput($I);
+
+		// Confirm that the default date format is as expected.
+		$I->seeInSource('<time datetime="' . date( 'Y-m-d', strtotime( $_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE'] ) ) . '">' . date( 'F j, Y', strtotime( $_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE'] ) ) . '</time>');
+
+		// Confirm that the default expected number of Broadcasts are displayed.
+		$I->seeNumberOfElements('li.convertkit-broadcast', [ 1, 10 ]);
+
+		// Confirm that the expected Broadcast name is displayed first links to the expected URL, with UTM parameters.
+		$I->assertEquals(
+			$I->grabAttributeFrom('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast:nth-child(2) a', 'href'),
+			$_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&utm_term=en_US&utm_content=convertkit'
+		);
+
+		// Deactivate Classic Editor.
+		$I->deactivateThirdPartyPlugin($I, 'classic-editor');
+	}
+
+	/**
+	 * Test the Broadcasts module works when added
+	 * using Divi's frontend editor.
+	 *
+	 * @since   2.8.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testBroadcastsModuleInFrontendEditor(EndToEndTester $I)
+	{
+		// Setup Plugin, without defining default Forms.
+		$I->setupKitPluginNoDefaultForms($I);
+		$I->setupKitPluginResources($I);
+
+		// Create a Divi Page in the frontend editor.
+		$url = $I->createDiviPageInFrontendEditor($I, 'Kit: Page: Broadcasts: Divi: Frontend Editor');
+
+		// Insert the Broadcasts module.
+		$I->insertDiviRowWithModule(
+			$I,
+			'Kit Broadcasts',
+			'convertkit_broadcasts'
+		);
+
+		// Save Divi module and view the page on the frontend site.
+		$I->saveDiviModuleInFrontendEditorAndViewPage($I, $url);
+
+		// Confirm that the block displays.
+		$I->seeBroadcastsOutput($I);
+
+		// Confirm that the default date format is as expected.
+		$I->seeInSource('<time datetime="' . date( 'Y-m-d', strtotime( $_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE'] ) ) . '">' . date( 'F j, Y', strtotime( $_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE'] ) ) . '</time>');
+
+		// Confirm that the default expected number of Broadcasts are displayed.
+		$I->seeNumberOfElements('li.convertkit-broadcast', [ 1, 10 ]);
+
+		// Confirm that the expected Broadcast name is displayed first links to the expected URL, with UTM parameters.
+		$I->assertEquals(
+			$I->grabAttributeFrom('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast:nth-child(2) a', 'href'),
+			$_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&utm_term=en_US&utm_content=convertkit'
+		);
+	}
+
+	/**
+	 * Test the Broadcasts module displays the expected message when the Plugin has no credentials
+	 *
+	 * @since   2.8.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testBroadcastsModuleInFrontendEditorWhenNoCredentials(EndToEndTester $I)
+	{
+		// Create a Divi Page in the frontend editor.
+		$I->createDiviPageInFrontendEditor($I, 'Kit: Page: Broadcasts: Divi: Frontend: No Credentials', false);
+
+		// Insert the Broadcasts module.
+		$I->insertDiviRowWithModule(
+			$I,
+			'Kit Broadcasts',
+			'convertkit_broadcasts'
+		);
+
+		// Confirm the on screen message displays.
+		$I->seeInSource('Not connected to Kit');
+		$I->seeInSource('Connect your Kit account at Settings > Kit, and then refresh this page to configure broadcasts to display.');
+	}
+
+	/**
+	 * Test the Broadcasts module displays the expected message when the Kit account
+	 * has no broadcasts.
+	 *
+	 * @since   2.8.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testBroadcastsModuleInFrontendEditorWhenNoBroadcasts(EndToEndTester $I)
+	{
+		// Setup Plugin.
+		$I->setupKitPluginCredentialsNoData($I);
+		$I->setupKitPluginResourcesNoData($I);
+
+		// Create a Divi Page in the frontend editor.
+		$I->createDiviPageInFrontendEditor($I, 'Kit: Page: Broadcasts: Divi: Frontend: No Broadcasts');
+
+		// Insert the Broadcasts module.
+		$I->insertDiviRowWithModule(
+			$I,
+			'Kit Broadcasts',
+			'convertkit_broadcasts'
+		);
+
+		// Confirm the on screen message displays.
+		$I->seeInSource('No broadcasts exist in Kit');
+		$I->seeInSource('Add a broadcast to your Kit account, and then refresh this page to configure broadcasts to display.');
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   2.8.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function _passed(EndToEndTester $I)
+	{
+		$I->useTheme('twentytwentytwo');
+		$I->deactivateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
+		$I->deactivateKitPlugin($I);
+		$I->resetKitPlugin($I);
+	}
+}

--- a/tests/EndToEnd/integrations/divi-theme/DiviThemeFormCest.php
+++ b/tests/EndToEnd/integrations/divi-theme/DiviThemeFormCest.php
@@ -5,16 +5,16 @@ namespace Tests\EndToEnd;
 use Tests\Support\EndToEndTester;
 
 /**
- * Tests for the Kit Form's Divi Module.
+ * Tests for the Kit Form's Divi Module using the Divi Theme.
  *
- * @since   2.5.6
+ * @since   2.8.0
  */
-class DiviFormCest
+class DiviThemeFormCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
 	 *
-	 * @since   2.5.6
+	 * @since   2.8.0
 	 *
 	 * @param   EndToEndTester $I  Tester.
 	 */
@@ -22,14 +22,14 @@ class DiviFormCest
 	{
 		$I->activateKitPlugin($I);
 		$I->activateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
-		$I->activateThirdPartyPlugin($I, 'divi-builder');
+		$I->useTheme('Divi');
 	}
 
 	/**
 	 * Test the Form module works when a valid Form is selected
 	 * using Divi's backend editor.
 	 *
-	 * @since   2.5.6
+	 * @since   2.8.0
 	 *
 	 * @param   EndToEndTester $I  Tester.
 	 */
@@ -66,7 +66,7 @@ class DiviFormCest
 	 * Test the Form module works when a valid Form is selected
 	 * using Divi's backend editor.
 	 *
-	 * @since   2.5.6
+	 * @since   2.8.0
 	 *
 	 * @param   EndToEndTester $I  Tester.
 	 */
@@ -99,7 +99,7 @@ class DiviFormCest
 	/**
 	 * Test the Form module displays the expected message when the Plugin has no credentials
 	 *
-	 * @since   2.5.7
+	 * @since   2.8.0
 	 *
 	 * @param   EndToEndTester $I  Tester.
 	 */
@@ -124,7 +124,7 @@ class DiviFormCest
 	 * Test the Form module displays the expected message when the Kit account
 	 * has no forms.
 	 *
-	 * @since   2.5.7
+	 * @since   2.8.0
 	 *
 	 * @param   EndToEndTester $I  Tester.
 	 */
@@ -152,7 +152,7 @@ class DiviFormCest
 	/**
 	 * Test the Form module works when a valid Legacy Form is selected.
 	 *
-	 * @since   2.5.6
+	 * @since   2.8.0
 	 *
 	 * @param   EndToEndTester $I  Tester.
 	 */
@@ -193,7 +193,7 @@ class DiviFormCest
 	/**
 	 * Test the Form module works when no Form is selected.
 	 *
-	 * @since   2.5.6
+	 * @since   2.8.0
 	 *
 	 * @param   EndToEndTester $I  Tester.
 	 */
@@ -227,13 +227,13 @@ class DiviFormCest
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
 	 *
-	 * @since   2.5.6
+	 * @since   2.8.0
 	 *
 	 * @param   EndToEndTester $I  Tester.
 	 */
 	public function _passed(EndToEndTester $I)
 	{
-		$I->deactivateThirdPartyPlugin($I, 'divi-builder');
+		$I->useTheme('twentytwentytwo');
 		$I->deactivateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
 		$I->deactivateKitPlugin($I);
 		$I->resetKitPlugin($I);

--- a/tests/EndToEnd/integrations/divi-theme/DiviThemeFormTriggerCest.php
+++ b/tests/EndToEnd/integrations/divi-theme/DiviThemeFormTriggerCest.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Tests\EndToEnd;
+
+use Tests\Support\EndToEndTester;
+
+/**
+ * Tests for the Kit Form's Divi Module using the Divi Theme.
+ *
+ * @since   2.8.0
+ */
+class DiviThemeFormTriggerCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   2.8.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function _before(EndToEndTester $I)
+	{
+		$I->activateKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
+		$I->useTheme('Divi');
+	}
+
+	/**
+	 * Test the Form module works when a valid Form is selected
+	 * using Divi's backend editor.
+	 *
+	 * @since   2.8.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormTriggerModuleInBackendEditor(EndToEndTester $I)
+	{
+		// Setup Plugin, without defining default Forms.
+		$I->setupKitPluginNoDefaultForms($I);
+		$I->setupKitPluginResources($I);
+
+		// Create a Divi Page in the backend editor.
+		$I->createDiviPageInBackendEditor($I, 'Kit: Page: Form Trigger: Divi: Backend Editor');
+
+		// Insert the Form module.
+		$I->insertDiviRowWithModule(
+			$I,
+			'Kit Form Trigger',
+			'convertkit_formtrigger',
+			'form',
+			$_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID']
+		);
+
+		// Save Divi module and view the page on the frontend site.
+		$I->saveDiviModuleInBackendEditorAndViewPage($I);
+
+		// Confirm that the block displays.
+		$I->seeFormTriggerOutput($I, $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_URL'], 'Subscribe');
+
+		// Confirm that one Kit Form is output in the DOM.
+		// This confirms that there is only one script on the page for this form, which renders the form.
+		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '"]', 1);
+
+		// Deactivate Classic Editor.
+		$I->deactivateThirdPartyPlugin($I, 'classic-editor');
+	}
+
+	/**
+	 * Test the Form module works when a valid Form is selected
+	 * using Divi's backend editor.
+	 *
+	 * @since   2.8.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormTriggerModuleInFrontendEditor(EndToEndTester $I)
+	{
+		// Setup Plugin, without defining default Forms.
+		$I->setupKitPluginNoDefaultForms($I);
+		$I->setupKitPluginResources($I);
+
+		// Create a Divi Page in the frontend editor.
+		$url = $I->createDiviPageInFrontendEditor($I, 'Kit: Page: Form Trigger: Divi: Frontend Editor');
+
+		// Insert the Form module.
+		$I->insertDiviRowWithModule(
+			$I,
+			'Kit Form Trigger',
+			'convertkit_formtrigger',
+			'form',
+			$_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID']
+		);
+
+		// Save Divi module and view the page on the frontend site.
+		$I->saveDiviModuleInFrontendEditorAndViewPage($I, $url);
+
+		// Confirm that the block displays.
+		$I->seeFormTriggerOutput($I, $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_URL'], 'Subscribe');
+
+		// Confirm that one Kit Form is output in the DOM.
+		// This confirms that there is only one script on the page for this form, which renders the form.
+		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '"]', 1);
+	}
+
+	/**
+	 * Test the Form module displays the expected message when the Plugin has no credentials
+	 *
+	 * @since   2.8.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormTriggerModuleInFrontendEditorWhenNoCredentials(EndToEndTester $I)
+	{
+		// Create a Divi Page in the frontend editor.
+		$I->createDiviPageInFrontendEditor($I, 'Kit: Page: Form Trigger: Divi: Frontend: No Credentials', false);
+
+		// Insert the Form module.
+		$I->insertDiviRowWithModule(
+			$I,
+			'Kit Form Trigger',
+			'convertkit_formtrigger'
+		);
+
+		// Confirm the on screen message displays.
+		$I->seeInSource('Not connected to Kit');
+		$I->seeInSource('Connect your Kit account at Settings > Kit, and then refresh this page to select a form.');
+	}
+
+	/**
+	 * Test the Form module displays the expected message when the Kit account
+	 * has no forms.
+	 *
+	 * @since   2.8.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormTriggerModuleInFrontendEditorWhenNoForms(EndToEndTester $I)
+	{
+		// Setup Plugin.
+		$I->setupKitPluginCredentialsNoData($I);
+		$I->setupKitPluginResourcesNoData($I);
+
+		// Create a Divi Page in the frontend editor.
+		$I->createDiviPageInFrontendEditor($I, 'Kit: Page: Form Trigger: Divi: Frontend: No Forms');
+
+		// Insert the Form module.
+		$I->insertDiviRowWithModule(
+			$I,
+			'Kit Form Trigger',
+			'convertkit_formtrigger'
+		);
+
+		// Confirm the on screen message displays.
+		$I->seeInSource('No modal, sticky bar or slide in forms exist in Kit');
+		$I->seeInSource('Add a non-inline form to your Kit account, and then refresh this page to select a form.');
+	}
+
+	/**
+	 * Test the Form module works when no Form is selected.
+	 *
+	 * @since   2.8.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormTriggerModuleWithNoFormParameter(EndToEndTester $I)
+	{
+		// Setup Plugin, without defining default Forms.
+		$I->setupKitPluginNoDefaultForms($I);
+		$I->setupKitPluginResources($I);
+
+		// Create Page with Form module in Divi.
+		$pageID = $I->createPageWithDiviModuleProgrammatically(
+			$I,
+			'Kit: Legacy Form Trigger: Divi Module: No Form Param',
+			'convertkit_formtrigger',
+			'form',
+			''
+		);
+
+		// Load Page.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that no Kit Form trigger button is displayed.
+		$I->dontSeeFormTriggerOutput($I);
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   2.8.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function _passed(EndToEndTester $I)
+	{
+		$I->useTheme('twentytwentytwo');
+		$I->deactivateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
+		$I->deactivateKitPlugin($I);
+		$I->resetKitPlugin($I);
+	}
+}

--- a/tests/EndToEnd/integrations/divi-theme/DiviThemeProductCest.php
+++ b/tests/EndToEnd/integrations/divi-theme/DiviThemeProductCest.php
@@ -5,16 +5,16 @@ namespace Tests\EndToEnd;
 use Tests\Support\EndToEndTester;
 
 /**
- * Tests for the Kit Product's Divi Module.
+ * Tests for the Kit Product's Divi Module using the Divi Theme.
  *
- * @since   2.5.7
+ * @since   2.8.0
  */
-class DiviProductCest
+class DiviThemeProductCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
 	 *
-	 * @since   2.5.7
+	 * @since   2.8.0
 	 *
 	 * @param   EndToEndTester $I  Tester.
 	 */
@@ -22,14 +22,14 @@ class DiviProductCest
 	{
 		$I->activateKitPlugin($I);
 		$I->activateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
-		$I->activateThirdPartyPlugin($I, 'divi-builder');
+		$I->useTheme('Divi');
 	}
 
 	/**
 	 * Test the Product module works when a valid Product is selected
 	 * using Divi's backend editor.
 	 *
-	 * @since   2.5.7
+	 * @since   2.8.0
 	 *
 	 * @param   EndToEndTester $I  Tester.
 	 */
@@ -65,7 +65,7 @@ class DiviProductCest
 	 * Test the Product module works when a valid Product is selected
 	 * using Divi's backend editor.
 	 *
-	 * @since   2.5.7
+	 * @since   2.8.0
 	 *
 	 * @param   EndToEndTester $I  Tester.
 	 */
@@ -97,7 +97,7 @@ class DiviProductCest
 	/**
 	 * Test the Product module displays the expected message when the Plugin has no credentials
 	 *
-	 * @since   2.5.7
+	 * @since   2.8.0
 	 *
 	 * @param   EndToEndTester $I  Tester.
 	 */
@@ -122,7 +122,7 @@ class DiviProductCest
 	 * Test the Product module displays the expected message when the Kit account
 	 * has no products.
 	 *
-	 * @since   2.5.7
+	 * @since   2.8.0
 	 *
 	 * @param   EndToEndTester $I  Tester.
 	 */
@@ -150,7 +150,7 @@ class DiviProductCest
 	/**
 	 * Test the Product module works when no Product is selected.
 	 *
-	 * @since   2.5.7
+	 * @since   2.8.0
 	 *
 	 * @param   EndToEndTester $I  Tester.
 	 */
@@ -185,13 +185,13 @@ class DiviProductCest
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
 	 *
-	 * @since   2.5.7
+	 * @since   2.8.0
 	 *
 	 * @param   EndToEndTester $I  Tester.
 	 */
 	public function _passed(EndToEndTester $I)
 	{
-		$I->deactivateThirdPartyPlugin($I, 'divi-builder');
+		$I->useTheme('twentytwentytwo');
 		$I->deactivateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
 		$I->deactivateKitPlugin($I);
 		$I->resetKitPlugin($I);

--- a/tests/Support/Helper/DiviBuilder.php
+++ b/tests/Support/Helper/DiviBuilder.php
@@ -48,6 +48,7 @@ class DiviBuilder extends \Codeception\Module
 		// Wait for notice to display.
 		$I->waitForElementNotVisible('.et-fb-preloader');
 		$I->waitForElementVisible('.notice-success');
+		$I->wait(2);
 
 		// Remove transient set by Divi that would show the welcome modal.
 		$I->dontHaveTransientInDatabase('et_builder_show_bfb_welcome_modal');
@@ -136,6 +137,7 @@ class DiviBuilder extends \Codeception\Module
 
 		// Insert module.
 		$I->waitForElementVisible('li.' . $programmaticName);
+		$I->wait(2);
 		$I->click('li.' . $programmaticName);
 
 		// Wait for module to load.
@@ -168,6 +170,7 @@ class DiviBuilder extends \Codeception\Module
 
 		// Load the Page on the frontend site.
 		$I->waitForElementNotVisible('.et-fb-preloader');
+		$I->wait(2);
 		$I->waitForElementVisible('.notice-success');
 		$I->click('.notice-success a');
 

--- a/tests/Support/Helper/WPCron.php
+++ b/tests/Support/Helper/WPCron.php
@@ -90,8 +90,10 @@ class WPCron extends \Codeception\Module
 
 		// Delete the event.
 		$I->click('Delete');
+		$I->acceptPopup();
 
 		// Confirm the event was deleted.
+		$I->waitForElementVisible('#crontrol-message');
 		$I->see('Deleted the cron event ' . $name );
 	}
 


### PR DESCRIPTION
## Summary

[WP Control 1.19.0](https://wordpress.org/plugins/wp-crontrol/) adds a confirmation popup when deleting a WordPress cron event, which caused the `testBroadcastsCronEventRecreatedWhenDeleted` test to fail.

![Screenshot 2025-04-24 at 14 09 48](https://github.com/user-attachments/assets/a6aff107-6936-49e7-9056-b09232c64078)

![Tests EndToEnd BroadcastsToPostsCest testBroadcastsCronEventRecreatedWhenDeleted fail](https://github.com/user-attachments/assets/1dc4026f-4a1d-44f9-a9d8-b10ccbdf55b6)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)