### PR TITLE
Run Tests and Coding Standards against PHP 8.4

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         wp-versions: [ 'latest' ] #[ '6.1.1', 'latest' ]
-        php-versions: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ] #[ '7.3', '7.4', '8.0', '8.1' ]
+        php-versions: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ] #[ '7.3', '7.4', '8.0', '8.1' ]
 
     # Steps to install, configure and run tests
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -170,7 +170,7 @@ jobs:
       # WP_DEBUG = true is required so all PHP errors are output and caught by tests (E_ALL).
       # WP_DEBUG = false for Divi, Elementor and WishList Member tests, as they throw PHP warnings, deprecations and notices.
       - name: Enable WP_DEBUG
-        if: ${{ matrix.test-groups != 'EndToEnd/integrations/wlm' && matrix.test-groups != 'EndToEnd/integrations/elementor' && matrix.test-groups != 'EndToEnd/integrations/divi' }}
+        if: ${{ matrix.test-groups != 'EndToEnd/integrations/other' && ${{ matrix.php-versions }} != '8.4' }}
         working-directory: ${{ env.ROOT_DIR }}
         run: |
           wp-cli config set WP_DEBUG true --raw

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -170,7 +170,7 @@ jobs:
       # WP_DEBUG = true is required so all PHP errors are output and caught by tests (E_ALL).
       # WP_DEBUG = false for other integraiton tests, as Elementor in PHP 8.4 throws a deprecation notice
       - name: Enable WP_DEBUG
-        if: ${{ matrix.test-groups != 'EndToEnd/integrations/other' && ${{ matrix.php-versions }} != '8.4' }}
+        if: ${{ matrix.test-groups != 'EndToEnd/integrations/other' && matrix.php-versions != '8.4' }}
         working-directory: ${{ env.ROOT_DIR }}
         run: |
           wp-cli config set WP_DEBUG true --raw

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -168,7 +168,7 @@ jobs:
         run: mv /home/runner/work/convertkit-wordpress/convertkit-wordpress/convertkit ${{ env.PLUGIN_DIR }}
       
       # WP_DEBUG = true is required so all PHP errors are output and caught by tests (E_ALL).
-      # WP_DEBUG = false for Divi, Elementor and WishList Member tests, as they throw PHP warnings, deprecations and notices.
+      # WP_DEBUG = false for other integraiton tests, as Elementor in PHP 8.4 throws a deprecation notice
       - name: Enable WP_DEBUG
         if: ${{ matrix.test-groups != 'EndToEnd/integrations/other' && ${{ matrix.php-versions }} != '8.4' }}
         working-directory: ${{ env.ROOT_DIR }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         wp-versions: [ 'latest' ] #[ '6.1.1', 'latest' ]
-        php-versions: [ '8.1', '8.2', '8.3' ] #[ '7.4', '8.0', '8.1' ]
+        php-versions: [ '8.1', '8.2', '8.3', '8.4' ] #[ '7.4', '8.0', '8.1' ]
 
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [

--- a/tests/EndToEnd/integrations/wlm/WishListMemberCest.php
+++ b/tests/EndToEnd/integrations/wlm/WishListMemberCest.php
@@ -21,6 +21,7 @@ class WishListMemberCest
 	public function _before(EndToEndTester $I)
 	{
 		$I->activateKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
 		$I->activateThirdPartyPlugin($I, 'wishlist-member');
 		$I->setupKitPlugin($I);
 		$I->setupKitPluginResources($I);
@@ -532,6 +533,8 @@ class WishListMemberCest
 	 */
 	public function _passed(EndToEndTester $I)
 	{
+		$I->deactivateThirdPartyPlugin($I, 'wishlist-member');
+		$I->deactivateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
 		$I->deactivateKitPlugin($I);
 		$I->resetKitPlugin($I);
 	}


### PR DESCRIPTION
## Summary

Runs tests and coding standards against the latest PHP version, 8.4.

Enabled `WP_DEBUG` on all tests, excluding Elementor in PHP 8.4 due to Elementor returning a deprecated notice regarding Implicitly nullable parameter declarations:
https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)