### PR TITLE
Tests: Fix Forminator Quiz Tests

### DIFF
--- a/tests/EndToEnd/integrations/other/ForminatorCest.php
+++ b/tests/EndToEnd/integrations/other/ForminatorCest.php
@@ -859,7 +859,7 @@ class ForminatorCest
 
 		// Complete quiz.
 		$I->checkOption('answers[question-1-0]', '0');
-		$I->click('View Results');
+		$I->click('button.forminator-button-submit');
 
 		// Complete Name and Email.
 		$I->waitForElementVisible('input[name=name-1]');


### PR DESCRIPTION
## Summary

Forminator 1.43.0 changes the button label for quiz forms. This PR resolves by using a CSS selector to target the button, which should be more consistent.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)