### PR TITLE
Broadcasts: Import: Remove emojis from Permalinks

### DIFF
--- a/includes/class-convertkit-broadcasts-importer.php
+++ b/includes/class-convertkit-broadcasts-importer.php
@@ -341,6 +341,7 @@ class ConvertKit_Broadcasts_Importer {
 			'post_excerpt'  => ( ! is_null( $broadcast['description'] ) ? $broadcast['description'] : '' ),
 			'post_date_gmt' => gmdate( 'Y-m-d H:i:s', strtotime( $broadcast['published_at'] ) ),
 			'post_author'   => $author_id,
+			'post_name'     => $this->generate_permalink( $broadcast['title'] ),
 		);
 
 		// If a Category was supplied, assign the Post to the given Category ID when created.
@@ -371,6 +372,24 @@ class ConvertKit_Broadcasts_Importer {
 		$post_args['meta_input']['_convertkit_broadcast_id'] = $broadcast['id'];
 
 		return $post_args;
+
+	}
+
+	/**
+	 * Removes emojis from the given string.
+	 *
+	 * @since   2.8.2
+	 *
+	 * @param   string $title Broadcast Title.
+	 * @return  string
+	 */
+	public function generate_permalink( $title ) {
+
+		// Remove emojis.
+		$title = preg_replace( '/[^\p{L}\p{N}\p{P}\s]+/u', '', $title );
+
+		// Return the Permalink.
+		return sanitize_title( $title );
 
 	}
 

--- a/tests/Integration/BroadcastsImportTest.php
+++ b/tests/Integration/BroadcastsImportTest.php
@@ -307,6 +307,21 @@ class BroadcastsImportTest extends WPTestCase
 	}
 
 	/**
+	 * Test that the generate_permalink() function strips emojis, and runs the string
+	 * through the WordPress sanitize_title() function, which will convert the string
+	 * to lowercase and replace spaces with hyphens.
+	 *
+	 * @since   2.8.2
+	 */
+	public function testGeneratePermalinkFunction()
+	{
+		$this->assertEquals('hello-world-123', $this->importer->generate_permalink('Hello World 123 🌍'));
+		$this->assertEquals('hello-123-world', $this->importer->generate_permalink('Hello ❤️‍🩹 123 ❤️ World'));
+		$this->assertEquals('123-hello-world', $this->importer->generate_permalink('🩹 123 👍🏿 Hello World'));
+		$this->assertEquals('accented-test', $this->importer->generate_permalink('🩹 Accénted test 👍🏿'));
+	}
+
+	/**
 	 * Assert that the created Post's content is valid.
 	 *
 	 * @since   2.6.4

--- a/tests/Integration/BroadcastsImportTest.php
+++ b/tests/Integration/BroadcastsImportTest.php
@@ -318,7 +318,8 @@ class BroadcastsImportTest extends WPTestCase
 		$this->assertEquals('hello-world-123', $this->importer->generate_permalink('Hello World 123 🌍'));
 		$this->assertEquals('hello-123-world', $this->importer->generate_permalink('Hello ❤️‍🩹 123 ❤️ World'));
 		$this->assertEquals('123-hello-world', $this->importer->generate_permalink('🩹 123 👍🏿 Hello World'));
-		$this->assertEquals('accented-test', $this->importer->generate_permalink('🩹 Accénted test 👍🏿'));
+		$this->assertEquals('cafe-deja-vu', $this->importer->generate_permalink('🩹 Café déjà-vu! 👍🏿'));
+		$this->assertEquals('cafe-deja-vu', $this->importer->generate_permalink('Café déjà-vu!'));
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Removes emojis from the WordPress Post's Permalink when importing Broadcasts that contain emojis in the title.

Whilst emojis are supported in Permalinks, it's better to exclude them for readability, link sharing and SEO.

WordPress' `sanitize_title` will remove non-alphanumeric characters, and replace spaces with hyphens - however won't cover removal of emojis.

## Testing

- `testGeneratePermalinkFunction`: Tests that emojis are removed from the given Broadcast title when parsed through the `generate_permalink` function.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)