### PR TITLE
Use `wp_doing_cron` method

### DIFF
--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -363,14 +363,7 @@ class WP_ConvertKit {
 	 */
 	public function is_cron() {
 
-		if ( ! defined( 'DOING_CRON' ) ) {
-			return false;
-		}
-		if ( ! DOING_CRON ) {
-			return false;
-		}
-
-		return true;
+		return wp_doing_cron();
 
 	}
 


### PR DESCRIPTION
## Summary

The [latest static analysis for WordPress](https://github.com/szepeviktor/phpstan-wordpress/releases/tag/v2.0.2) flags that the Plugin should use the `wp_doing_cron` method instead of checking the `DOING_CRON` constant.

![Screenshot 2025-05-19 at 13 53 10](https://github.com/user-attachments/assets/40e146f1-fd44-4b67-95fe-6bf8f787cad4)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)