### PR TITLE
Tests: Use Named Arguments

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -122,10 +122,11 @@ jobs:
         working-directory: ${{ env.PLUGIN_DIR }}
         run: php vendor/bin/phpcs -q --standard=phpcs.tests.xml --report=checkstyle ./tests | cs2pr
 
-      # Run WordPress Coding Standards on Plugin.
-      - name: Run WordPress Coding Standards
+      # Run Coding Standards on Tests.
+      - name: Run Coding Standards on Tests
         working-directory: ${{ env.PLUGIN_DIR }}
-        run: php vendor/bin/phpcs -q --standard=phpcs.xml --report=checkstyle ./ | cs2pr
+        if: ${{ matrix.php-versions == '8.1' || matrix.php-versions == '8.2' || matrix.php-versions == '8.3' || matrix.php-versions == '8.4' }}
+        run: php vendor/bin/phpcs -q --standard=phpcs.tests.xml --report=checkstyle ./tests | cs2pr
 
       # Run PHPStan for static analysis.
       - name: Run PHPStan Static Analysis

--- a/tests/EndToEnd/broadcasts/blocks-shortcodes/PageBlockBroadcastsCest.php
+++ b/tests/EndToEnd/broadcasts/blocks-shortcodes/PageBlockBroadcastsCest.php
@@ -35,15 +35,22 @@ class PageBlockBroadcastsCest
 	public function testBroadcastsBlockWhenNoCredentials(EndToEndTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: Block: No Credentials');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Block: No Credentials'
+		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Broadcasts', 'convertkit-broadcasts');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts'
+		);
 
 		// Test that the popup window works.
 		$I->testBlockNoCredentialsPopupWindow(
 			$I,
-			'convertkit-broadcasts'
+			blockName: 'convertkit-broadcasts'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -72,13 +79,23 @@ class PageBlockBroadcastsCest
 		$I->setupKitPluginResourcesNoData($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: No Broadcasts');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: No Broadcasts'
+		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Broadcasts', 'convertkit-broadcasts');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts'
+		);
 
 		// Confirm that the Broadcasts block displays instructions to the user on how to add a Broadcast in Kit.
-		$I->seeBlockHasNoContentMessage($I, 'No broadcasts exist in Kit.');
+		$I->seeBlockHasNoContentMessage(
+			$I,
+			message: 'No broadcasts exist in Kit.'
+		);
 
 		// Click the link to confirm it loads Kit.
 		$I->clickLinkInBlockAndAssertKitLoginScreen($I, 'Click here to send your first broadcast.');
@@ -104,10 +121,17 @@ class PageBlockBroadcastsCest
 		$I->setupKitPluginResourcesNoData($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: Refresh Button');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Refresh Button'
+		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Broadcasts', 'convertkit-broadcasts');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts'
+		);
 
 		// Setup Plugin with a valid API Key and resources, as if the user performed the necessary steps to authenticate
 		// and created a broadcast.
@@ -143,10 +167,17 @@ class PageBlockBroadcastsCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: Default Params');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Default Params'
+		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Broadcasts', 'convertkit-broadcasts');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts'
+		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -183,14 +214,17 @@ class PageBlockBroadcastsCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: Display as Grid');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Display as Grid'
+		);
 
 		// Add block to Page, setting the date format.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			parameters: [
 				'#inspector-toggle-control-0' => [ 'toggle', true ],
 			]
 		);
@@ -222,14 +256,17 @@ class PageBlockBroadcastsCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: Date Format Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Date Format Param'
+		);
 
 		// Add block to Page, setting the date format.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			parameters: [
 				'date_format' => [ 'select', 'Y-m-d' ],
 			]
 		);
@@ -269,14 +306,17 @@ class PageBlockBroadcastsCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: Display image');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Display image'
+		);
 
 		// Add block to Page, setting the date format.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			parameters: [
 				'#inspector-toggle-control-0' => [ 'toggle', true ],
 				'#inspector-toggle-control-1' => [ 'toggle', true ],
 			]
@@ -310,14 +350,17 @@ class PageBlockBroadcastsCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: Display description');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Display description'
+		);
 
 		// Add block to Page, setting the date format.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			parameters: [
 				'#inspector-toggle-control-2' => [ 'toggle', true ],
 			]
 		);
@@ -349,14 +392,17 @@ class PageBlockBroadcastsCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: Display read more link');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Display read more link'
+		);
 
 		// Add block to Page, setting the date format.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			parameters: [
 				'#inspector-toggle-control-3' => [ 'toggle', true ],
 				'read_more_label'             => [ 'input', 'Continue reading' ],
 			]
@@ -389,14 +435,17 @@ class PageBlockBroadcastsCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: Limit Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Limit Param'
+		);
 
 		// Add block to Page, setting the limit.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			parameters: [
 				'limit' => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 			]
 		);
@@ -433,10 +482,17 @@ class PageBlockBroadcastsCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: Blank Limit Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Blank Limit Param'
+		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Broadcasts', 'convertkit-broadcasts');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts'
+		);
 
 		// When the sidebar appears, blank the limit parameter as the user might, by pressing the backspace key twice.
 		$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
@@ -479,14 +535,17 @@ class PageBlockBroadcastsCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: Pagination');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Pagination'
+		);
 
 		// Add block to Page, setting the limit.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			parameters: [
 				'limit'                       => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 				'#inspector-toggle-control-4' => [ 'toggle', true ],
 			]
@@ -513,14 +572,17 @@ class PageBlockBroadcastsCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: Pagination Labels');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Pagination Labels'
+		);
 
 		// Add block to Page, setting the limit.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			parameters: [
 				'limit'                       => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 				'#inspector-toggle-control-4' => [ 'toggle', true ],
 				'paginate_label_prev'         => [ 'input', 'Newer' ],
@@ -549,14 +611,17 @@ class PageBlockBroadcastsCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: Blank Pagination Labels');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Blank Pagination Labels'
+		);
 
 		// Add block to Page, setting the limit.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			parameters: [
 				'limit'                       => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 				'#inspector-toggle-control-4' => [ 'toggle', true ],
 				'paginate_label_prev'         => [ 'input', '' ],

--- a/tests/EndToEnd/broadcasts/blocks-shortcodes/PageShortcodeBroadcastsCest.php
+++ b/tests/EndToEnd/broadcasts/blocks-shortcodes/PageShortcodeBroadcastsCest.php
@@ -36,14 +36,16 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInVisualEditorWithDefaultParameters(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Visual Editor');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Visual Editor'
+		);
 
 		// Add shortcode to Page.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Broadcasts',
-			false,
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			shortcodeName:'Kit Broadcasts',
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -77,16 +79,19 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInVisualEditorWithDisplayGridParameter(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Display as Grid');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Display as Grid'
+		);
 
 		// Add shortcode to Page.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Broadcasts',
-			[
+			shortcodeName: 'Kit Broadcasts',
+			shortcodeConfiguration: [
 				'display_grid' => [ 'toggle', 'Yes' ],
 			],
-			'[convertkit_broadcasts display_grid="1" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="1" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -113,16 +118,19 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInVisualEditorWithDateFormatParameter(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Date Format');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Date Format'
+		);
 
 		// Add shortcode to Page.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Broadcasts',
-			[
+			shortcodeName: 'Kit Broadcasts',
+			shortcodeConfiguration: [
 				'date_format' => [ 'select', date('Y-m-d') ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="Y-m-d" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="Y-m-d" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -156,16 +164,19 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInVisualEditorWithDisplayImageParameter(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Display image');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Display image'
+		);
 
 		// Add shortcode to Page.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Broadcasts',
-			[
+			shortcodeName: 'Kit Broadcasts',
+			shortcodeConfiguration: [
 				'display_image' => [ 'toggle', 'Yes' ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="1" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="1" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -191,16 +202,19 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInVisualEditorWithDisplayDescriptionParameter(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Display description');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Display description'
+		);
 
 		// Add shortcode to Page.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Broadcasts',
-			[
+			shortcodeName: 'Kit Broadcasts',
+			shortcodeConfiguration: [
 				'display_description' => [ 'toggle', 'Yes' ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="1" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="1" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -226,17 +240,20 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInVisualEditorWithDisplayReadMoreLinkParameter(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Display read more link');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Display read more link'
+		);
 
 		// Add shortcode to Page.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Broadcasts',
-			[
+			shortcodeName: 'Kit Broadcasts',
+			shortcodeConfiguration: [
 				'display_read_more' => [ 'toggle', 'Yes' ],
 				'read_more_label'   => [ 'input', 'Continue reading' ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="1" read_more_label="Continue reading" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="1" read_more_label="Continue reading" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -263,16 +280,19 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInVisualEditorWithLimitParameter(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Limit');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Limit'
+		);
 
 		// Add shortcode to Page.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Broadcasts',
-			[
+			shortcodeName: 'Kit Broadcasts',
+			shortcodeConfiguration: [
 				'limit' => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -304,24 +324,31 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInVisualEditorWithPaginationEnabled(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Pagination');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Pagination'
+		);
 
 		// Add shortcode to Page.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Broadcasts',
-			[
+			shortcodeName: 'Kit Broadcasts',
+			shortcodeConfiguration: [
 				'limit'    => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 				'paginate' => [ 'toggle', 'Yes' ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewClassicEditorPage($I);
 
 		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Previous', 'Next');
+		$I->testBroadcastsPagination(
+			$I,
+			previousLabel: 'Previous',
+			nextLabel: 'Next'
+		);
 	}
 
 	/**
@@ -335,26 +362,33 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInVisualEditorWithPaginationLabelParameters(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Pagination Labels');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Pagination Labels'
+		);
 
 		// Add shortcode to Page.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Broadcasts',
-			[
+			shortcodeName: 'Kit Broadcasts',
+			shortcodeConfiguration: [
 				'limit'               => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 				'paginate'            => [ 'toggle', 'Yes' ],
 				'paginate_label_prev' => [ 'input', 'Newer' ],
 				'paginate_label_next' => [ 'input', 'Older' ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older"]'
 		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewClassicEditorPage($I);
 
 		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Older', 'Newer');
+		$I->testBroadcastsPagination(
+			$I,
+			previousLabel: 'Older',
+			nextLabel: 'Newer'
+		);
 	}
 
 	/**
@@ -368,26 +402,33 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInVisualEditorWithBlankPaginationLabelParameters(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Blank Pagination Labels');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Blank Pagination Labels'
+		);
 
 		// Add shortcode to Page.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Broadcasts',
-			[
+			shortcodeName: 'Kit Broadcasts',
+			shortcodeConfiguration: [
 				'limit'               => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 				'paginate'            => [ 'toggle', 'Yes' ],
 				'paginate_label_prev' => [ 'input', '' ],
 				'paginate_label_next' => [ 'input', '' ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="1"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="1"]'
 		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewClassicEditorPage($I);
 
 		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Previous', 'Next');
+		$I->testBroadcastsPagination(
+			$I,
+			previousLabel: 'Previous',
+			nextLabel: 'Next'
+		);
 	}
 
 	/**
@@ -441,7 +482,11 @@ class PageShortcodeBroadcastsCest
 		$I->seeInSource('<a href="' . $_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:' . $linkColor . '"');
 
 		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Older', 'Newer');
+		$I->testBroadcastsPagination(
+			$I,
+			previousLabel: 'Older',
+			nextLabel: 'Newer'
+		);
 
 		// Confirm that link styles are still applied to refreshed data.
 		$I->seeInSource('<a href="' . $_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:' . $linkColor . '"');
@@ -458,14 +503,16 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInTextEditorWithDefaultParameters(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Text Editor');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Text Editor'
+		);
 
 		// Add shortcode to Page.
 		$I->addTextEditorShortcode(
 			$I,
-			'convertkit-broadcasts',
-			false,
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			shortcodeProgrammaticName: 'convertkit-broadcasts',
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -497,16 +544,19 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInTextEditorWithDisplayGridParameter(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Text Editor: Display as Grid');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Text Editor: Display as Grid'
+		);
 
 		// Add shortcode to Page.
 		$I->addTextEditorShortcode(
 			$I,
-			'convertkit-broadcasts',
-			[
+			shortcodeProgrammaticName: 'convertkit-broadcasts',
+			shortcodeConfiguration: [
 				'display_grid' => [ 'toggle', 'Yes' ],
 			],
-			'[convertkit_broadcasts display_grid="1" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="1" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -533,16 +583,19 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInTextEditorWithDateFormatParameter(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Text Editor: Date Format');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Text Editor: Date Format'
+		);
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
-			'convertkit-broadcasts',
-			[
+			shortcodeProgrammaticName: 'convertkit-broadcasts',
+			shortcodeConfiguration: [
 				'date_format' => [ 'select', date('Y-m-d') ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="Y-m-d" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="Y-m-d" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -571,16 +624,19 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInTextEditorWithDisplayImageParameter(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Text Editor: Display image');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Text Editor: Display image'
+		);
 
 		// Add shortcode to Page.
 		$I->addTextEditorShortcode(
 			$I,
-			'convertkit-broadcasts',
-			[
+			shortcodeProgrammaticName: 'convertkit-broadcasts',
+			shortcodeConfiguration: [
 				'display_image' => [ 'toggle', 'Yes' ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="1" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="1" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -607,16 +663,19 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInTextEditorWithDisplayDescriptionParameter(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Text Editor: Display description');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Text Editor: Display description'
+		);
 
 		// Add shortcode to Page.
 		$I->addTextEditorShortcode(
 			$I,
-			'convertkit-broadcasts',
-			[
+			shortcodeProgrammaticName: 'convertkit-broadcasts',
+			shortcodeConfiguration: [
 				'display_description' => [ 'toggle', 'Yes' ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="1" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="1" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -643,17 +702,20 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInTextEditorWithDisplayReadMoreLinkParameter(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Text Editor: Display read more link');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Text Editor: Display read more link'
+		);
 
 		// Add shortcode to Page.
 		$I->addTextEditorShortcode(
 			$I,
-			'convertkit-broadcasts',
-			[
+			shortcodeProgrammaticName: 'convertkit-broadcasts',
+			shortcodeConfiguration: [
 				'display_read_more' => [ 'toggle', 'Yes' ],
 				'read_more_label'   => [ 'input', 'Continue reading' ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="1" read_more_label="Continue reading" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="1" read_more_label="Continue reading" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -680,16 +742,19 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInTextEditorWithLimitParameter(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Text Editor: Limit');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Text Editor: Limit'
+		);
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
-			'convertkit-broadcasts',
-			[
+			shortcodeProgrammaticName: 'convertkit-broadcasts',
+			shortcodeConfiguration: [
 				'limit' => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -718,24 +783,31 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInTextEditorWithPaginationEnabled(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Text Editor: Pagination');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Text Editor: Pagination'
+		);
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
-			'convertkit-broadcasts',
-			[
+			shortcodeProgrammaticName: 'convertkit-broadcasts',
+			shortcodeConfiguration: [
 				'limit'    => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 				'paginate' => [ 'toggle', 'Yes' ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewClassicEditorPage($I);
 
 		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Previous', 'Next');
+		$I->testBroadcastsPagination(
+			$I,
+			previousLabel: 'Previous',
+			nextLabel: 'Next'
+		);
 	}
 
 	/**
@@ -749,26 +821,33 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInTextEditorWithPaginationLabelParameters(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Text Editor: Pagination Labels');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Text Editor: Pagination Labels'
+		);
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
-			'convertkit-broadcasts',
-			[
+			shortcodeProgrammaticName: 'convertkit-broadcasts',
+			shortcodeConfiguration: [
 				'limit'               => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 				'paginate'            => [ 'toggle', 'Yes' ],
 				'paginate_label_prev' => [ 'input', 'Newer' ],
 				'paginate_label_next' => [ 'input', 'Older' ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older"]'
 		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewClassicEditorPage($I);
 
 		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Older', 'Newer');
+		$I->testBroadcastsPagination(
+			$I,
+			previousLabel: 'Older',
+			nextLabel: 'Newer'
+		);
 	}
 
 	/**
@@ -782,7 +861,10 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeWhenSwitchingEditors(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Editor Switching');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Editor Switching'
+		);
 
 		// Open Text Editor modal.
 		$I->openTextEditorShortcodeModal($I, 'convertkit-broadcasts', 'content');
@@ -794,12 +876,12 @@ class PageShortcodeBroadcastsCest
 		// still works, inserting the shortcode into the Visual Editor.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Broadcasts',
-			[
+			shortcodeName: 'Kit Broadcasts',
+			shortcodeConfiguration: [
 				'limit'    => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 				'paginate' => [ 'toggle', 'Yes' ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -838,7 +920,11 @@ class PageShortcodeBroadcastsCest
 		$I->dontSeeInSource('style="color:red" onmouseover="alert(1)""');
 
 		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Previous', 'Next');
+		$I->testBroadcastsPagination(
+			$I,
+			previousLabel: 'Previous',
+			nextLabel: 'Next'
+		);
 
 		// Confirm that the output is still escaped.
 		$I->seeInSource('style="color:red&quot; onmouseover=&quot;alert(1)&quot;"');

--- a/tests/EndToEnd/broadcasts/blocks-shortcodes/WidgetBroadcastsCest.php
+++ b/tests/EndToEnd/broadcasts/blocks-shortcodes/WidgetBroadcastsCest.php
@@ -52,7 +52,11 @@ class WidgetBroadcastsCest
 	public function testBroadcastsBlockWidgetWithDefaultParameters(EndToEndTester $I)
 	{
 		// Add block widget.
-		$I->addBlockWidget($I, 'Kit Broadcasts', 'convertkit-broadcasts');
+		$I->addBlockWidget(
+			$I,
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts'
+		);
 
 		// View the home page.
 		$I->amOnPage('/');
@@ -79,9 +83,9 @@ class WidgetBroadcastsCest
 		// Add block widget.
 		$I->addBlockWidget(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			blockConfiguration: [
 				'date_format' => [ 'select', 'Y-m-d' ],
 			]
 		);
@@ -111,9 +115,9 @@ class WidgetBroadcastsCest
 		// Add block widget.
 		$I->addBlockWidget(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			blockConfiguration: [
 				'limit' => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 			]
 		);
@@ -140,9 +144,9 @@ class WidgetBroadcastsCest
 		// Add block widget.
 		$I->addBlockWidget(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			blockConfiguration: [
 				'#inspector-toggle-control-4' => [ 'toggle', true, 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 				'limit'                       => [ 'input', '2' ],
 			]
@@ -167,9 +171,9 @@ class WidgetBroadcastsCest
 		// Add block widget.
 		$I->addBlockWidget(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			blockConfiguration: [
 				'#inspector-toggle-control-4' => [ 'toggle', true, 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 				'limit'                       => [ 'input', '2' ],
 				'paginate_label_prev'         => [ 'input', 'Newer' ],
@@ -181,7 +185,11 @@ class WidgetBroadcastsCest
 		$I->amOnPage('/');
 
 		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Older', 'Newer');
+		$I->testBroadcastsPagination(
+			$I,
+			previousLabel: 'Older',
+			nextLabel: 'Newer'
+		);
 	}
 
 	/**
@@ -196,9 +204,9 @@ class WidgetBroadcastsCest
 		// Add block widget.
 		$I->addBlockWidget(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			blockConfiguration: [
 				'#inspector-toggle-control-4' => [ 'toggle', true, 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 				'limit'                       => [ 'input', '2' ],
 				'paginate_label_prev'         => [ 'input', '' ],
@@ -210,7 +218,11 @@ class WidgetBroadcastsCest
 		$I->amOnPage('/');
 
 		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Previous', 'Next');
+		$I->testBroadcastsPagination(
+			$I,
+			previousLabel: 'Previous',
+			nextLabel: 'Next'
+		);
 	}
 
 	/**

--- a/tests/EndToEnd/broadcasts/import-export/BroadcastsExportPostCest.php
+++ b/tests/EndToEnd/broadcasts/import-export/BroadcastsExportPostCest.php
@@ -37,7 +37,11 @@ class BroadcastsExportPostCest
 	public function testCreateBroadcastNotDisplayedWhenDisabledInPlugin(EndToEndTester $I)
 	{
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Broadcast: Export: Disabled in Plugin');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'post',
+			title: 'Kit: Post: Broadcast: Export: Disabled in Plugin'
+		);
 
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');
@@ -71,7 +75,11 @@ class BroadcastsExportPostCest
 		);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcast: Export: Disabled in Plugin');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'page',
+			title: 'Kit: Page: Broadcast: Export: Disabled in Plugin'
+		);
 
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');
@@ -106,7 +114,11 @@ class BroadcastsExportPostCest
 		);
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Broadcast: Export: Disabled in Post');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'post',
+			title: 'Kit: Post: Broadcast: Export: Disabled in Post'
+		);
 
 		// Publish Post.
 		$I->publishGutenbergPage($I);
@@ -143,7 +155,11 @@ class BroadcastsExportPostCest
 		);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Page: Broadcast: Export: Enabled in Post');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'post',
+			title: 'Kit: Page: Broadcast: Export: Enabled in Post'
+		);
 
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');

--- a/tests/EndToEnd/broadcasts/import-export/BroadcastsExportPostClassicEditorCest.php
+++ b/tests/EndToEnd/broadcasts/import-export/BroadcastsExportPostClassicEditorCest.php
@@ -92,7 +92,11 @@ class BroadcastsExportPostClassicEditorCest
 		);
 
 		// Create a Post.
-		$I->addClassicEditorPage($I, 'post', 'Kit: Broadcasts: Export: Previously published');
+		$I->addClassicEditorPage(
+			$I,
+			postType: 'post',
+			title: 'Kit: Broadcasts: Export: Previously published'
+		);
 
 		// Scroll to Publish meta box, so its buttons are not hidden.
 		$I->scrollTo('#submitdiv');
@@ -127,7 +131,11 @@ class BroadcastsExportPostClassicEditorCest
 		);
 
 		// Create a Post.
-		$I->addClassicEditorPage($I, 'post', 'Kit: Broadcasts: Export: Disabled in Post');
+		$I->addClassicEditorPage(
+			$I,
+			postType: 'post',
+			title: 'Kit: Broadcasts: Export: Disabled in Post'
+		);
 
 		// Scroll to Publish meta box, so its buttons are not hidden.
 		$I->scrollTo('#submitdiv');
@@ -170,7 +178,11 @@ class BroadcastsExportPostClassicEditorCest
 		);
 
 		// Create a Post.
-		$I->addClassicEditorPage($I, 'post', 'Kit: Broadcasts: Export: Enabled in Post');
+		$I->addClassicEditorPage(
+			$I,
+			postType: 'post',
+			title: 'Kit: Broadcasts: Export: Enabled in Post'
+		);
 
 		// Enable the Create Broadcast option.
 		$I->checkOption('#convertkit_action_broadcast_export');

--- a/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormCest.php
+++ b/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormCest.php
@@ -37,7 +37,10 @@ class PageBlockFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Valid Form Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: Valid Form Param'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -51,9 +54,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -89,7 +92,10 @@ class PageBlockFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Legacy Form: Block: Valid Form Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Legacy Form: Block: Valid Form Param'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -103,9 +109,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
 			]
 		);
@@ -132,7 +138,10 @@ class PageBlockFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Valid Modal Form Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: Valid Modal Form Param'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -146,9 +155,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
 		);
@@ -180,7 +189,10 @@ class PageBlockFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Valid Modal Form Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: Valid Modal Form Param'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -194,9 +206,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
 		);
@@ -208,9 +220,9 @@ class PageBlockFormCest
 		// Add the block a second time for the same form, so we can test that only one script / form is output.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
 		);
@@ -238,7 +250,10 @@ class PageBlockFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Valid Slide In Form Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: Valid Slide In Form Param'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -252,9 +267,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] ],
 			]
 		);
@@ -286,7 +301,10 @@ class PageBlockFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Valid Slide In Form Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: Valid Slide In Form Param'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -300,9 +318,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] ],
 			]
 		);
@@ -314,9 +332,9 @@ class PageBlockFormCest
 		// Add the block a second time for the same form, so we can test that only one script / form is output.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] ],
 			]
 		);
@@ -344,7 +362,10 @@ class PageBlockFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Valid Sticky Bar Form Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: Valid Sticky Bar Form Param'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -358,9 +379,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ],
 			]
 		);
@@ -392,7 +413,10 @@ class PageBlockFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Valid Sticky Bar Form Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: Valid Sticky Bar Form Param'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -406,9 +430,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ],
 			]
 		);
@@ -420,9 +444,9 @@ class PageBlockFormCest
 		// Add the block a second time for the same form, so we can test that only one script / form is output.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ],
 			]
 		);
@@ -449,7 +473,10 @@ class PageBlockFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Valid Sticky Bar Form Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: No Form Param'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -461,7 +488,11 @@ class PageBlockFormCest
 		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Form', 'convertkit-form');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form'
+		);
 
 		// Confirm that the Form block displays instructions to the user on how to select a Form.
 		$I->seeBlockHasNoContentMessage($I, 'Select a Form using the Form option in the Gutenberg sidebar.');
@@ -485,16 +516,23 @@ class PageBlockFormCest
 	public function testFormBlockWhenNoCredentials(EndToEndTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: No Credentials');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: No Credentials'
+		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Form', 'convertkit-form');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form'
+		);
 
 		// Test that the popup window works.
 		$I->testBlockNoCredentialsPopupWindow(
 			$I,
-			'convertkit-form',
-			'Select a Form using the Form option in the Gutenberg sidebar.'
+			blockName: 'convertkit-form',
+			expectedMessage: 'Select a Form using the Form option in the Gutenberg sidebar.'
 		);
 
 		// Save page to avoid alert box when _passed() runs to deactivate the Plugin.
@@ -516,10 +554,17 @@ class PageBlockFormCest
 		$I->setupKitPluginResourcesNoData($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: No Forms');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: No Forms'
+		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Form', 'convertkit-form');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form'
+		);
 
 		// Confirm that the Form block displays instructions to the user on how to add a Form in Kit.
 		$I->seeBlockHasNoContentMessage($I, 'No forms exist in Kit.');
@@ -545,10 +590,17 @@ class PageBlockFormCest
 		$I->setupKitPluginResourcesNoData($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Forms: Refresh Button');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Forms: Refresh Button'
+		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Form', 'convertkit-form');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form'
+		);
 
 		// Setup Plugin with a valid API Key and resources, as if the user performed the necessary steps to authenticate
 		// and create a form.
@@ -583,7 +635,10 @@ class PageBlockFormCest
 		$I->activateThirdPartyPlugin($I, 'autoptimize');
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Autoptimize');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: Autoptimize'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -597,9 +652,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -639,7 +694,10 @@ class PageBlockFormCest
 		$I->click('#inspector-toggle-control-1');
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Jetpack Boost');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: Jetpack Boost'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -653,9 +711,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -694,7 +752,10 @@ class PageBlockFormCest
 		$I->haveOptionInDatabase('siteground_optimizer_combine_javascript', '1');
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Siteground Speed Optimizer');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: Siteground Speed Optimizer'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -708,9 +769,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -748,7 +809,10 @@ class PageBlockFormCest
 		$I->enableLiteSpeedCacheLoadJSDeferred($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: LiteSpeed Cache');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: LiteSpeed Cache'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -762,9 +826,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -811,7 +875,10 @@ class PageBlockFormCest
 		);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Perfmatters');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: Perfmatters'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -825,9 +892,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -865,7 +932,10 @@ class PageBlockFormCest
 		$I->enableWPRocketDelayJS($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: WP Rocket');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: WP Rocket'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -879,9 +949,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -926,7 +996,10 @@ class PageBlockFormCest
 		$I->enableWPRocketMinifyConcatenateJSAndCSS($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: WP Rocket');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: WP Rocket'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -940,9 +1013,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);

--- a/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormTriggerCest.php
+++ b/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormTriggerCest.php
@@ -37,7 +37,10 @@ class PageBlockFormTriggerCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form Trigger: Valid Form Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Valid Form Param'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -51,9 +54,9 @@ class PageBlockFormTriggerCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form Trigger',
-			'convertkit-formtrigger',
-			[
+			blockName: 'Kit Form Trigger',
+			blockProgrammaticName: 'convertkit-formtrigger',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
 		);
@@ -79,7 +82,10 @@ class PageBlockFormTriggerCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form Trigger: Valid Form Param, Multiple Blocks');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Valid Form Param, Multiple Blocks'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -93,9 +99,9 @@ class PageBlockFormTriggerCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form Trigger',
-			'convertkit-formtrigger',
-			[
+			blockName: 'Kit Form Trigger',
+			blockProgrammaticName: 'convertkit-formtrigger',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
 		);
@@ -135,7 +141,10 @@ class PageBlockFormTriggerCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form Trigger: No Form Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: No Form Param'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -147,7 +156,11 @@ class PageBlockFormTriggerCest
 		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Form Trigger', 'convertkit-formtrigger');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Form Trigger',
+			blockProgrammaticName: 'convertkit-formtrigger'
+		);
 
 		// Confirm that the Form block displays instructions to the user on how to select a Form.
 		$I->seeBlockHasNoContentMessage($I, 'Select a Form using the Form option in the Gutenberg sidebar.');
@@ -173,14 +186,17 @@ class PageBlockFormTriggerCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form Trigger: Text Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Text Param'
+		);
 
 		// Add block to Page, setting the date format.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form Trigger',
-			'convertkit-formtrigger',
-			[
+			blockName: 'Kit Form Trigger',
+			blockProgrammaticName: 'convertkit-formtrigger',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 				'text' => [ 'text', 'Sign up' ],
 			]
@@ -207,14 +223,17 @@ class PageBlockFormTriggerCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form Trigger: Blank Text Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Blank Text Param'
+		);
 
 		// Add block to Page, setting the date format.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form Trigger',
-			'convertkit-formtrigger',
-			[
+			blockName: 'Kit Form Trigger',
+			blockProgrammaticName: 'convertkit-formtrigger',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 				'text' => [ 'text', '' ],
 			]
@@ -362,16 +381,23 @@ class PageBlockFormTriggerCest
 	public function testFormTriggerBlockWhenNoCredentials(EndToEndTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form Trigger: Block: No Credentials');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Block: No Credentials'
+		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Form Trigger', 'convertkit-formtrigger');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Form Trigger',
+			blockProgrammaticName: 'convertkit-formtrigger'
+		);
 
 		// Test that the popup window works.
 		$I->testBlockNoCredentialsPopupWindow(
 			$I,
-			'convertkit-formtrigger',
-			'Select a Form using the Form option in the Gutenberg sidebar.'
+			blockName: 'convertkit-formtrigger',
+			expectedMessage: 'Select a Form using the Form option in the Gutenberg sidebar.'
 		);
 
 		// Save page to avoid alert box when _passed() runs to deactivate the Plugin.
@@ -393,10 +419,17 @@ class PageBlockFormTriggerCest
 		$I->setupKitPluginResourcesNoData($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form Trigger: Block: No Forms');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Block: No Forms'
+		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Form Trigger', 'convertkit-formtrigger');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Form Trigger',
+			blockProgrammaticName: 'convertkit-formtrigger'
+		);
 
 		// Confirm that the Form block displays instructions to the user on how to add a Form in Kit.
 		$I->seeBlockHasNoContentMessage($I, 'No modal, sticky bar or slide in forms exist in Kit.');
@@ -422,10 +455,17 @@ class PageBlockFormTriggerCest
 		$I->setupKitPluginResourcesNoData($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form Trigger: Refresh Button');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Refresh Button'
+		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Form Trigger', 'convertkit-formtrigger');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Form Trigger',
+			blockProgrammaticName: 'convertkit-formtrigger'
+		);
 
 		// Setup Plugin with a valid API Key and resources, as if the user performed the necessary steps to authenticate
 		// and create a form.

--- a/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormatterFormTriggerCest.php
+++ b/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormatterFormTriggerCest.php
@@ -37,7 +37,10 @@ class PageBlockFormatterFormTriggerCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form Trigger Formatter: Modal Form');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Trigger Formatter: Modal Form'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -57,9 +60,9 @@ class PageBlockFormatterFormTriggerCest
 		// Apply formatter to link the selected text.
 		$I->applyGutenbergFormatter(
 			$I,
-			'Kit Form Trigger',
-			'convertkit-form-link',
-			[
+			formatterName: 'Kit Form Trigger',
+			formatterProgrammaticName: 'convertkit-form-link',
+			formatterConfiguration: [
 				// Form.
 				'data-id' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
@@ -69,7 +72,11 @@ class PageBlockFormatterFormTriggerCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the link displays and works when clicked.
-		$I->seeFormTriggerLinkOutput($I, $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_URL'], 'Subscribe');
+		$I->seeFormTriggerLinkOutput(
+			$I,
+			formURL: $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_URL'],
+			text: 'Subscribe'
+		);
 
 		// Confirm that one Kit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
@@ -91,7 +98,10 @@ class PageBlockFormatterFormTriggerCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form Trigger Formatter: Modal Form Toggle');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Trigger Formatter: Modal Form Toggle'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -111,9 +121,9 @@ class PageBlockFormatterFormTriggerCest
 		// Apply formatter to link the selected text.
 		$I->applyGutenbergFormatter(
 			$I,
-			'Kit Form Trigger',
-			'convertkit-form-link',
-			[
+			formatterName: 'Kit Form Trigger',
+			formatterProgrammaticName: 'convertkit-form-link',
+			formatterConfiguration: [
 				// Form.
 				'data-id' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
@@ -122,9 +132,9 @@ class PageBlockFormatterFormTriggerCest
 		// Select text and apply the formatter again, this time selecting the 'None' option.
 		$I->applyGutenbergFormatter(
 			$I,
-			'Kit Form Trigger',
-			'convertkit-form-link',
-			[
+			formatterName: 'Kit Form Trigger',
+			formatterProgrammaticName: 'convertkit-form-link',
+			formatterConfiguration: [
 				// Form.
 				'data-id' => [ 'select', 'None' ],
 			]
@@ -151,7 +161,10 @@ class PageBlockFormatterFormTriggerCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form Trigger Formatter: No Form');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Trigger Formatter: No Form'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -171,9 +184,9 @@ class PageBlockFormatterFormTriggerCest
 		// Apply formatter to link the selected text.
 		$I->applyGutenbergFormatter(
 			$I,
-			'Kit Form Trigger',
-			'convertkit-form-link',
-			[
+			formatterName: 'Kit Form Trigger',
+			formatterProgrammaticName: 'convertkit-form-link',
+			formatterConfiguration: [
 				// Form.
 				'data-id' => [ 'select', 'None' ],
 			]
@@ -196,7 +209,10 @@ class PageBlockFormatterFormTriggerCest
 	public function testFormTriggerFormatterNotRegisteredWhenNoFormsExist(EndToEndTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form Trigger Formatter: No Forms Exist');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Trigger Formatter: No Forms Exist'
+		);
 
 		// Add paragraph to Page.
 		$I->addGutenbergParagraphBlock($I, 'Subscribe');

--- a/tests/EndToEnd/forms/blocks-shortcodes/PageShortcodeFormCest.php
+++ b/tests/EndToEnd/forms/blocks-shortcodes/PageShortcodeFormCest.php
@@ -38,7 +38,10 @@ class PageShortcodeFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form: Shortcode: Visual Editor');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form: Shortcode: Visual Editor'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
 		$I->configureMetaboxSettings(
@@ -52,11 +55,11 @@ class PageShortcodeFormCest
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Form',
-			[
+			shortcodeName: 'Kit Form',
+			shortcodeConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			],
-			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
+			expectedShortcodeOutput: '[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -82,7 +85,10 @@ class PageShortcodeFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form: Shortcode: Text Editor');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form: Shortcode: Text Editor'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
 		$I->configureMetaboxSettings(
@@ -96,11 +102,11 @@ class PageShortcodeFormCest
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
-			'convertkit-form',
-			[
+			shortcodeName: 'Kit Form',
+			shortcodeConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			],
-			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
+			expectedShortcodeOutput: '[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -439,7 +445,10 @@ class PageShortcodeFormCest
 		$I->setupKitPluginResourcesNoData($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form: Shortcode: No Forms');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form: Shortcode: No Forms'
+		);
 
 		// Open Visual Editor modal for the shortcode.
 		$I->openVisualEditorShortcodeModal(
@@ -500,7 +509,10 @@ class PageShortcodeFormCest
 		$I->activateThirdPartyPlugin($I, 'autoptimize');
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form: Shortcode: Autoptimize');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form: Shortcode: Autoptimize'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
 		$I->configureMetaboxSettings(
@@ -514,11 +526,11 @@ class PageShortcodeFormCest
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Form',
-			[
+			shortcodeName: 'Kit Form',
+			shortcodeConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			],
-			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
+			expectedShortcodeOutput: '[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -556,7 +568,10 @@ class PageShortcodeFormCest
 		$I->click('#inspector-toggle-control-1');
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form: Shortcode: Jetpack Boost');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form: Shortcode: Jetpack Boost'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
 		$I->configureMetaboxSettings(
@@ -570,11 +585,11 @@ class PageShortcodeFormCest
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Form',
-			[
+			shortcodeName: 'Kit Form',
+			shortcodeConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			],
-			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
+			expectedShortcodeOutput: '[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -612,7 +627,10 @@ class PageShortcodeFormCest
 		$I->enableLiteSpeedCacheLoadJSDeferred($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form: Shortcode: LiteSpeed Cache');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form: Shortcode: LiteSpeed Cache'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
 		$I->configureMetaboxSettings(
@@ -626,11 +644,11 @@ class PageShortcodeFormCest
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Form',
-			[
+			shortcodeName: 'Kit Form',
+			shortcodeConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			],
-			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
+			expectedShortcodeOutput: '[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -676,7 +694,10 @@ class PageShortcodeFormCest
 		);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form: Shortcode: Perfmatters');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form: Shortcode: Perfmatters'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
 		$I->configureMetaboxSettings(
@@ -690,11 +711,11 @@ class PageShortcodeFormCest
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Form',
-			[
+			shortcodeName: 'Kit Form',
+			shortcodeConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			],
-			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
+			expectedShortcodeOutput: '[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -730,7 +751,10 @@ class PageShortcodeFormCest
 		$I->haveOptionInDatabase('siteground_optimizer_combine_javascript', '1');
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form: Shortcode: Siteground Speed Optimizer');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form: Shortcode: Siteground Speed Optimizer'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
 		$I->configureMetaboxSettings(
@@ -744,11 +768,11 @@ class PageShortcodeFormCest
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Form',
-			[
+			shortcodeName: 'Kit Form',
+			shortcodeConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			],
-			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
+			expectedShortcodeOutput: '[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -784,7 +808,10 @@ class PageShortcodeFormCest
 		$I->enableWPRocketDelayJS($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form: Shortcode: WP Rocket');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form: Shortcode: WP Rocket'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
 		$I->configureMetaboxSettings(
@@ -798,11 +825,11 @@ class PageShortcodeFormCest
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Form',
-			[
+			shortcodeName: 'Kit Form',
+			shortcodeConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			],
-			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
+			expectedShortcodeOutput: '[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
 		);
 
 		// Publish and view the Page on the frontend site.

--- a/tests/EndToEnd/forms/blocks-shortcodes/PageShortcodeFormTriggerCest.php
+++ b/tests/EndToEnd/forms/blocks-shortcodes/PageShortcodeFormTriggerCest.php
@@ -38,16 +38,19 @@ class PageShortcodeFormTriggerCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form Trigger: Shortcode: Visual Editor');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Shortcode: Visual Editor'
+		);
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Form Trigger',
-			[
+			shortcodeName: 'Kit Form Trigger',
+			shortcodeConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			],
-			'[convertkit_formtrigger form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '" text="Subscribe"]'
+			expectedShortcodeOutput: '[convertkit_formtrigger form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '" text="Subscribe"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -72,16 +75,19 @@ class PageShortcodeFormTriggerCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form Trigger: Shortcode: Text Editor');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Shortcode: Text Editor'
+		);
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
-			'convertkit-formtrigger',
-			[
+			shortcodeName: 'convertkit-formtrigger',
+			shortcodeConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			],
-			'[convertkit_formtrigger form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '" text="Subscribe"]'
+			expectedShortcodeOutput: '[convertkit_formtrigger form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '" text="Subscribe"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -136,17 +142,20 @@ class PageShortcodeFormTriggerCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form Trigger: Shortcode: Text Param');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Shortcode: Text Param'
+		);
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Form Trigger',
-			[
+			shortcodeName: 'Kit Form Trigger',
+			shortcodeConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 				'text' => [ 'input', 'Sign up' ],
 			],
-			'[convertkit_formtrigger form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '" text="Sign up"]'
+			expectedShortcodeOutput: '[convertkit_formtrigger form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '" text="Sign up"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -170,17 +179,20 @@ class PageShortcodeFormTriggerCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form Trigger: Shortcode: Blank Text Param');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Shortcode: Blank Text Param'
+		);
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Form Trigger',
-			[
+			shortcodeName: 'Kit Form Trigger',
+			shortcodeConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 				'text' => [ 'input', '' ],
 			],
-			'[convertkit_formtrigger form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '"]'
+			expectedShortcodeOutput: '[convertkit_formtrigger form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -281,12 +293,15 @@ class PageShortcodeFormTriggerCest
 	public function testFormTriggerShortcodeWhenNoCredentials(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form Trigger: Shortcode: No Credentials');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Shortcode: No Credentials'
+		);
 
 		// Open Visual Editor modal for the shortcode.
 		$I->openVisualEditorShortcodeModal(
 			$I,
-			'Kit Form Trigger'
+			shortcodeName: 'Kit Form Trigger'
 		);
 
 		// Confirm an error notice displays.
@@ -339,12 +354,15 @@ class PageShortcodeFormTriggerCest
 		$I->setupKitPluginResourcesNoData($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form Trigger: Shortcode: No Forms');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Shortcode: No Forms'
+		);
 
 		// Open Visual Editor modal for the shortcode.
 		$I->openVisualEditorShortcodeModal(
 			$I,
-			'Kit Form Trigger'
+			shortcodeName: 'Kit Form Trigger'
 		);
 
 		// Confirm an error notice displays.

--- a/tests/EndToEnd/forms/general/CategoryFormCest.php
+++ b/tests/EndToEnd/forms/general/CategoryFormCest.php
@@ -45,13 +45,17 @@ class CategoryFormCest
 
 		// Create Category.
 		$I->fillField('tag-name', 'Kit: Create Category');
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 
 		// Check the order of the Form resources are alphabetical, with the Default option prepending the Forms.
 		$I->checkSelectFormOptionOrder(
 			$I,
-			'#wp-convertkit-form',
-			[
+			selectElement: '#wp-convertkit-form',
+			prependedOptions: [
 				'Default',
 				'None',
 			]
@@ -107,13 +111,17 @@ class CategoryFormCest
 
 		// Create Category.
 		$I->fillField('tag-name', 'Kit: Create Category: None');
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None');
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-form-container',
+			value: 'None'
+		);
 
 		// Check the order of the Form resources are alphabetical, with the Default option prepending the Forms.
 		$I->checkSelectFormOptionOrder(
 			$I,
-			'#wp-convertkit-form',
-			[
+			selectElement: '#wp-convertkit-form',
+			prependedOptions: [
 				'Default',
 				'None',
 			]
@@ -187,15 +195,19 @@ class CategoryFormCest
 		// Check the order of the Form resources are alphabetical, with the Default option prepending the Forms.
 		$I->checkSelectFormOptionOrder(
 			$I,
-			'#wp-convertkit-form',
-			[
+			selectElement: '#wp-convertkit-form',
+			prependedOptions: [
 				'Default',
 				'None',
 			]
 		);
 
 		// Change Form to value specified in the .env file.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 
 		// Click Update.
 		$I->click('Update');
@@ -258,15 +270,19 @@ class CategoryFormCest
 		// Check the order of the Form resources are alphabetical, with the Default option prepending the Forms.
 		$I->checkSelectFormOptionOrder(
 			$I,
-			'#wp-convertkit-form',
-			[
+			selectElement: '#wp-convertkit-form',
+			prependedOptions: [
 				'Default',
 				'None',
 			]
 		);
 
 		// Change Form to None.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None');
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-form-container',
+			value: 'None'
+		);
 
 		// Click Update.
 		$I->click('Update');
@@ -307,7 +323,11 @@ class CategoryFormCest
 
 		// Create Category.
 		$I->fillField('tag-name', 'Kit: Position: Before');
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 		$I->selectOption('wp-convertkit[form_position]', 'before');
 
 		// Save.
@@ -365,7 +385,11 @@ class CategoryFormCest
 
 		// Create Category.
 		$I->fillField('tag-name', 'Kit: Position: After');
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 		$I->selectOption('wp-convertkit[form_position]', 'after');
 
 		// Save.
@@ -445,15 +469,19 @@ class CategoryFormCest
 		// Check the order of the Form resources are alphabetical, with the Default option prepending the Forms.
 		$I->checkSelectFormOptionOrder(
 			$I,
-			'#wp-convertkit-form',
-			[
+			selectElement: '#wp-convertkit-form',
+			prependedOptions: [
 				'Default',
 				'None',
 			]
 		);
 
 		// Change Form to value specified in the .env file.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 		$I->selectOption('wp-convertkit[form_position]', 'before');
 
 		// Click Update.
@@ -526,15 +554,19 @@ class CategoryFormCest
 		// Check the order of the Form resources are alphabetical, with the Default option prepending the Forms.
 		$I->checkSelectFormOptionOrder(
 			$I,
-			'#wp-convertkit-form',
-			[
+			selectElement: '#wp-convertkit-form',
+			prependedOptions: [
 				'Default',
 				'None',
 			]
 		);
 
 		// Change Form to value specified in the .env file.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 		$I->selectOption('wp-convertkit[form_position]', 'after');
 
 		// Click Update.

--- a/tests/EndToEnd/forms/general/EditFormLinkCest.php
+++ b/tests/EndToEnd/forms/general/EditFormLinkCest.php
@@ -39,13 +39,16 @@ class EditFormLinkCest
 	public function testEditFormLinkOnPage(EndToEndTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Default: Edit Link');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Default: Edit Link'
+		);
 
 		// Configure metabox's Form setting = Default.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'Default' ],
 			]
 		);
@@ -77,13 +80,16 @@ class EditFormLinkCest
 	public function testEditFormLinkOnPageWithNoForm(EndToEndTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: None: Edit Link');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: None: Edit Link'
+		);
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
@@ -174,13 +180,16 @@ class EditFormLinkCest
 		);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Legacy: Edit Link');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Legacy: Edit Link'
+		);
 
 		// Configure metabox's Form setting = Legacy.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
 			]
 		);
@@ -212,13 +221,16 @@ class EditFormLinkCest
 	public function testEditFormLinkOnPageWithFormBlock(EndToEndTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Edit Link');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: Edit Link'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
@@ -226,9 +238,9 @@ class EditFormLinkCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -261,13 +273,16 @@ class EditFormLinkCest
 	public function testEditFormLinkOnPageWithFormBlockSpecifyingNonInlineForm(EndToEndTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Non Inline: Edit Link');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: Non Inline: Edit Link'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
@@ -275,9 +290,9 @@ class EditFormLinkCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ],
 			]
 		);

--- a/tests/EndToEnd/forms/general/NonInlineFormCest.php
+++ b/tests/EndToEnd/forms/general/NonInlineFormCest.php
@@ -200,8 +200,8 @@ class NonInlineFormCest
 		// Configure metabox's Form setting = Default.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'Default' ],
 			]
 		);
@@ -235,13 +235,16 @@ class NonInlineFormCest
 		);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Non-Inline Form: Specific');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Non-Inline Form: Specific'
+		);
 
 		// Configure metabox's Form setting = Modal Form.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
 		);
@@ -275,13 +278,16 @@ class NonInlineFormCest
 		);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Non-Inline Form: None: Ignored');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Non-Inline Form: None: Ignored'
+		);
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
@@ -316,13 +322,16 @@ class NonInlineFormCest
 		);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Non-Inline Form: None: Honored');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Non-Inline Form: None: Honored'
+		);
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
@@ -355,13 +364,16 @@ class NonInlineFormCest
 		);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Non-Inline Form: Block');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Non-Inline Form: Block'
+		);
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
@@ -369,9 +381,9 @@ class NonInlineFormCest
 		// Add Form block to the Page set to the Modal Form.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
 		);
@@ -405,13 +417,16 @@ class NonInlineFormCest
 		);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Non-Inline Form: Shortcode');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Non-Inline Form: Shortcode'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
@@ -419,11 +434,11 @@ class NonInlineFormCest
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Form',
-			[
+			shortcodeName: 'Kit Form',
+			shortcodeConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			],
-			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '"]'
+			shortcodeContent: '[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -457,13 +472,16 @@ class NonInlineFormCest
 		);
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Non-Inline Form: Default');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Post: Non-Inline Form: Default'
+		);
 
 		// Configure metabox's Form setting = Default.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'Default' ],
 			]
 		);
@@ -497,13 +515,16 @@ class NonInlineFormCest
 		);
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Non-Inline Form: Specific');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Post: Non-Inline Form: Specific'
+		);
 
 		// Configure metabox's Form setting = Modal Form.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
 		);
@@ -593,13 +614,16 @@ class NonInlineFormCest
 		);
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Non-Inline Form: None: Ignored');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Post: Non-Inline Form: None: Ignored'
+		);
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
@@ -634,13 +658,16 @@ class NonInlineFormCest
 		);
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Non-Inline Form: None: Honored');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Post: Non-Inline Form: None: Honored'
+		);
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);

--- a/tests/EndToEnd/forms/general/WidgetFormCest.php
+++ b/tests/EndToEnd/forms/general/WidgetFormCest.php
@@ -61,9 +61,9 @@ class WidgetFormCest
 		// Add legacy widget, setting the Form setting to the value specified in the .env file.
 		$I->addLegacyWidget(
 			$I,
-			'Kit Form (Legacy Widget)',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form (Legacy Widget)',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -99,9 +99,9 @@ class WidgetFormCest
 		// Add legacy widget, setting the Form setting to the value specified in the .env file.
 		$I->addLegacyWidget(
 			$I,
-			'Kit Form (Legacy Widget)',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form (Legacy Widget)',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
 			]
 		);
@@ -125,9 +125,9 @@ class WidgetFormCest
 		// Add block widget, setting the Form setting to the value specified in the .env file.
 		$I->addBlockWidget(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -159,9 +159,9 @@ class WidgetFormCest
 		// Add block widget, setting the Form setting to the value specified in the .env file.
 		$I->addBlockWidget(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
 			]
 		);
@@ -186,9 +186,9 @@ class WidgetFormCest
 		// Add block widget, setting the Form setting to the value specified in the .env file.
 		$I->addBlockWidget(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
 		);
@@ -220,9 +220,9 @@ class WidgetFormCest
 		// Add block widget, setting the Form setting to the value specified in the .env file.
 		$I->addBlockWidget(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] ],
 			]
 		);
@@ -254,9 +254,9 @@ class WidgetFormCest
 		// Add block widget, setting the Form setting to the value specified in the .env file.
 		$I->addBlockWidget(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ],
 			]
 		);


### PR DESCRIPTION
## Summary

Uses named arguments in Tests, as they run on PHP 8.1 and higher, which supports this.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)