### PR TITLE
Tests: Use Named Arguments, Part 2

### DIFF
--- a/tests/EndToEnd/broadcasts/blocks-shortcodes/PageBlockBroadcastsCest.php
+++ b/tests/EndToEnd/broadcasts/blocks-shortcodes/PageBlockBroadcastsCest.php
@@ -35,15 +35,22 @@ class PageBlockBroadcastsCest
 	public function testBroadcastsBlockWhenNoCredentials(EndToEndTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: Block: No Credentials');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Block: No Credentials'
+		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Broadcasts', 'convertkit-broadcasts');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts'
+		);
 
 		// Test that the popup window works.
 		$I->testBlockNoCredentialsPopupWindow(
 			$I,
-			'convertkit-broadcasts'
+			blockName: 'convertkit-broadcasts'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -72,13 +79,23 @@ class PageBlockBroadcastsCest
 		$I->setupKitPluginResourcesNoData($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: No Broadcasts');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: No Broadcasts'
+		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Broadcasts', 'convertkit-broadcasts');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts'
+		);
 
 		// Confirm that the Broadcasts block displays instructions to the user on how to add a Broadcast in Kit.
-		$I->seeBlockHasNoContentMessage($I, 'No broadcasts exist in Kit.');
+		$I->seeBlockHasNoContentMessage(
+			$I,
+			message: 'No broadcasts exist in Kit.'
+		);
 
 		// Click the link to confirm it loads Kit.
 		$I->clickLinkInBlockAndAssertKitLoginScreen($I, 'Click here to send your first broadcast.');
@@ -104,10 +121,17 @@ class PageBlockBroadcastsCest
 		$I->setupKitPluginResourcesNoData($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: Refresh Button');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Refresh Button'
+		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Broadcasts', 'convertkit-broadcasts');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts'
+		);
 
 		// Setup Plugin with a valid API Key and resources, as if the user performed the necessary steps to authenticate
 		// and created a broadcast.
@@ -143,10 +167,17 @@ class PageBlockBroadcastsCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: Default Params');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Default Params'
+		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Broadcasts', 'convertkit-broadcasts');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts'
+		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -183,14 +214,17 @@ class PageBlockBroadcastsCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: Display as Grid');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Display as Grid'
+		);
 
 		// Add block to Page, setting the date format.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			parameters: [
 				'#inspector-toggle-control-0' => [ 'toggle', true ],
 			]
 		);
@@ -222,14 +256,17 @@ class PageBlockBroadcastsCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: Date Format Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Date Format Param'
+		);
 
 		// Add block to Page, setting the date format.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			parameters: [
 				'date_format' => [ 'select', 'Y-m-d' ],
 			]
 		);
@@ -269,14 +306,17 @@ class PageBlockBroadcastsCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: Display image');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Display image'
+		);
 
 		// Add block to Page, setting the date format.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			parameters: [
 				'#inspector-toggle-control-0' => [ 'toggle', true ],
 				'#inspector-toggle-control-1' => [ 'toggle', true ],
 			]
@@ -310,14 +350,17 @@ class PageBlockBroadcastsCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: Display description');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Display description'
+		);
 
 		// Add block to Page, setting the date format.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			parameters: [
 				'#inspector-toggle-control-2' => [ 'toggle', true ],
 			]
 		);
@@ -349,14 +392,17 @@ class PageBlockBroadcastsCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: Display read more link');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Display read more link'
+		);
 
 		// Add block to Page, setting the date format.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			parameters: [
 				'#inspector-toggle-control-3' => [ 'toggle', true ],
 				'read_more_label'             => [ 'input', 'Continue reading' ],
 			]
@@ -389,14 +435,17 @@ class PageBlockBroadcastsCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: Limit Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Limit Param'
+		);
 
 		// Add block to Page, setting the limit.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			parameters: [
 				'limit' => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 			]
 		);
@@ -433,10 +482,17 @@ class PageBlockBroadcastsCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: Blank Limit Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Blank Limit Param'
+		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Broadcasts', 'convertkit-broadcasts');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts'
+		);
 
 		// When the sidebar appears, blank the limit parameter as the user might, by pressing the backspace key twice.
 		$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
@@ -479,14 +535,17 @@ class PageBlockBroadcastsCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: Pagination');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Pagination'
+		);
 
 		// Add block to Page, setting the limit.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			parameters: [
 				'limit'                       => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 				'#inspector-toggle-control-4' => [ 'toggle', true ],
 			]
@@ -513,14 +572,17 @@ class PageBlockBroadcastsCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: Pagination Labels');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Pagination Labels'
+		);
 
 		// Add block to Page, setting the limit.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			parameters: [
 				'limit'                       => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 				'#inspector-toggle-control-4' => [ 'toggle', true ],
 				'paginate_label_prev'         => [ 'input', 'Newer' ],
@@ -549,14 +611,17 @@ class PageBlockBroadcastsCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: Blank Pagination Labels');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Blank Pagination Labels'
+		);
 
 		// Add block to Page, setting the limit.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			parameters: [
 				'limit'                       => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 				'#inspector-toggle-control-4' => [ 'toggle', true ],
 				'paginate_label_prev'         => [ 'input', '' ],

--- a/tests/EndToEnd/broadcasts/blocks-shortcodes/PageShortcodeBroadcastsCest.php
+++ b/tests/EndToEnd/broadcasts/blocks-shortcodes/PageShortcodeBroadcastsCest.php
@@ -36,14 +36,16 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInVisualEditorWithDefaultParameters(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Visual Editor');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Visual Editor'
+		);
 
 		// Add shortcode to Page.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Broadcasts',
-			false,
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			shortcodeName:'Kit Broadcasts',
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -77,16 +79,19 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInVisualEditorWithDisplayGridParameter(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Display as Grid');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Display as Grid'
+		);
 
 		// Add shortcode to Page.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Broadcasts',
-			[
+			shortcodeName: 'Kit Broadcasts',
+			shortcodeConfiguration: [
 				'display_grid' => [ 'toggle', 'Yes' ],
 			],
-			'[convertkit_broadcasts display_grid="1" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="1" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -113,16 +118,19 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInVisualEditorWithDateFormatParameter(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Date Format');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Date Format'
+		);
 
 		// Add shortcode to Page.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Broadcasts',
-			[
+			shortcodeName: 'Kit Broadcasts',
+			shortcodeConfiguration: [
 				'date_format' => [ 'select', date('Y-m-d') ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="Y-m-d" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="Y-m-d" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -156,16 +164,19 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInVisualEditorWithDisplayImageParameter(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Display image');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Display image'
+		);
 
 		// Add shortcode to Page.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Broadcasts',
-			[
+			shortcodeName: 'Kit Broadcasts',
+			shortcodeConfiguration: [
 				'display_image' => [ 'toggle', 'Yes' ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="1" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="1" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -191,16 +202,19 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInVisualEditorWithDisplayDescriptionParameter(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Display description');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Display description'
+		);
 
 		// Add shortcode to Page.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Broadcasts',
-			[
+			shortcodeName: 'Kit Broadcasts',
+			shortcodeConfiguration: [
 				'display_description' => [ 'toggle', 'Yes' ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="1" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="1" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -226,17 +240,20 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInVisualEditorWithDisplayReadMoreLinkParameter(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Display read more link');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Display read more link'
+		);
 
 		// Add shortcode to Page.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Broadcasts',
-			[
+			shortcodeName: 'Kit Broadcasts',
+			shortcodeConfiguration: [
 				'display_read_more' => [ 'toggle', 'Yes' ],
 				'read_more_label'   => [ 'input', 'Continue reading' ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="1" read_more_label="Continue reading" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="1" read_more_label="Continue reading" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -263,16 +280,19 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInVisualEditorWithLimitParameter(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Limit');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Limit'
+		);
 
 		// Add shortcode to Page.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Broadcasts',
-			[
+			shortcodeName: 'Kit Broadcasts',
+			shortcodeConfiguration: [
 				'limit' => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -304,24 +324,31 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInVisualEditorWithPaginationEnabled(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Pagination');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Pagination'
+		);
 
 		// Add shortcode to Page.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Broadcasts',
-			[
+			shortcodeName: 'Kit Broadcasts',
+			shortcodeConfiguration: [
 				'limit'    => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 				'paginate' => [ 'toggle', 'Yes' ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewClassicEditorPage($I);
 
 		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Previous', 'Next');
+		$I->testBroadcastsPagination(
+			$I,
+			previousLabel: 'Previous',
+			nextLabel: 'Next'
+		);
 	}
 
 	/**
@@ -335,26 +362,33 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInVisualEditorWithPaginationLabelParameters(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Pagination Labels');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Pagination Labels'
+		);
 
 		// Add shortcode to Page.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Broadcasts',
-			[
+			shortcodeName: 'Kit Broadcasts',
+			shortcodeConfiguration: [
 				'limit'               => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 				'paginate'            => [ 'toggle', 'Yes' ],
 				'paginate_label_prev' => [ 'input', 'Newer' ],
 				'paginate_label_next' => [ 'input', 'Older' ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older"]'
 		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewClassicEditorPage($I);
 
 		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Older', 'Newer');
+		$I->testBroadcastsPagination(
+			$I,
+			previousLabel: 'Older',
+			nextLabel: 'Newer'
+		);
 	}
 
 	/**
@@ -368,26 +402,33 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInVisualEditorWithBlankPaginationLabelParameters(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Blank Pagination Labels');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Visual Editor: Blank Pagination Labels'
+		);
 
 		// Add shortcode to Page.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Broadcasts',
-			[
+			shortcodeName: 'Kit Broadcasts',
+			shortcodeConfiguration: [
 				'limit'               => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 				'paginate'            => [ 'toggle', 'Yes' ],
 				'paginate_label_prev' => [ 'input', '' ],
 				'paginate_label_next' => [ 'input', '' ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="1"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="1"]'
 		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewClassicEditorPage($I);
 
 		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Previous', 'Next');
+		$I->testBroadcastsPagination(
+			$I,
+			previousLabel: 'Previous',
+			nextLabel: 'Next'
+		);
 	}
 
 	/**
@@ -441,7 +482,11 @@ class PageShortcodeBroadcastsCest
 		$I->seeInSource('<a href="' . $_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:' . $linkColor . '"');
 
 		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Older', 'Newer');
+		$I->testBroadcastsPagination(
+			$I,
+			previousLabel: 'Older',
+			nextLabel: 'Newer'
+		);
 
 		// Confirm that link styles are still applied to refreshed data.
 		$I->seeInSource('<a href="' . $_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:' . $linkColor . '"');
@@ -458,14 +503,16 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInTextEditorWithDefaultParameters(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Text Editor');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Text Editor'
+		);
 
 		// Add shortcode to Page.
 		$I->addTextEditorShortcode(
 			$I,
-			'convertkit-broadcasts',
-			false,
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			shortcodeProgrammaticName: 'convertkit-broadcasts',
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -497,16 +544,19 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInTextEditorWithDisplayGridParameter(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Text Editor: Display as Grid');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Text Editor: Display as Grid'
+		);
 
 		// Add shortcode to Page.
 		$I->addTextEditorShortcode(
 			$I,
-			'convertkit-broadcasts',
-			[
+			shortcodeProgrammaticName: 'convertkit-broadcasts',
+			shortcodeConfiguration: [
 				'display_grid' => [ 'toggle', 'Yes' ],
 			],
-			'[convertkit_broadcasts display_grid="1" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="1" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -533,16 +583,19 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInTextEditorWithDateFormatParameter(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Text Editor: Date Format');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Text Editor: Date Format'
+		);
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
-			'convertkit-broadcasts',
-			[
+			shortcodeProgrammaticName: 'convertkit-broadcasts',
+			shortcodeConfiguration: [
 				'date_format' => [ 'select', date('Y-m-d') ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="Y-m-d" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="Y-m-d" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -571,16 +624,19 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInTextEditorWithDisplayImageParameter(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Text Editor: Display image');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Text Editor: Display image'
+		);
 
 		// Add shortcode to Page.
 		$I->addTextEditorShortcode(
 			$I,
-			'convertkit-broadcasts',
-			[
+			shortcodeProgrammaticName: 'convertkit-broadcasts',
+			shortcodeConfiguration: [
 				'display_image' => [ 'toggle', 'Yes' ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="1" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="1" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -607,16 +663,19 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInTextEditorWithDisplayDescriptionParameter(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Text Editor: Display description');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Text Editor: Display description'
+		);
 
 		// Add shortcode to Page.
 		$I->addTextEditorShortcode(
 			$I,
-			'convertkit-broadcasts',
-			[
+			shortcodeProgrammaticName: 'convertkit-broadcasts',
+			shortcodeConfiguration: [
 				'display_description' => [ 'toggle', 'Yes' ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="1" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="1" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -643,17 +702,20 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInTextEditorWithDisplayReadMoreLinkParameter(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Text Editor: Display read more link');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Text Editor: Display read more link'
+		);
 
 		// Add shortcode to Page.
 		$I->addTextEditorShortcode(
 			$I,
-			'convertkit-broadcasts',
-			[
+			shortcodeProgrammaticName: 'convertkit-broadcasts',
+			shortcodeConfiguration: [
 				'display_read_more' => [ 'toggle', 'Yes' ],
 				'read_more_label'   => [ 'input', 'Continue reading' ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="1" read_more_label="Continue reading" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="1" read_more_label="Continue reading" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -680,16 +742,19 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInTextEditorWithLimitParameter(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Text Editor: Limit');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Text Editor: Limit'
+		);
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
-			'convertkit-broadcasts',
-			[
+			shortcodeProgrammaticName: 'convertkit-broadcasts',
+			shortcodeConfiguration: [
 				'limit' => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -718,24 +783,31 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInTextEditorWithPaginationEnabled(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Text Editor: Pagination');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Text Editor: Pagination'
+		);
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
-			'convertkit-broadcasts',
-			[
+			shortcodeProgrammaticName: 'convertkit-broadcasts',
+			shortcodeConfiguration: [
 				'limit'    => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 				'paginate' => [ 'toggle', 'Yes' ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewClassicEditorPage($I);
 
 		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Previous', 'Next');
+		$I->testBroadcastsPagination(
+			$I,
+			previousLabel: 'Previous',
+			nextLabel: 'Next'
+		);
 	}
 
 	/**
@@ -749,26 +821,33 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeInTextEditorWithPaginationLabelParameters(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Text Editor: Pagination Labels');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Text Editor: Pagination Labels'
+		);
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
-			'convertkit-broadcasts',
-			[
+			shortcodeProgrammaticName: 'convertkit-broadcasts',
+			shortcodeConfiguration: [
 				'limit'               => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 				'paginate'            => [ 'toggle', 'Yes' ],
 				'paginate_label_prev' => [ 'input', 'Newer' ],
 				'paginate_label_next' => [ 'input', 'Older' ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older"]'
 		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewClassicEditorPage($I);
 
 		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Older', 'Newer');
+		$I->testBroadcastsPagination(
+			$I,
+			previousLabel: 'Older',
+			nextLabel: 'Newer'
+		);
 	}
 
 	/**
@@ -782,7 +861,10 @@ class PageShortcodeBroadcastsCest
 	public function testBroadcastsShortcodeWhenSwitchingEditors(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Broadcasts: Shortcode: Editor Switching');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Broadcasts: Shortcode: Editor Switching'
+		);
 
 		// Open Text Editor modal.
 		$I->openTextEditorShortcodeModal($I, 'convertkit-broadcasts', 'content');
@@ -794,12 +876,12 @@ class PageShortcodeBroadcastsCest
 		// still works, inserting the shortcode into the Visual Editor.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Broadcasts',
-			[
+			shortcodeName: 'Kit Broadcasts',
+			shortcodeConfiguration: [
 				'limit'    => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 				'paginate' => [ 'toggle', 'Yes' ],
 			],
-			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			expectedShortcodeOutput: '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -838,7 +920,11 @@ class PageShortcodeBroadcastsCest
 		$I->dontSeeInSource('style="color:red" onmouseover="alert(1)""');
 
 		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Previous', 'Next');
+		$I->testBroadcastsPagination(
+			$I,
+			previousLabel: 'Previous',
+			nextLabel: 'Next'
+		);
 
 		// Confirm that the output is still escaped.
 		$I->seeInSource('style="color:red&quot; onmouseover=&quot;alert(1)&quot;"');

--- a/tests/EndToEnd/broadcasts/blocks-shortcodes/WidgetBroadcastsCest.php
+++ b/tests/EndToEnd/broadcasts/blocks-shortcodes/WidgetBroadcastsCest.php
@@ -52,7 +52,11 @@ class WidgetBroadcastsCest
 	public function testBroadcastsBlockWidgetWithDefaultParameters(EndToEndTester $I)
 	{
 		// Add block widget.
-		$I->addBlockWidget($I, 'Kit Broadcasts', 'convertkit-broadcasts');
+		$I->addBlockWidget(
+			$I,
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts'
+		);
 
 		// View the home page.
 		$I->amOnPage('/');
@@ -79,9 +83,9 @@ class WidgetBroadcastsCest
 		// Add block widget.
 		$I->addBlockWidget(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			blockConfiguration: [
 				'date_format' => [ 'select', 'Y-m-d' ],
 			]
 		);
@@ -111,9 +115,9 @@ class WidgetBroadcastsCest
 		// Add block widget.
 		$I->addBlockWidget(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			blockConfiguration: [
 				'limit' => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 			]
 		);
@@ -140,9 +144,9 @@ class WidgetBroadcastsCest
 		// Add block widget.
 		$I->addBlockWidget(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			blockConfiguration: [
 				'#inspector-toggle-control-4' => [ 'toggle', true, 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 				'limit'                       => [ 'input', '2' ],
 			]
@@ -167,9 +171,9 @@ class WidgetBroadcastsCest
 		// Add block widget.
 		$I->addBlockWidget(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			blockConfiguration: [
 				'#inspector-toggle-control-4' => [ 'toggle', true, 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 				'limit'                       => [ 'input', '2' ],
 				'paginate_label_prev'         => [ 'input', 'Newer' ],
@@ -181,7 +185,11 @@ class WidgetBroadcastsCest
 		$I->amOnPage('/');
 
 		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Older', 'Newer');
+		$I->testBroadcastsPagination(
+			$I,
+			previousLabel: 'Older',
+			nextLabel: 'Newer'
+		);
 	}
 
 	/**
@@ -196,9 +204,9 @@ class WidgetBroadcastsCest
 		// Add block widget.
 		$I->addBlockWidget(
 			$I,
-			'Kit Broadcasts',
-			'convertkit-broadcasts',
-			[
+			blockName: 'Kit Broadcasts',
+			blockProgrammaticName: 'convertkit-broadcasts',
+			blockConfiguration: [
 				'#inspector-toggle-control-4' => [ 'toggle', true, 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
 				'limit'                       => [ 'input', '2' ],
 				'paginate_label_prev'         => [ 'input', '' ],
@@ -210,7 +218,11 @@ class WidgetBroadcastsCest
 		$I->amOnPage('/');
 
 		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Previous', 'Next');
+		$I->testBroadcastsPagination(
+			$I,
+			previousLabel: 'Previous',
+			nextLabel: 'Next'
+		);
 	}
 
 	/**

--- a/tests/EndToEnd/broadcasts/import-export/BroadcastsExportPostCest.php
+++ b/tests/EndToEnd/broadcasts/import-export/BroadcastsExportPostCest.php
@@ -37,7 +37,11 @@ class BroadcastsExportPostCest
 	public function testCreateBroadcastNotDisplayedWhenDisabledInPlugin(EndToEndTester $I)
 	{
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Broadcast: Export: Disabled in Plugin');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'post',
+			title: 'Kit: Post: Broadcast: Export: Disabled in Plugin'
+		);
 
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');
@@ -71,7 +75,11 @@ class BroadcastsExportPostCest
 		);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcast: Export: Disabled in Plugin');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'page',
+			title: 'Kit: Page: Broadcast: Export: Disabled in Plugin'
+		);
 
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');
@@ -106,7 +114,11 @@ class BroadcastsExportPostCest
 		);
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Broadcast: Export: Disabled in Post');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'post',
+			title: 'Kit: Post: Broadcast: Export: Disabled in Post'
+		);
 
 		// Publish Post.
 		$I->publishGutenbergPage($I);
@@ -143,7 +155,11 @@ class BroadcastsExportPostCest
 		);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Page: Broadcast: Export: Enabled in Post');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'post',
+			title: 'Kit: Page: Broadcast: Export: Enabled in Post'
+		);
 
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');

--- a/tests/EndToEnd/broadcasts/import-export/BroadcastsExportPostClassicEditorCest.php
+++ b/tests/EndToEnd/broadcasts/import-export/BroadcastsExportPostClassicEditorCest.php
@@ -92,7 +92,11 @@ class BroadcastsExportPostClassicEditorCest
 		);
 
 		// Create a Post.
-		$I->addClassicEditorPage($I, 'post', 'Kit: Broadcasts: Export: Previously published');
+		$I->addClassicEditorPage(
+			$I,
+			postType: 'post',
+			title: 'Kit: Broadcasts: Export: Previously published'
+		);
 
 		// Scroll to Publish meta box, so its buttons are not hidden.
 		$I->scrollTo('#submitdiv');
@@ -127,7 +131,11 @@ class BroadcastsExportPostClassicEditorCest
 		);
 
 		// Create a Post.
-		$I->addClassicEditorPage($I, 'post', 'Kit: Broadcasts: Export: Disabled in Post');
+		$I->addClassicEditorPage(
+			$I,
+			postType: 'post',
+			title: 'Kit: Broadcasts: Export: Disabled in Post'
+		);
 
 		// Scroll to Publish meta box, so its buttons are not hidden.
 		$I->scrollTo('#submitdiv');
@@ -170,7 +178,11 @@ class BroadcastsExportPostClassicEditorCest
 		);
 
 		// Create a Post.
-		$I->addClassicEditorPage($I, 'post', 'Kit: Broadcasts: Export: Enabled in Post');
+		$I->addClassicEditorPage(
+			$I,
+			postType: 'post',
+			title: 'Kit: Broadcasts: Export: Enabled in Post'
+		);
 
 		// Enable the Create Broadcast option.
 		$I->checkOption('#convertkit_action_broadcast_export');

--- a/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormCest.php
+++ b/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormCest.php
@@ -37,7 +37,10 @@ class PageBlockFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Valid Form Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: Valid Form Param'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -51,9 +54,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -89,7 +92,10 @@ class PageBlockFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Legacy Form: Block: Valid Form Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Legacy Form: Block: Valid Form Param'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -103,9 +109,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
 			]
 		);
@@ -132,7 +138,10 @@ class PageBlockFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Valid Modal Form Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: Valid Modal Form Param'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -146,9 +155,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
 		);
@@ -180,7 +189,10 @@ class PageBlockFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Valid Modal Form Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: Valid Modal Form Param'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -194,9 +206,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
 		);
@@ -208,9 +220,9 @@ class PageBlockFormCest
 		// Add the block a second time for the same form, so we can test that only one script / form is output.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
 		);
@@ -238,7 +250,10 @@ class PageBlockFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Valid Slide In Form Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: Valid Slide In Form Param'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -252,9 +267,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] ],
 			]
 		);
@@ -286,7 +301,10 @@ class PageBlockFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Valid Slide In Form Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: Valid Slide In Form Param'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -300,9 +318,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] ],
 			]
 		);
@@ -314,9 +332,9 @@ class PageBlockFormCest
 		// Add the block a second time for the same form, so we can test that only one script / form is output.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] ],
 			]
 		);
@@ -344,7 +362,10 @@ class PageBlockFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Valid Sticky Bar Form Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: Valid Sticky Bar Form Param'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -358,9 +379,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ],
 			]
 		);
@@ -392,7 +413,10 @@ class PageBlockFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Valid Sticky Bar Form Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: Valid Sticky Bar Form Param'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -406,9 +430,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ],
 			]
 		);
@@ -420,9 +444,9 @@ class PageBlockFormCest
 		// Add the block a second time for the same form, so we can test that only one script / form is output.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ],
 			]
 		);
@@ -449,7 +473,10 @@ class PageBlockFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Valid Sticky Bar Form Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: No Form Param'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -461,7 +488,11 @@ class PageBlockFormCest
 		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Form', 'convertkit-form');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form'
+		);
 
 		// Confirm that the Form block displays instructions to the user on how to select a Form.
 		$I->seeBlockHasNoContentMessage($I, 'Select a Form using the Form option in the Gutenberg sidebar.');
@@ -485,16 +516,23 @@ class PageBlockFormCest
 	public function testFormBlockWhenNoCredentials(EndToEndTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: No Credentials');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: No Credentials'
+		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Form', 'convertkit-form');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form'
+		);
 
 		// Test that the popup window works.
 		$I->testBlockNoCredentialsPopupWindow(
 			$I,
-			'convertkit-form',
-			'Select a Form using the Form option in the Gutenberg sidebar.'
+			blockName: 'convertkit-form',
+			expectedMessage: 'Select a Form using the Form option in the Gutenberg sidebar.'
 		);
 
 		// Save page to avoid alert box when _passed() runs to deactivate the Plugin.
@@ -516,10 +554,17 @@ class PageBlockFormCest
 		$I->setupKitPluginResourcesNoData($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: No Forms');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: No Forms'
+		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Form', 'convertkit-form');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form'
+		);
 
 		// Confirm that the Form block displays instructions to the user on how to add a Form in Kit.
 		$I->seeBlockHasNoContentMessage($I, 'No forms exist in Kit.');
@@ -545,10 +590,17 @@ class PageBlockFormCest
 		$I->setupKitPluginResourcesNoData($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Forms: Refresh Button');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Forms: Refresh Button'
+		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Form', 'convertkit-form');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form'
+		);
 
 		// Setup Plugin with a valid API Key and resources, as if the user performed the necessary steps to authenticate
 		// and create a form.
@@ -583,7 +635,10 @@ class PageBlockFormCest
 		$I->activateThirdPartyPlugin($I, 'autoptimize');
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Autoptimize');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: Autoptimize'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -597,9 +652,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -639,7 +694,10 @@ class PageBlockFormCest
 		$I->click('#inspector-toggle-control-1');
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Jetpack Boost');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: Jetpack Boost'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -653,9 +711,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -694,7 +752,10 @@ class PageBlockFormCest
 		$I->haveOptionInDatabase('siteground_optimizer_combine_javascript', '1');
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Siteground Speed Optimizer');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: Siteground Speed Optimizer'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -708,9 +769,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -748,7 +809,10 @@ class PageBlockFormCest
 		$I->enableLiteSpeedCacheLoadJSDeferred($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: LiteSpeed Cache');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: LiteSpeed Cache'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -762,9 +826,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -811,7 +875,10 @@ class PageBlockFormCest
 		);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Perfmatters');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: Perfmatters'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -825,9 +892,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -865,7 +932,10 @@ class PageBlockFormCest
 		$I->enableWPRocketDelayJS($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: WP Rocket');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: WP Rocket'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -879,9 +949,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -926,7 +996,10 @@ class PageBlockFormCest
 		$I->enableWPRocketMinifyConcatenateJSAndCSS($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: WP Rocket');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: WP Rocket'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -940,9 +1013,9 @@ class PageBlockFormCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);

--- a/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormTriggerCest.php
+++ b/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormTriggerCest.php
@@ -37,7 +37,10 @@ class PageBlockFormTriggerCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form Trigger: Valid Form Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Valid Form Param'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -51,9 +54,9 @@ class PageBlockFormTriggerCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form Trigger',
-			'convertkit-formtrigger',
-			[
+			blockName: 'Kit Form Trigger',
+			blockProgrammaticName: 'convertkit-formtrigger',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
 		);
@@ -79,7 +82,10 @@ class PageBlockFormTriggerCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form Trigger: Valid Form Param, Multiple Blocks');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Valid Form Param, Multiple Blocks'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -93,9 +99,9 @@ class PageBlockFormTriggerCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form Trigger',
-			'convertkit-formtrigger',
-			[
+			blockName: 'Kit Form Trigger',
+			blockProgrammaticName: 'convertkit-formtrigger',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
 		);
@@ -135,7 +141,10 @@ class PageBlockFormTriggerCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form Trigger: No Form Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: No Form Param'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -147,7 +156,11 @@ class PageBlockFormTriggerCest
 		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Form Trigger', 'convertkit-formtrigger');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Form Trigger',
+			blockProgrammaticName: 'convertkit-formtrigger'
+		);
 
 		// Confirm that the Form block displays instructions to the user on how to select a Form.
 		$I->seeBlockHasNoContentMessage($I, 'Select a Form using the Form option in the Gutenberg sidebar.');
@@ -173,14 +186,17 @@ class PageBlockFormTriggerCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form Trigger: Text Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Text Param'
+		);
 
 		// Add block to Page, setting the date format.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form Trigger',
-			'convertkit-formtrigger',
-			[
+			blockName: 'Kit Form Trigger',
+			blockProgrammaticName: 'convertkit-formtrigger',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 				'text' => [ 'text', 'Sign up' ],
 			]
@@ -207,14 +223,17 @@ class PageBlockFormTriggerCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form Trigger: Blank Text Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Blank Text Param'
+		);
 
 		// Add block to Page, setting the date format.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form Trigger',
-			'convertkit-formtrigger',
-			[
+			blockName: 'Kit Form Trigger',
+			blockProgrammaticName: 'convertkit-formtrigger',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 				'text' => [ 'text', '' ],
 			]
@@ -362,16 +381,23 @@ class PageBlockFormTriggerCest
 	public function testFormTriggerBlockWhenNoCredentials(EndToEndTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form Trigger: Block: No Credentials');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Block: No Credentials'
+		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Form Trigger', 'convertkit-formtrigger');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Form Trigger',
+			blockProgrammaticName: 'convertkit-formtrigger'
+		);
 
 		// Test that the popup window works.
 		$I->testBlockNoCredentialsPopupWindow(
 			$I,
-			'convertkit-formtrigger',
-			'Select a Form using the Form option in the Gutenberg sidebar.'
+			blockName: 'convertkit-formtrigger',
+			expectedMessage: 'Select a Form using the Form option in the Gutenberg sidebar.'
 		);
 
 		// Save page to avoid alert box when _passed() runs to deactivate the Plugin.
@@ -393,10 +419,17 @@ class PageBlockFormTriggerCest
 		$I->setupKitPluginResourcesNoData($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form Trigger: Block: No Forms');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Block: No Forms'
+		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Form Trigger', 'convertkit-formtrigger');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Form Trigger',
+			blockProgrammaticName: 'convertkit-formtrigger'
+		);
 
 		// Confirm that the Form block displays instructions to the user on how to add a Form in Kit.
 		$I->seeBlockHasNoContentMessage($I, 'No modal, sticky bar or slide in forms exist in Kit.');
@@ -422,10 +455,17 @@ class PageBlockFormTriggerCest
 		$I->setupKitPluginResourcesNoData($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form Trigger: Refresh Button');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Refresh Button'
+		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Form Trigger', 'convertkit-formtrigger');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Form Trigger',
+			blockProgrammaticName: 'convertkit-formtrigger'
+		);
 
 		// Setup Plugin with a valid API Key and resources, as if the user performed the necessary steps to authenticate
 		// and create a form.

--- a/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormatterFormTriggerCest.php
+++ b/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormatterFormTriggerCest.php
@@ -37,7 +37,10 @@ class PageBlockFormatterFormTriggerCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form Trigger Formatter: Modal Form');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Trigger Formatter: Modal Form'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -57,9 +60,9 @@ class PageBlockFormatterFormTriggerCest
 		// Apply formatter to link the selected text.
 		$I->applyGutenbergFormatter(
 			$I,
-			'Kit Form Trigger',
-			'convertkit-form-link',
-			[
+			formatterName: 'Kit Form Trigger',
+			formatterProgrammaticName: 'convertkit-form-link',
+			formatterConfiguration: [
 				// Form.
 				'data-id' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
@@ -69,7 +72,11 @@ class PageBlockFormatterFormTriggerCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the link displays and works when clicked.
-		$I->seeFormTriggerLinkOutput($I, $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_URL'], 'Subscribe');
+		$I->seeFormTriggerLinkOutput(
+			$I,
+			formURL: $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_URL'],
+			text: 'Subscribe'
+		);
 
 		// Confirm that one Kit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
@@ -91,7 +98,10 @@ class PageBlockFormatterFormTriggerCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form Trigger Formatter: Modal Form Toggle');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Trigger Formatter: Modal Form Toggle'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -111,9 +121,9 @@ class PageBlockFormatterFormTriggerCest
 		// Apply formatter to link the selected text.
 		$I->applyGutenbergFormatter(
 			$I,
-			'Kit Form Trigger',
-			'convertkit-form-link',
-			[
+			formatterName: 'Kit Form Trigger',
+			formatterProgrammaticName: 'convertkit-form-link',
+			formatterConfiguration: [
 				// Form.
 				'data-id' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
@@ -122,9 +132,9 @@ class PageBlockFormatterFormTriggerCest
 		// Select text and apply the formatter again, this time selecting the 'None' option.
 		$I->applyGutenbergFormatter(
 			$I,
-			'Kit Form Trigger',
-			'convertkit-form-link',
-			[
+			formatterName: 'Kit Form Trigger',
+			formatterProgrammaticName: 'convertkit-form-link',
+			formatterConfiguration: [
 				// Form.
 				'data-id' => [ 'select', 'None' ],
 			]
@@ -151,7 +161,10 @@ class PageBlockFormatterFormTriggerCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form Trigger Formatter: No Form');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Trigger Formatter: No Form'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -171,9 +184,9 @@ class PageBlockFormatterFormTriggerCest
 		// Apply formatter to link the selected text.
 		$I->applyGutenbergFormatter(
 			$I,
-			'Kit Form Trigger',
-			'convertkit-form-link',
-			[
+			formatterName: 'Kit Form Trigger',
+			formatterProgrammaticName: 'convertkit-form-link',
+			formatterConfiguration: [
 				// Form.
 				'data-id' => [ 'select', 'None' ],
 			]
@@ -196,7 +209,10 @@ class PageBlockFormatterFormTriggerCest
 	public function testFormTriggerFormatterNotRegisteredWhenNoFormsExist(EndToEndTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form Trigger Formatter: No Forms Exist');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Trigger Formatter: No Forms Exist'
+		);
 
 		// Add paragraph to Page.
 		$I->addGutenbergParagraphBlock($I, 'Subscribe');

--- a/tests/EndToEnd/forms/blocks-shortcodes/PageShortcodeFormCest.php
+++ b/tests/EndToEnd/forms/blocks-shortcodes/PageShortcodeFormCest.php
@@ -38,7 +38,10 @@ class PageShortcodeFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form: Shortcode: Visual Editor');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form: Shortcode: Visual Editor'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
 		$I->configureMetaboxSettings(
@@ -52,11 +55,11 @@ class PageShortcodeFormCest
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Form',
-			[
+			shortcodeName: 'Kit Form',
+			shortcodeConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			],
-			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
+			expectedShortcodeOutput: '[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -82,7 +85,10 @@ class PageShortcodeFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form: Shortcode: Text Editor');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form: Shortcode: Text Editor'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
 		$I->configureMetaboxSettings(
@@ -96,11 +102,11 @@ class PageShortcodeFormCest
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
-			'convertkit-form',
-			[
+			shortcodeName: 'Kit Form',
+			shortcodeConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			],
-			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
+			expectedShortcodeOutput: '[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -439,7 +445,10 @@ class PageShortcodeFormCest
 		$I->setupKitPluginResourcesNoData($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form: Shortcode: No Forms');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form: Shortcode: No Forms'
+		);
 
 		// Open Visual Editor modal for the shortcode.
 		$I->openVisualEditorShortcodeModal(
@@ -500,7 +509,10 @@ class PageShortcodeFormCest
 		$I->activateThirdPartyPlugin($I, 'autoptimize');
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form: Shortcode: Autoptimize');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form: Shortcode: Autoptimize'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
 		$I->configureMetaboxSettings(
@@ -514,11 +526,11 @@ class PageShortcodeFormCest
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Form',
-			[
+			shortcodeName: 'Kit Form',
+			shortcodeConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			],
-			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
+			expectedShortcodeOutput: '[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -556,7 +568,10 @@ class PageShortcodeFormCest
 		$I->click('#inspector-toggle-control-1');
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form: Shortcode: Jetpack Boost');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form: Shortcode: Jetpack Boost'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
 		$I->configureMetaboxSettings(
@@ -570,11 +585,11 @@ class PageShortcodeFormCest
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Form',
-			[
+			shortcodeName: 'Kit Form',
+			shortcodeConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			],
-			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
+			expectedShortcodeOutput: '[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -612,7 +627,10 @@ class PageShortcodeFormCest
 		$I->enableLiteSpeedCacheLoadJSDeferred($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form: Shortcode: LiteSpeed Cache');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form: Shortcode: LiteSpeed Cache'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
 		$I->configureMetaboxSettings(
@@ -626,11 +644,11 @@ class PageShortcodeFormCest
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Form',
-			[
+			shortcodeName: 'Kit Form',
+			shortcodeConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			],
-			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
+			expectedShortcodeOutput: '[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -676,7 +694,10 @@ class PageShortcodeFormCest
 		);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form: Shortcode: Perfmatters');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form: Shortcode: Perfmatters'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
 		$I->configureMetaboxSettings(
@@ -690,11 +711,11 @@ class PageShortcodeFormCest
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Form',
-			[
+			shortcodeName: 'Kit Form',
+			shortcodeConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			],
-			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
+			expectedShortcodeOutput: '[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -730,7 +751,10 @@ class PageShortcodeFormCest
 		$I->haveOptionInDatabase('siteground_optimizer_combine_javascript', '1');
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form: Shortcode: Siteground Speed Optimizer');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form: Shortcode: Siteground Speed Optimizer'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
 		$I->configureMetaboxSettings(
@@ -744,11 +768,11 @@ class PageShortcodeFormCest
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Form',
-			[
+			shortcodeName: 'Kit Form',
+			shortcodeConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			],
-			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
+			expectedShortcodeOutput: '[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -784,7 +808,10 @@ class PageShortcodeFormCest
 		$I->enableWPRocketDelayJS($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form: Shortcode: WP Rocket');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form: Shortcode: WP Rocket'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
 		$I->configureMetaboxSettings(
@@ -798,11 +825,11 @@ class PageShortcodeFormCest
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Form',
-			[
+			shortcodeName: 'Kit Form',
+			shortcodeConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			],
-			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
+			expectedShortcodeOutput: '[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
 		);
 
 		// Publish and view the Page on the frontend site.

--- a/tests/EndToEnd/forms/blocks-shortcodes/PageShortcodeFormTriggerCest.php
+++ b/tests/EndToEnd/forms/blocks-shortcodes/PageShortcodeFormTriggerCest.php
@@ -38,16 +38,19 @@ class PageShortcodeFormTriggerCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form Trigger: Shortcode: Visual Editor');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Shortcode: Visual Editor'
+		);
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Form Trigger',
-			[
+			shortcodeName: 'Kit Form Trigger',
+			shortcodeConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			],
-			'[convertkit_formtrigger form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '" text="Subscribe"]'
+			expectedShortcodeOutput: '[convertkit_formtrigger form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '" text="Subscribe"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -72,16 +75,19 @@ class PageShortcodeFormTriggerCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form Trigger: Shortcode: Text Editor');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Shortcode: Text Editor'
+		);
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
-			'convertkit-formtrigger',
-			[
+			shortcodeName: 'convertkit-formtrigger',
+			shortcodeConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			],
-			'[convertkit_formtrigger form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '" text="Subscribe"]'
+			expectedShortcodeOutput: '[convertkit_formtrigger form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '" text="Subscribe"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -136,17 +142,20 @@ class PageShortcodeFormTriggerCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form Trigger: Shortcode: Text Param');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Shortcode: Text Param'
+		);
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Form Trigger',
-			[
+			shortcodeName: 'Kit Form Trigger',
+			shortcodeConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 				'text' => [ 'input', 'Sign up' ],
 			],
-			'[convertkit_formtrigger form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '" text="Sign up"]'
+			expectedShortcodeOutput: '[convertkit_formtrigger form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '" text="Sign up"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -170,17 +179,20 @@ class PageShortcodeFormTriggerCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form Trigger: Shortcode: Blank Text Param');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Shortcode: Blank Text Param'
+		);
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Form Trigger',
-			[
+			shortcodeName: 'Kit Form Trigger',
+			shortcodeConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 				'text' => [ 'input', '' ],
 			],
-			'[convertkit_formtrigger form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '"]'
+			expectedShortcodeOutput: '[convertkit_formtrigger form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -281,12 +293,15 @@ class PageShortcodeFormTriggerCest
 	public function testFormTriggerShortcodeWhenNoCredentials(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form Trigger: Shortcode: No Credentials');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Shortcode: No Credentials'
+		);
 
 		// Open Visual Editor modal for the shortcode.
 		$I->openVisualEditorShortcodeModal(
 			$I,
-			'Kit Form Trigger'
+			shortcodeName: 'Kit Form Trigger'
 		);
 
 		// Confirm an error notice displays.
@@ -339,12 +354,15 @@ class PageShortcodeFormTriggerCest
 		$I->setupKitPluginResourcesNoData($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form Trigger: Shortcode: No Forms');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Shortcode: No Forms'
+		);
 
 		// Open Visual Editor modal for the shortcode.
 		$I->openVisualEditorShortcodeModal(
 			$I,
-			'Kit Form Trigger'
+			shortcodeName: 'Kit Form Trigger'
 		);
 
 		// Confirm an error notice displays.

--- a/tests/EndToEnd/forms/general/CategoryFormCest.php
+++ b/tests/EndToEnd/forms/general/CategoryFormCest.php
@@ -45,13 +45,17 @@ class CategoryFormCest
 
 		// Create Category.
 		$I->fillField('tag-name', 'Kit: Create Category');
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 
 		// Check the order of the Form resources are alphabetical, with the Default option prepending the Forms.
 		$I->checkSelectFormOptionOrder(
 			$I,
-			'#wp-convertkit-form',
-			[
+			selectElement: '#wp-convertkit-form',
+			prependedOptions: [
 				'Default',
 				'None',
 			]
@@ -107,13 +111,17 @@ class CategoryFormCest
 
 		// Create Category.
 		$I->fillField('tag-name', 'Kit: Create Category: None');
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None');
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-form-container',
+			value: 'None'
+		);
 
 		// Check the order of the Form resources are alphabetical, with the Default option prepending the Forms.
 		$I->checkSelectFormOptionOrder(
 			$I,
-			'#wp-convertkit-form',
-			[
+			selectElement: '#wp-convertkit-form',
+			prependedOptions: [
 				'Default',
 				'None',
 			]
@@ -187,15 +195,19 @@ class CategoryFormCest
 		// Check the order of the Form resources are alphabetical, with the Default option prepending the Forms.
 		$I->checkSelectFormOptionOrder(
 			$I,
-			'#wp-convertkit-form',
-			[
+			selectElement: '#wp-convertkit-form',
+			prependedOptions: [
 				'Default',
 				'None',
 			]
 		);
 
 		// Change Form to value specified in the .env file.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 
 		// Click Update.
 		$I->click('Update');
@@ -258,15 +270,19 @@ class CategoryFormCest
 		// Check the order of the Form resources are alphabetical, with the Default option prepending the Forms.
 		$I->checkSelectFormOptionOrder(
 			$I,
-			'#wp-convertkit-form',
-			[
+			selectElement: '#wp-convertkit-form',
+			prependedOptions: [
 				'Default',
 				'None',
 			]
 		);
 
 		// Change Form to None.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None');
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-form-container',
+			value: 'None'
+		);
 
 		// Click Update.
 		$I->click('Update');
@@ -307,7 +323,11 @@ class CategoryFormCest
 
 		// Create Category.
 		$I->fillField('tag-name', 'Kit: Position: Before');
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 		$I->selectOption('wp-convertkit[form_position]', 'before');
 
 		// Save.
@@ -365,7 +385,11 @@ class CategoryFormCest
 
 		// Create Category.
 		$I->fillField('tag-name', 'Kit: Position: After');
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 		$I->selectOption('wp-convertkit[form_position]', 'after');
 
 		// Save.
@@ -445,15 +469,19 @@ class CategoryFormCest
 		// Check the order of the Form resources are alphabetical, with the Default option prepending the Forms.
 		$I->checkSelectFormOptionOrder(
 			$I,
-			'#wp-convertkit-form',
-			[
+			selectElement: '#wp-convertkit-form',
+			prependedOptions: [
 				'Default',
 				'None',
 			]
 		);
 
 		// Change Form to value specified in the .env file.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 		$I->selectOption('wp-convertkit[form_position]', 'before');
 
 		// Click Update.
@@ -526,15 +554,19 @@ class CategoryFormCest
 		// Check the order of the Form resources are alphabetical, with the Default option prepending the Forms.
 		$I->checkSelectFormOptionOrder(
 			$I,
-			'#wp-convertkit-form',
-			[
+			selectElement: '#wp-convertkit-form',
+			prependedOptions: [
 				'Default',
 				'None',
 			]
 		);
 
 		// Change Form to value specified in the .env file.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 		$I->selectOption('wp-convertkit[form_position]', 'after');
 
 		// Click Update.

--- a/tests/EndToEnd/forms/general/EditFormLinkCest.php
+++ b/tests/EndToEnd/forms/general/EditFormLinkCest.php
@@ -39,13 +39,16 @@ class EditFormLinkCest
 	public function testEditFormLinkOnPage(EndToEndTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Default: Edit Link');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Default: Edit Link'
+		);
 
 		// Configure metabox's Form setting = Default.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'Default' ],
 			]
 		);
@@ -77,13 +80,16 @@ class EditFormLinkCest
 	public function testEditFormLinkOnPageWithNoForm(EndToEndTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: None: Edit Link');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: None: Edit Link'
+		);
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
@@ -174,13 +180,16 @@ class EditFormLinkCest
 		);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Legacy: Edit Link');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Legacy: Edit Link'
+		);
 
 		// Configure metabox's Form setting = Legacy.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
 			]
 		);
@@ -212,13 +221,16 @@ class EditFormLinkCest
 	public function testEditFormLinkOnPageWithFormBlock(EndToEndTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Edit Link');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: Edit Link'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
@@ -226,9 +238,9 @@ class EditFormLinkCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -261,13 +273,16 @@ class EditFormLinkCest
 	public function testEditFormLinkOnPageWithFormBlockSpecifyingNonInlineForm(EndToEndTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Block: Non Inline: Edit Link');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Block: Non Inline: Edit Link'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
@@ -275,9 +290,9 @@ class EditFormLinkCest
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ],
 			]
 		);

--- a/tests/EndToEnd/forms/general/NonInlineFormCest.php
+++ b/tests/EndToEnd/forms/general/NonInlineFormCest.php
@@ -200,8 +200,8 @@ class NonInlineFormCest
 		// Configure metabox's Form setting = Default.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'Default' ],
 			]
 		);
@@ -235,13 +235,16 @@ class NonInlineFormCest
 		);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Non-Inline Form: Specific');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Non-Inline Form: Specific'
+		);
 
 		// Configure metabox's Form setting = Modal Form.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
 		);
@@ -275,13 +278,16 @@ class NonInlineFormCest
 		);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Non-Inline Form: None: Ignored');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Non-Inline Form: None: Ignored'
+		);
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
@@ -316,13 +322,16 @@ class NonInlineFormCest
 		);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Non-Inline Form: None: Honored');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Non-Inline Form: None: Honored'
+		);
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
@@ -355,13 +364,16 @@ class NonInlineFormCest
 		);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Non-Inline Form: Block');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Non-Inline Form: Block'
+		);
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
@@ -369,9 +381,9 @@ class NonInlineFormCest
 		// Add Form block to the Page set to the Modal Form.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
 		);
@@ -405,13 +417,16 @@ class NonInlineFormCest
 		);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Non-Inline Form: Shortcode');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Non-Inline Form: Shortcode'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
@@ -419,11 +434,11 @@ class NonInlineFormCest
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Form',
-			[
+			shortcodeName: 'Kit Form',
+			shortcodeConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			],
-			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '"]'
+			shortcodeContent: '[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -457,13 +472,16 @@ class NonInlineFormCest
 		);
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Non-Inline Form: Default');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Post: Non-Inline Form: Default'
+		);
 
 		// Configure metabox's Form setting = Default.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'Default' ],
 			]
 		);
@@ -497,13 +515,16 @@ class NonInlineFormCest
 		);
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Non-Inline Form: Specific');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Post: Non-Inline Form: Specific'
+		);
 
 		// Configure metabox's Form setting = Modal Form.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
 		);
@@ -593,13 +614,16 @@ class NonInlineFormCest
 		);
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Non-Inline Form: None: Ignored');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Post: Non-Inline Form: None: Ignored'
+		);
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
@@ -634,13 +658,16 @@ class NonInlineFormCest
 		);
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Non-Inline Form: None: Honored');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Post: Non-Inline Form: None: Honored'
+		);
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);

--- a/tests/EndToEnd/forms/general/WidgetFormCest.php
+++ b/tests/EndToEnd/forms/general/WidgetFormCest.php
@@ -61,9 +61,9 @@ class WidgetFormCest
 		// Add legacy widget, setting the Form setting to the value specified in the .env file.
 		$I->addLegacyWidget(
 			$I,
-			'Kit Form (Legacy Widget)',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form (Legacy Widget)',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -99,9 +99,9 @@ class WidgetFormCest
 		// Add legacy widget, setting the Form setting to the value specified in the .env file.
 		$I->addLegacyWidget(
 			$I,
-			'Kit Form (Legacy Widget)',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form (Legacy Widget)',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
 			]
 		);
@@ -125,9 +125,9 @@ class WidgetFormCest
 		// Add block widget, setting the Form setting to the value specified in the .env file.
 		$I->addBlockWidget(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -159,9 +159,9 @@ class WidgetFormCest
 		// Add block widget, setting the Form setting to the value specified in the .env file.
 		$I->addBlockWidget(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
 			]
 		);
@@ -186,9 +186,9 @@ class WidgetFormCest
 		// Add block widget, setting the Form setting to the value specified in the .env file.
 		$I->addBlockWidget(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
 		);
@@ -220,9 +220,9 @@ class WidgetFormCest
 		// Add block widget, setting the Form setting to the value specified in the .env file.
 		$I->addBlockWidget(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] ],
 			]
 		);
@@ -254,9 +254,9 @@ class WidgetFormCest
 		// Add block widget, setting the Form setting to the value specified in the .env file.
 		$I->addBlockWidget(
 			$I,
-			'Kit Form',
-			'convertkit-form',
-			[
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form',
+			blockConfiguration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ],
 			]
 		);

--- a/tests/EndToEnd/forms/post-types/CPTFormCest.php
+++ b/tests/EndToEnd/forms/post-types/CPTFormCest.php
@@ -64,7 +64,11 @@ class CPTFormCest
 	public function testNoOptionsOrOutputOnPrivateCustomPostType(EndToEndTester $I)
 	{
 		// Add a Private CPT using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'private', 'Kit: Private: Form: None');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'private',
+			title: 'Kit: Private: Form: None'
+		);
 
 		// Check that the metabox is not displayed.
 		$I->dontSeeElementInDOM('#wp-convertkit-meta-box');
@@ -128,7 +132,11 @@ class CPTFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a CPT using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'article', 'Kit: CPT: Form: Default: None');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'article',
+			title: 'Kit: CPT: Form: Default: None'
+		);
 
 		// Check the order of the Form resources are alphabetical, with the Default and None options prepending the Forms.
 		$I->checkSelectFormOptionOrder(
@@ -143,8 +151,8 @@ class CPTFormCest
 		// Configure metabox's Form setting = Default.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'Default' ],
 			]
 		);
@@ -176,13 +184,17 @@ class CPTFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a CPT using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'article', 'Kit: CPT: Form: Default');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'article',
+			title: 'Kit: CPT: Form: Default'
+		);
 
 		// Configure metabox's Form setting = Default.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'Default' ],
 			]
 		);
@@ -217,7 +229,11 @@ class CPTFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a CPT using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'article', 'Kit: CPT: Form: Default: Before Content');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'article',
+			title: 'Kit: CPT: Form: Default: Before Content'
+		);
 
 		// Add paragraph to CPT.
 		$I->addGutenbergParagraphBlock($I, 'CPT content');
@@ -225,8 +241,8 @@ class CPTFormCest
 		// Configure metabox's Form setting = Default.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'Default' ],
 			]
 		);
@@ -261,7 +277,11 @@ class CPTFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a CPT using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'article', 'Kit: CPT: Form: Default: Before and After Content');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'article',
+			title: 'Kit: CPT: Form: Default: Before and After Content'
+		);
 
 		// Add paragraph to CPT.
 		$I->addGutenbergParagraphBlock($I, 'CPT content');
@@ -269,8 +289,8 @@ class CPTFormCest
 		// Configure metabox's Form setting = Default.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'Default' ],
 			]
 		);
@@ -279,7 +299,11 @@ class CPTFormCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that two Kit Forms are output in the DOM before and after the CPT content.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'before_after_content');
+		$I->seeFormOutput(
+			$I,
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			position: 'before_after_content'
+		);
 	}
 
 	/**
@@ -306,7 +330,11 @@ class CPTFormCest
 		$I->setupKitPluginResources($I);
 
 		// Setup Article with placeholder content.
-		$pageID = $I->addGutenbergPageToDatabase($I, 'article', 'Kit: CPT: Form: Default: After 3rd Paragraph Element');
+		$pageID = $I->addGutenbergPageToDatabase(
+			$I,
+			postType: 'article',
+			title: 'Kit: CPT: Form: Default: After 3rd Paragraph Element'
+		);
 
 		// View the CPT on the frontend site.
 		$I->amOnPage('?p=' . $pageID);
@@ -315,7 +343,13 @@ class CPTFormCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that one Kit Form is output in the DOM after the third paragraph.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_element', 'p', 3);
+		$I->seeFormOutput(
+			$I,
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			position: 'after_element',
+			element: 'p',
+			elementIndex: 3
+		);
 
 		// Confirm character encoding is not broken due to using DOMDocument.
 		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
@@ -348,7 +382,11 @@ class CPTFormCest
 		$I->setupKitPluginResources($I);
 
 		// Setup CPT with placeholder content.
-		$pageID = $I->addGutenbergPageToDatabase($I, 'article', 'Kit: CPT: Non-Inline Form: Default: After 3rd Paragraph Element');
+		$pageID = $I->addGutenbergPageToDatabase(
+			$I,
+			postType: 'article',
+			title: 'Kit: CPT: Non-Inline Form: Default: After 3rd Paragraph Element'
+		);
 
 		// View the Page on the frontend site.
 		$I->amOnPage('?p=' . $pageID);
@@ -391,7 +429,11 @@ class CPTFormCest
 		$I->setupKitPluginResources($I);
 
 		// Setup Article with placeholder content.
-		$pageID = $I->addGutenbergPageToDatabase($I, 'article', 'Kit: CPT: Form: Default: After 2nd H2 Element');
+		$pageID = $I->addGutenbergPageToDatabase(
+			$I,
+			postType: 'article',
+			title: 'Kit: CPT: Form: Default: After 2nd H2 Element'
+		);
 
 		// View the CPT on the frontend site.
 		$I->amOnPage('?p=' . $pageID);
@@ -400,7 +442,13 @@ class CPTFormCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that one Kit Form is output in the DOM after the second <h2> element.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_element', 'h2', 2);
+		$I->seeFormOutput(
+			$I,
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			position: 'after_element',
+			element: 'h2',
+			elementIndex: 2
+		);
 
 		// Confirm character encoding is not broken due to using DOMDocument.
 		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
@@ -433,7 +481,11 @@ class CPTFormCest
 		$I->setupKitPluginResources($I);
 
 		// Setup Article with placeholder content.
-		$pageID = $I->addGutenbergPageToDatabase($I, 'article', 'Kit: CPT: Form: Default: After 2nd Image Element');
+		$pageID = $I->addGutenbergPageToDatabase(
+			$I,
+			postType: 'article',
+			title: 'Kit: CPT: Form: Default: After 2nd Image Element'
+		);
 
 		// View the CPT on the frontend site.
 		$I->amOnPage('?p=' . $pageID);
@@ -442,7 +494,13 @@ class CPTFormCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that one Kit Form is output in the DOM after the second <img> element.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_element', 'img', 2);
+		$I->seeFormOutput(
+			$I,
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			position: 'after_element',
+			element: 'img',
+			elementIndex: 2
+		);
 
 		// Confirm character encoding is not broken due to using DOMDocument.
 		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
@@ -475,7 +533,11 @@ class CPTFormCest
 		$I->setupKitPluginResources($I);
 
 		// Setup Article with placeholder content.
-		$pageID = $I->addGutenbergPageToDatabase($I, 'article', 'Kit: CPT: Form: Default: After 9th Paragraph Element');
+		$pageID = $I->addGutenbergPageToDatabase(
+			$I,
+			postType: 'article',
+			title: 'Kit: CPT: Form: Default: After 9th Paragraph Element'
+		);
 
 		// View the CPT on the frontend site.
 		$I->amOnPage('?p=' . $pageID);
@@ -485,7 +547,11 @@ class CPTFormCest
 
 		// Confirm that one Kit Form is output in the DOM after the content, as
 		// the number of paragraphs is less than the position.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_content');
+		$I->seeFormOutput(
+			$I,
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			position: 'after_content'
+		);
 
 		// Confirm character encoding is not broken due to using DOMDocument.
 		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
@@ -516,7 +582,11 @@ class CPTFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a CPT using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'article', 'Kit: CPT: Form: Legacy: Default');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'article',
+			title: 'Kit: CPT: Form: Legacy: Default'
+		);
 
 		// Configure metabox's Form setting = Default.
 		$I->configureMetaboxSettings(
@@ -554,13 +624,17 @@ class CPTFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a CPT using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'article', 'Kit: CPT: Form: None');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'article',
+			title: 'Kit: CPT: Form: None'
+		);
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
@@ -592,13 +666,17 @@ class CPTFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a CPT using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'article', 'Kit: CPT: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->addGutenbergPage(
+			$I,
+			postType: 'article',
+			title: 'Kit: CPT: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -633,13 +711,17 @@ class CPTFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a CPT using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'article', 'Kit: CPT: Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
+		$I->addGutenbergPage(
+			$I,
+			postType: 'article',
+			title: 'Kit: CPT: Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']
+		);
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
 			]
 		);
@@ -735,9 +817,9 @@ class CPTFormCest
 		// Quick Edit the CPT in the CPTs WP_List_Table.
 		$I->quickEdit(
 			$I,
-			'article',
-			$postID,
-			[
+			postType: 'article',
+			postID: $postID,
+			configuration: [
 				'form' => [ 'select', 'Default' ],
 			]
 		);
@@ -783,9 +865,9 @@ class CPTFormCest
 		// Quick Edit the CPT in the CPTs WP_List_Table.
 		$I->quickEdit(
 			$I,
-			'article',
-			$postID,
-			[
+			postType: 'article',
+			postID: $postID,
+			configuration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -839,9 +921,9 @@ class CPTFormCest
 		// Bulk Edit the CPTs in the CPTs WP_List_Table.
 		$I->bulkEdit(
 			$I,
-			'article',
-			$postIDs,
-			[
+			postType: 'article',
+			postIDs: $postIDs,
+			configuration: [
 				'form' => [ 'select', 'Default' ],
 			]
 		);
@@ -898,9 +980,9 @@ class CPTFormCest
 		// Bulk Edit the CPTs in the CPTs WP_List_Table.
 		$I->bulkEdit(
 			$I,
-			'article',
-			$postIDs,
-			[
+			postType: 'article',
+			postIDs: $postIDs,
+			configuration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -971,9 +1053,9 @@ class CPTFormCest
 		// Bulk Edit the CPTs in the CPTs WP_List_Table.
 		$I->bulkEdit(
 			$I,
-			'article',
-			$postIDs,
-			[
+			postType: 'article',
+			postIDs: $postIDs,
+			configuration: [
 				'form' => [ 'select', '— No Change —' ],
 			]
 		);

--- a/tests/EndToEnd/forms/post-types/PageFormCest.php
+++ b/tests/EndToEnd/forms/post-types/PageFormCest.php
@@ -1105,7 +1105,7 @@ class PageFormCest
 		$I->bulkEdit(
 			$I,
 			postType: 'page',
-			pageIDs: $pageIDs,
+			postIDs: $pageIDs,
 			configuration: [
 				'form' => [ 'select', 'Default' ],
 			]
@@ -1159,7 +1159,7 @@ class PageFormCest
 		$I->bulkEdit(
 			$I,
 			postType: 'page',
-			pageIDs: $pageIDs,
+			postIDs: $pageIDs,
 			configuration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
@@ -1227,7 +1227,7 @@ class PageFormCest
 		$I->bulkEdit(
 			$I,
 			postType: 'page',
-			pageIDs: $pageIDs,
+			postIDs: $pageIDs,
 			configuration: [
 				'form' => [ 'select', '— No Change —' ],
 			]

--- a/tests/EndToEnd/forms/post-types/PageFormCest.php
+++ b/tests/EndToEnd/forms/post-types/PageFormCest.php
@@ -1010,9 +1010,9 @@ class PageFormCest
 		// Quick Edit the Page in the Pages WP_List_Table.
 		$I->quickEdit(
 			$I,
-			'page',
-			$pageID,
-			[
+			postType: 'page',
+			pageID: $pageID,
+			configuration: [
 				'form' => [ 'select', 'Default' ],
 			]
 		);
@@ -1053,9 +1053,9 @@ class PageFormCest
 		// Quick Edit the Page in the Pages WP_List_Table.
 		$I->quickEdit(
 			$I,
-			'page',
-			$pageID,
-			[
+			postType: 'page',
+			pageID: $pageID,
+			configuration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -1104,9 +1104,9 @@ class PageFormCest
 		// Bulk Edit the Pages in the Pages WP_List_Table.
 		$I->bulkEdit(
 			$I,
-			'page',
-			$pageIDs,
-			[
+			postType: 'page',
+			pageIDs: $pageIDs,
+			configuration: [
 				'form' => [ 'select', 'Default' ],
 			]
 		);
@@ -1158,9 +1158,9 @@ class PageFormCest
 		// Bulk Edit the Pages in the Pages WP_List_Table.
 		$I->bulkEdit(
 			$I,
-			'page',
-			$pageIDs,
-			[
+			postType: 'page',
+			pageIDs: $pageIDs,
+			configuration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -1226,9 +1226,9 @@ class PageFormCest
 		// Bulk Edit the Pages in the Pages WP_List_Table.
 		$I->bulkEdit(
 			$I,
-			'page',
-			$pageIDs,
-			[
+			postType: 'page',
+			pageIDs: $pageIDs,
+			configuration: [
 				'form' => [ 'select', '— No Change —' ],
 			]
 		);

--- a/tests/EndToEnd/forms/post-types/PageFormCest.php
+++ b/tests/EndToEnd/forms/post-types/PageFormCest.php
@@ -62,13 +62,16 @@ class PageFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Default: None');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Default: None'
+		);
 
 		// Check the order of the Form resources are alphabetical, with the Default and None options prepending the Forms.
 		$I->checkSelectFormOptionOrder(
 			$I,
-			'#wp-convertkit-form',
-			[
+			selectElement: '#wp-convertkit-form',
+			prependOptions: [
 				'Default',
 				'None',
 			]
@@ -77,8 +80,8 @@ class PageFormCest
 		// Configure metabox's Form setting = Default.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'Default' ],
 			]
 		);
@@ -105,13 +108,16 @@ class PageFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Default');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Default'
+		);
 
 		// Configure metabox's Form setting = Default.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'Default' ],
 			]
 		);
@@ -145,7 +151,10 @@ class PageFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Default: Before Content');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Default: Before Content'
+		);
 
 		// Add paragraph to Page.
 		$I->addGutenbergParagraphBlock($I, 'Page content');
@@ -153,8 +162,8 @@ class PageFormCest
 		// Configure metabox's Form setting = Default.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'Default' ],
 			]
 		);
@@ -164,7 +173,11 @@ class PageFormCest
 
 		// Confirm that one Kit Form is output in the DOM after the Page content.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'before_content');
+		$I->seeFormOutput(
+			$I,
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			position: 'before_content'
+		);
 	}
 
 	/**
@@ -188,7 +201,10 @@ class PageFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Default: Before and After Content');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Default: Before and After Content'
+		);
 
 		// Add paragraph to Page.
 		$I->addGutenbergParagraphBlock($I, 'Page content');
@@ -196,8 +212,8 @@ class PageFormCest
 		// Configure metabox's Form setting = Default.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'Default' ],
 			]
 		);
@@ -206,7 +222,11 @@ class PageFormCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that two Kit Forms are output in the DOM before and after the Page content.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'before_after_content');
+		$I->seeFormOutput(
+			$I,
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			position: 'before_after_content'
+		);
 	}
 
 	/**
@@ -233,7 +253,10 @@ class PageFormCest
 		$I->setupKitPluginResources($I);
 
 		// Setup Page with placeholder content.
-		$pageID = $I->addGutenbergPageToDatabase($I, 'page', 'Kit: Page: Form: Default: After 3rd Paragraph Element');
+		$pageID = $I->addGutenbergPageToDatabase(
+			$I,
+			title: 'Kit: Page: Form: Default: After 3rd Paragraph Element'
+		);
 
 		// View the Page on the frontend site.
 		$I->amOnPage('?p=' . $pageID);
@@ -242,7 +265,13 @@ class PageFormCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that one Kit Form is output in the DOM after the third paragraph.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_element', 'p', 3);
+		$I->seeFormOutput(
+			$I,
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			position: 'after_element',
+			element: 'p',
+			elementIndex: 3
+		);
 
 		// Confirm character encoding is not broken due to using DOMDocument.
 		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
@@ -275,7 +304,10 @@ class PageFormCest
 		$I->setupKitPluginResources($I);
 
 		// Setup Page with placeholder content.
-		$pageID = $I->addGutenbergPageToDatabase($I, 'page', 'Kit: Page: Non-Inline Form: Default: After 3rd Paragraph Element');
+		$pageID = $I->addGutenbergPageToDatabase(
+			$I,
+			title: 'Kit: Page: Non-Inline Form: Default: After 3rd Paragraph Element'
+		);
 
 		// View the Page on the frontend site.
 		$I->amOnPage('?p=' . $pageID);
@@ -318,7 +350,10 @@ class PageFormCest
 		$I->setupKitPluginResources($I);
 
 		// Setup Page with placeholder content.
-		$pageID = $I->addGutenbergPageToDatabase($I, 'page', 'Kit: Page: Form: Default: After 2nd H2 Element');
+		$pageID = $I->addGutenbergPageToDatabase(
+			$I,
+			title: 'Kit: Page: Form: Default: After 2nd H2 Element'
+		);
 
 		// View the Page on the frontend site.
 		$I->amOnPage('?p=' . $pageID);
@@ -327,7 +362,13 @@ class PageFormCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that one Kit Form is output in the DOM after the second <h2> element.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_element', 'h2', 2);
+		$I->seeFormOutput(
+			$I,
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			position: 'after_element',
+			element: 'h2',
+			elementIndex: 2
+		);
 
 		// Confirm character encoding is not broken due to using DOMDocument.
 		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
@@ -360,7 +401,10 @@ class PageFormCest
 		$I->setupKitPluginResources($I);
 
 		// Setup Page with placeholder content.
-		$pageID = $I->addGutenbergPageToDatabase($I, 'page', 'Kit: Page: Form: Default: After 2nd H2 Element');
+		$pageID = $I->addGutenbergPageToDatabase(
+			$I,
+			title: 'Kit: Page: Form: Default: After 2nd Image Element'
+		);
 
 		// View the Post on the frontend site.
 		$I->amOnPage('?p=' . $pageID);
@@ -369,7 +413,13 @@ class PageFormCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that one Kit Form is output in the DOM after the second <img> element.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_element', 'img', 2);
+		$I->seeFormOutput(
+			$I,
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			position: 'after_element',
+			element: 'img',
+			elementIndex: 2
+		);
 
 		// Confirm character encoding is not broken due to using DOMDocument.
 		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
@@ -405,7 +455,10 @@ class PageFormCest
 		$I->setupKitPluginResources($I);
 
 		// Setup Page with placeholder content.
-		$pageID = $I->addGutenbergPageToDatabase($I, 'page', 'Kit: Page: Form: Default: After 9th Paragraph Element');
+		$pageID = $I->addGutenbergPageToDatabase(
+			$I,
+			title: 'Kit: Page: Form: Default: After 9th Paragraph Element'
+		);
 
 		// View the Page on the frontend site.
 		$I->amOnPage('?p=' . $pageID);
@@ -415,7 +468,11 @@ class PageFormCest
 
 		// Confirm that one Kit Form is output in the DOM after the content, as
 		// the number of paragraphs is less than the position.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_content');
+		$I->seeFormOutput(
+			$I,
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			position: 'after_content'
+		);
 
 		// Confirm character encoding is not broken due to using DOMDocument.
 		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
@@ -446,13 +503,16 @@ class PageFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Legacy: Default');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Legacy: Default'
+		);
 
 		// Configure metabox's Form setting = Default.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'Default' ],
 			]
 		);
@@ -482,13 +542,16 @@ class PageFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: None');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: None'
+		);
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
@@ -515,13 +578,16 @@ class PageFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -552,13 +618,16 @@ class PageFormCest
 		$I->activateThirdPartyPlugin($I, 'autoptimize');
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . ': Autoptimize');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . ': Autoptimize'
+		);
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
 		);
@@ -598,13 +667,16 @@ class PageFormCest
 		$I->click('#inspector-toggle-control-1');
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . ': Jetpack Boost');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . ': Jetpack Boost'
+		);
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
 		);
@@ -644,13 +716,16 @@ class PageFormCest
 		$I->enableLiteSpeedCacheLoadJSDeferred($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . ': LiteSpeed Cache');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . ': LiteSpeed Cache'
+		);
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
 		);
@@ -688,13 +763,16 @@ class PageFormCest
 		$I->haveOptionInDatabase('siteground_optimizer_combine_javascript', '1');
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . ': Siteground Speed Optimizer');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . ': Siteground Speed Optimizer'
+		);
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
 		);
@@ -739,13 +817,16 @@ class PageFormCest
 		);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . ': Perfmatters');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . ': Perfmatters'
+		);
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
 		);
@@ -783,13 +864,16 @@ class PageFormCest
 		$I->enableWPRocketDelayJS($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . ': WP Rocket');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . ': WP Rocket'
+		);
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
 			]
 		);
@@ -828,13 +912,16 @@ class PageFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']
+		);
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
 			]
 		);

--- a/tests/EndToEnd/forms/post-types/PageFormCest.php
+++ b/tests/EndToEnd/forms/post-types/PageFormCest.php
@@ -1011,7 +1011,7 @@ class PageFormCest
 		$I->quickEdit(
 			$I,
 			postType: 'page',
-			pageID: $pageID,
+			postID: $pageID,
 			configuration: [
 				'form' => [ 'select', 'Default' ],
 			]
@@ -1054,7 +1054,7 @@ class PageFormCest
 		$I->quickEdit(
 			$I,
 			postType: 'page',
-			pageID: $pageID,
+			postID: $pageID,
 			configuration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]

--- a/tests/EndToEnd/forms/post-types/PostFormCest.php
+++ b/tests/EndToEnd/forms/post-types/PostFormCest.php
@@ -70,7 +70,7 @@ class PostFormCest
 		// Check the order of the Form resources are alphabetical, with the Default and None options prepending the Forms.
 		$I->checkSelectFormOptionOrder(
 			$I,
-			selector: '#wp-convertkit-form',
+			selectElement: '#wp-convertkit-form',
 			prependOptions: [
 				'Default',
 				'None',

--- a/tests/EndToEnd/forms/post-types/PostFormCest.php
+++ b/tests/EndToEnd/forms/post-types/PostFormCest.php
@@ -61,13 +61,17 @@ class PostFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Form: Default: None');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'post',
+			title: 'Kit: Post: Form: Default: None'
+		);
 
 		// Check the order of the Form resources are alphabetical, with the Default and None options prepending the Forms.
 		$I->checkSelectFormOptionOrder(
 			$I,
-			'#wp-convertkit-form',
-			[
+			selector: '#wp-convertkit-form',
+			prependOptions: [
 				'Default',
 				'None',
 			]
@@ -76,8 +80,8 @@ class PostFormCest
 		// Configure metabox's Form setting = Default.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'Default' ],
 			]
 		);
@@ -104,13 +108,17 @@ class PostFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Form: Default');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'post',
+			title: 'Kit: Post: Form: Default'
+		);
 
 		// Configure metabox's Form setting = Default.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'Default' ],
 			]
 		);
@@ -144,7 +152,11 @@ class PostFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Form: Default: Before Content');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'post',
+			title: 'Kit: Post: Form: Default: Before Content'
+		);
 
 		// Add paragraph to Post.
 		$I->addGutenbergParagraphBlock($I, 'Post content');
@@ -152,8 +164,8 @@ class PostFormCest
 		// Configure metabox's Form setting = Default.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'Default' ],
 			]
 		);
@@ -163,7 +175,11 @@ class PostFormCest
 
 		// Confirm that one Kit Form is output in the DOM after the Post content.
 		// This confirms that there is only one script on the post for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'before_content');
+		$I->seeFormOutput(
+			$I,
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			position: 'before_content'
+		);
 	}
 
 	/**
@@ -187,7 +203,11 @@ class PostFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Form: Default: Before and After Content');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'post',
+			title: 'Kit: Post: Form: Default: Before and After Content'
+		);
 
 		// Add paragraph to Post.
 		$I->addGutenbergParagraphBlock($I, 'Post content');
@@ -195,8 +215,8 @@ class PostFormCest
 		// Configure metabox's Form setting = Default.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'Default' ],
 			]
 		);
@@ -205,7 +225,11 @@ class PostFormCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that two Kit Forms are output in the DOM before and after the Post content.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'before_after_content');
+		$I->seeFormOutput(
+			$I,
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			position: 'before_after_content'
+		);
 	}
 
 	/**
@@ -232,7 +256,11 @@ class PostFormCest
 		$I->setupKitPluginResources($I);
 
 		// Setup Post with placeholder content.
-		$pageID = $I->addGutenbergPageToDatabase($I, 'post', 'Kit: Post: Form: Default: After 3rd Paragraph Element');
+		$pageID = $I->addGutenbergPageToDatabase(
+			$I,
+			postType: 'post',
+			title: 'Kit: Post: Form: Default: After 3rd Paragraph Element'
+		);
 
 		// View the Post on the frontend site.
 		$I->amOnPage('?p=' . $pageID);
@@ -241,7 +269,13 @@ class PostFormCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that one Kit Form is output in the DOM after the third paragraph.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_element', 'p', 3);
+		$I->seeFormOutput(
+			$I,
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			position: 'after_element',
+			element: 'p',
+			elementIndex: 3
+		);
 
 		// Confirm character encoding is not broken due to using DOMDocument.
 		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
@@ -274,7 +308,11 @@ class PostFormCest
 		$I->setupKitPluginResources($I);
 
 		// Setup Post with placeholder content.
-		$pageID = $I->addGutenbergPageToDatabase($I, 'post', 'Kit: Post: Non-Inline Form: Default: After 3rd Paragraph Element');
+		$pageID = $I->addGutenbergPageToDatabase(
+			$I,
+			postType: 'post',
+			title: 'Kit: Post: Non-Inline Form: Default: After 3rd Paragraph Element'
+		);
 
 		// View the Page on the frontend site.
 		$I->amOnPage('?p=' . $pageID);
@@ -317,7 +355,11 @@ class PostFormCest
 		$I->setupKitPluginResources($I);
 
 		// Setup Post with placeholder content.
-		$pageID = $I->addGutenbergPageToDatabase($I, 'post', 'Kit: Post: Form: Default: After 2nd H2 Element');
+		$pageID = $I->addGutenbergPageToDatabase(
+			$I,
+			postType: 'post',
+			title: 'Kit: Post: Form: Default: After 2nd H2 Element'
+		);
 
 		// View the Post on the frontend site.
 		$I->amOnPage('?p=' . $pageID);
@@ -326,7 +368,13 @@ class PostFormCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that one Kit Form is output in the DOM after the second <h2> element.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_element', 'h2', 2);
+		$I->seeFormOutput(
+			$I,
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			position: 'after_element',
+			element: 'h2',
+			elementIndex: 2
+		);
 
 		// Confirm character encoding is not broken due to using DOMDocument.
 		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
@@ -359,7 +407,11 @@ class PostFormCest
 		$I->setupKitPluginResources($I);
 
 		// Setup Post with placeholder content.
-		$pageID = $I->addGutenbergPageToDatabase($I, 'post', 'Kit: Post: Form: Default: After 2nd Image Element');
+		$pageID = $I->addGutenbergPageToDatabase(
+			$I,
+			postType: 'post',
+			title: 'Kit: Post: Form: Default: After 2nd Image Element'
+		);
 
 		// View the Post on the frontend site.
 		$I->amOnPage('?p=' . $pageID);
@@ -368,7 +420,13 @@ class PostFormCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that one Kit Form is output in the DOM after the second <img> element.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_element', 'img', 2);
+		$I->seeFormOutput(
+			$I,
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			position: 'after_element',
+			element: 'img',
+			elementIndex: 2
+		);
 
 		// Confirm character encoding is not broken due to using DOMDocument.
 		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
@@ -401,7 +459,11 @@ class PostFormCest
 		$I->setupKitPluginResources($I);
 
 		// Setup Post with placeholder content.
-		$pageID = $I->addGutenbergPageToDatabase($I, 'post', 'Kit: Post: Form: Default: After 9th Paragraph Element');
+		$pageID = $I->addGutenbergPageToDatabase(
+			$I,
+			postType: 'post',
+			title: 'Kit: Post: Form: Default: After 9th Paragraph Element'
+		);
 
 		// View the Post on the frontend site.
 		$I->amOnPage('?p=' . $pageID);
@@ -411,7 +473,11 @@ class PostFormCest
 
 		// Confirm that one Kit Form is output in the DOM after the content, as
 		// the number of paragraphs is less than the position.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_content');
+		$I->seeFormOutput(
+			$I,
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			position: 'after_content'
+		);
 
 		// Confirm character encoding is not broken due to using DOMDocument.
 		$I->seeInSource('Adhaésionés altéram improbis mi pariendarum sit stulti triarium');
@@ -442,13 +508,17 @@ class PostFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Form: Legacy: Default');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'post',
+			title: 'Kit: Post: Form: Legacy: Default'
+		);
 
 		// Configure metabox's Form setting = Default.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'Default' ],
 			]
 		);
@@ -475,13 +545,17 @@ class PostFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Form: None');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'post',
+			title: 'Kit: Post: Form: None'
+		);
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
@@ -508,13 +582,17 @@ class PostFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->addGutenbergPage(
+			$I,
+			postType: 'post',
+			title: 'Kit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -549,13 +627,17 @@ class PostFormCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
+		$I->addGutenbergPage(
+			$I,
+			postType: 'post',
+			title: 'Kit: Post: Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']
+		);
 
 		// Configure metabox's Form setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
 			]
 		);
@@ -641,9 +723,9 @@ class PostFormCest
 		// Quick Edit the Post in the Posts WP_List_Table.
 		$I->quickEdit(
 			$I,
-			'post',
-			$postID,
-			[
+			postType: 'post',
+			postID: $postID,
+			configuration: [
 				'form' => [ 'select', 'Default' ],
 			]
 		);
@@ -684,9 +766,9 @@ class PostFormCest
 		// Quick Edit the Post in the Posts WP_List_Table.
 		$I->quickEdit(
 			$I,
-			'post',
-			$postID,
-			[
+			postType: 'post',
+			postID: $postID,
+			configuration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -735,9 +817,9 @@ class PostFormCest
 		// Bulk Edit the Posts in the Posts WP_List_Table.
 		$I->bulkEdit(
 			$I,
-			'post',
-			$postIDs,
-			[
+			postType: 'post',
+			postIDs: $postIDs,
+			configuration: [
 				'form' => [ 'select', 'Default' ],
 			]
 		);
@@ -789,9 +871,9 @@ class PostFormCest
 		// Bulk Edit the Posts in the Posts WP_List_Table.
 		$I->bulkEdit(
 			$I,
-			'post',
-			$postIDs,
-			[
+			postType: 'post',
+			postIDs: $postIDs,
+			configuration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -857,9 +939,9 @@ class PostFormCest
 		// Bulk Edit the Posts in the Posts WP_List_Table.
 		$I->bulkEdit(
 			$I,
-			'post',
-			$postIDs,
-			[
+			postType: 'post',
+			postIDs: $postIDs,
+			configuration: [
 				'form' => [ 'select', '— No Change —' ],
 			]
 		);

--- a/tests/EndToEnd/general/other/RefreshResourcesButtonCest.php
+++ b/tests/EndToEnd/general/other/RefreshResourcesButtonCest.php
@@ -178,7 +178,6 @@ class RefreshResourcesButtonCest
 		// If the expected dropdown value does not exist, this will fail the test.
 		$I->selectOption('#wp-convertkit-quick-edit-form', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
-
 		// Click the Tags refresh button.
 		$I->click('button.wp-convertkit-refresh-resources[data-resource="tags"]');
 

--- a/tests/EndToEnd/general/other/RefreshResourcesButtonCest.php
+++ b/tests/EndToEnd/general/other/RefreshResourcesButtonCest.php
@@ -51,8 +51,8 @@ class RefreshResourcesButtonCest
 		// Check the order of the Form resources are alphabetical, with Default and None options prepending the Forms.
 		$I->checkSelectFormOptionOrder(
 			$I,
-			'#wp-convertkit-form',
-			[
+			selectElement: '#wp-convertkit-form',
+			prependOptions: [
 				'Default',
 				'None',
 			]
@@ -60,7 +60,11 @@ class RefreshResourcesButtonCest
 
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist in the Select2 field, this will fail the test.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 
 		// Click the Landing Pages refresh button.
 		$I->click('button.wp-convertkit-refresh-resources[data-resource="landing_pages"]');
@@ -71,15 +75,19 @@ class RefreshResourcesButtonCest
 		// Check the order of the Landing Page resources are alphabetical, with the None option prepending the Landing Pages.
 		$I->checkSelectLandingPageOptionOrder(
 			$I,
-			'#wp-convertkit-landing_page',
-			[
+			selectElement: '#wp-convertkit-landing_page',
+			prependOptions: [
 				'None',
 			]
 		);
 
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist in the Select2 field, this will fail the test.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-landing_page-container', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-landing_page-container',
+			value: $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME']
+		);
 
 		// Click the Tags refresh button.
 		$I->click('button.wp-convertkit-refresh-resources[data-resource="tags"]');
@@ -90,15 +98,19 @@ class RefreshResourcesButtonCest
 		// Check the order of the Tag resources are alphabetical, with the None option prepending the Tags.
 		$I->checkSelectTagOptionOrder(
 			$I,
-			'#wp-convertkit-tag',
-			[
+			selectElement: '#wp-convertkit-tag',
+			prependOptions: [
 				'None',
 			]
 		);
 
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist in the Select2 field, this will fail the test.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-tag-container', $_ENV['CONVERTKIT_API_TAG_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-tag-container',
+			value: $_ENV['CONVERTKIT_API_TAG_NAME']
+		);
 
 		// Click the Restrict Content refresh button.
 		$I->click('button.wp-convertkit-refresh-resources[data-resource="restrict_content"]');
@@ -108,11 +120,19 @@ class RefreshResourcesButtonCest
 
 		// Confirm that the expected Tag is within the Tags option group and selectable.
 		$I->seeElementInDOM('select#wp-convertkit-restrict_content optgroup[data-resource="tags"] option[value="tag_' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]');
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-restrict_content-container', $_ENV['CONVERTKIT_API_TAG_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-restrict_content-container',
+			value: $_ENV['CONVERTKIT_API_TAG_NAME']
+		);
 
 		// Confirm that the expected Product is within the Products option group and selectable.
 		$I->seeElementInDOM('select#wp-convertkit-restrict_content optgroup[data-resource="products"] option[value="product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '"]');
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-restrict_content-container', $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-restrict_content-container',
+			value: $_ENV['CONVERTKIT_API_PRODUCT_NAME']
+		);
 	}
 
 	/**
@@ -147,8 +167,8 @@ class RefreshResourcesButtonCest
 		// Check the order of the Form resources are alphabetical, with Default and None options prepending the Forms.
 		$I->checkSelectFormOptionOrder(
 			$I,
-			'#wp-convertkit-quick-edit-form',
-			[
+			selectElement: '#wp-convertkit-quick-edit-form',
+			prependOptions: [
 				'Default',
 				'None',
 			]
@@ -156,7 +176,11 @@ class RefreshResourcesButtonCest
 
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist, this will fail the test.
-		$I->selectOption('#wp-convertkit-quick-edit-form', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-quick-edit-form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 
 		// Click the Tags refresh button.
 		$I->click('button.wp-convertkit-refresh-resources[data-resource="tags"]');
@@ -167,8 +191,8 @@ class RefreshResourcesButtonCest
 		// Check the order of the Tag resources are alphabetical, with the None option prepending the Tags.
 		$I->checkSelectTagOptionOrder(
 			$I,
-			'#wp-convertkit-quick-edit-tag',
-			[
+			selectElement: '#wp-convertkit-quick-edit-tag',
+			prependOptions: [
 				'None',
 			]
 		);
@@ -232,8 +256,8 @@ class RefreshResourcesButtonCest
 		// Check the order of the Form resources are alphabetical, with No Change, Default and None options prepending the Forms.
 		$I->checkSelectFormOptionOrder(
 			$I,
-			'#wp-convertkit-bulk-edit-form',
-			[
+			selectElement: '#wp-convertkit-bulk-edit-form',
+			prependOptions: [
 				'— No Change —',
 				'Default',
 				'None',
@@ -253,8 +277,8 @@ class RefreshResourcesButtonCest
 		// Check the order of the Tag resources are alphabetical, with the No Chage and None options prepending the Tags.
 		$I->checkSelectTagOptionOrder(
 			$I,
-			'#wp-convertkit-bulk-edit-tag',
-			[
+			selectElement: '#wp-convertkit-bulk-edit-tag',
+			prependOptions: [
 				'— No Change —',
 				'None',
 			]
@@ -303,8 +327,8 @@ class RefreshResourcesButtonCest
 		// Check the order of the Form resources are alphabetical, with the Default option prepending the Forms.
 		$I->checkSelectFormOptionOrder(
 			$I,
-			'#wp-convertkit-form',
-			[
+			selectElement: '#wp-convertkit-form',
+			prependOptions: [
 				'Default',
 				'None',
 			]
@@ -312,7 +336,11 @@ class RefreshResourcesButtonCest
 
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist in the Select2 field, this will fail the test.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 	}
 
 	/**
@@ -343,8 +371,8 @@ class RefreshResourcesButtonCest
 		// Check the order of the Form resources are alphabetical, with the Default option prepending the Forms.
 		$I->checkSelectFormOptionOrder(
 			$I,
-			'#wp-convertkit-form',
-			[
+			selectElement: '#wp-convertkit-form',
+			prependOptions: [
 				'Default',
 				'None',
 			]
@@ -352,7 +380,11 @@ class RefreshResourcesButtonCest
 
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist in the Select2 field, this will fail the test.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 	}
 
 	/**
@@ -386,13 +418,16 @@ class RefreshResourcesButtonCest
 		);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Forms: Block: Refresh Button');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Forms: Block: Refresh Button'
+		);
 
 		// Add block to Page.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form',
-			'convertkit-form'
+			blockName: 'Kit Form',
+			blockProgrammaticName: 'convertkit-form'
 		);
 
 		// Click the refresh button.
@@ -441,7 +476,10 @@ class RefreshResourcesButtonCest
 		);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form: Shortcode: Visual Editor: Refresh Button');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form: Shortcode: Visual Editor: Refresh Button'
+		);
 
 		// Open Visual Editor shortcode modal.
 		$I->openVisualEditorShortcodeModal($I, 'Kit Form');
@@ -501,7 +539,10 @@ class RefreshResourcesButtonCest
 		);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form: Shortcode: Text Editor: Refresh Button');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form: Shortcode: Text Editor: Refresh Button'
+		);
 
 		// Open Text Editor shortcode modal.
 		$I->openTextEditorShortcodeModal($I, 'convertkit-form');
@@ -560,13 +601,16 @@ class RefreshResourcesButtonCest
 		);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form Trigger: Block: Refresh Button');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Block: Refresh Button'
+		);
 
 		// Add block to Page.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Form Trigger',
-			'convertkit-formtrigger'
+			blockName: 'Kit Form Trigger',
+			blockProgrammaticName: 'convertkit-formtrigger'
 		);
 
 		// Click the refresh button.
@@ -615,7 +659,10 @@ class RefreshResourcesButtonCest
 		);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form Trigger: Shortcode: Visual Editor: Refresh Button');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Shortcode: Visual Editor: Refresh Button'
+		);
 
 		// Open Visual Editor shortcode modal.
 		$I->openVisualEditorShortcodeModal($I, 'Kit Form Trigger');
@@ -675,7 +722,10 @@ class RefreshResourcesButtonCest
 		);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Form Trigger: Shortcode: Text Editor: Refresh Button');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Shortcode: Text Editor: Refresh Button'
+		);
 
 		// Open Text Editor shortcode modal.
 		$I->openTextEditorShortcodeModal($I, 'convertkit-formtrigger');
@@ -729,13 +779,16 @@ class RefreshResourcesButtonCest
 		);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Product: Block: Refresh Button');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Product: Block: Refresh Button'
+		);
 
 		// Add block to Page.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Product',
-			'convertkit-product'
+			blockName: 'Kit Product',
+			blockProgrammaticName: 'convertkit-product'
 		);
 
 		// Click the refresh button.
@@ -779,7 +832,10 @@ class RefreshResourcesButtonCest
 		);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Product: Shortcode: Visual Editor: Refresh Button');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Product: Shortcode: Visual Editor: Refresh Button'
+		);
 
 		// Open Visual Editor shortcode modal.
 		$I->openVisualEditorShortcodeModal($I, 'Kit Product');
@@ -834,7 +890,10 @@ class RefreshResourcesButtonCest
 		);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Product: Shortcode: Text Editor: Refresh Button');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Product: Shortcode: Text Editor: Refresh Button'
+		);
 
 		// Open Text Editor shortcode modal.
 		$I->openTextEditorShortcodeModal($I, 'convertkit-product');
@@ -908,7 +967,10 @@ class RefreshResourcesButtonCest
 		$I->setupKitPluginFakeAPIKey($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Refresh Resources: Classic Editor' );
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Refresh Resources: Classic Editor'
+		);
 
 		// Click the Forms refresh button.
 		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');

--- a/tests/EndToEnd/general/other/RefreshResourcesButtonCest.php
+++ b/tests/EndToEnd/general/other/RefreshResourcesButtonCest.php
@@ -176,11 +176,8 @@ class RefreshResourcesButtonCest
 
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist, this will fail the test.
-		$I->fillSelect2Field(
-			$I,
-			container: '#select2-wp-convertkit-quick-edit-form-container',
-			value: $_ENV['CONVERTKIT_API_FORM_NAME']
-		);
+		$I->selectOption('#wp-convertkit-quick-edit-form', $_ENV['CONVERTKIT_API_FORM_NAME']);
+
 
 		// Click the Tags refresh button.
 		$I->click('button.wp-convertkit-refresh-resources[data-resource="tags"]');

--- a/tests/EndToEnd/general/other/ReviewRequestCest.php
+++ b/tests/EndToEnd/general/other/ReviewRequestCest.php
@@ -40,8 +40,16 @@ class ReviewRequestCest
 		$I->loadKitSettingsGeneralScreen($I);
 
 		// Select Default Form for Pages and Posts.
-		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
-		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_post_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-_wp_convertkit_settings_page_form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-_wp_convertkit_settings_post_form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 
 		// Click the Save Changes button.
 		$I->click('Save Changes');
@@ -99,13 +107,16 @@ class ReviewRequestCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Test Review Request on Save with Form Specified');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Test Review Request on Save with Form Specified'
+		);
 
 		// Configure metabox's Form setting = Default.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -139,13 +150,16 @@ class ReviewRequestCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Test Review Request on Save with Form Specified');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Test Review Request on Save with Landing Page Specified'
+		);
 
 		// Configure metabox's Form setting = Default.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME'] ],
 			]
 		);

--- a/tests/EndToEnd/general/plugin-screens/PluginSettingsGeneralCest.php
+++ b/tests/EndToEnd/general/plugin-screens/PluginSettingsGeneralCest.php
@@ -246,7 +246,11 @@ class PluginSettingsGeneralCest
 		$I->loadKitSettingsGeneralScreen($I);
 
 		// Select Default Form for Pages, and change the Position.
-		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-_wp_convertkit_settings_page_form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 		$I->selectOption('_wp_convertkit_settings[page_form_position]', 'Before Page content');
 
 		// Open preview.
@@ -267,7 +271,11 @@ class PluginSettingsGeneralCest
 		$I->closeTab();
 
 		// Select Default Form for Posts.
-		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_post_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-_wp_convertkit_settings_post_form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 
 		// Open preview.
 		$I->click('a#convertkit-preview-form-post');
@@ -317,7 +325,11 @@ class PluginSettingsGeneralCest
 		$I->loadKitSettingsGeneralScreen($I);
 
 		// Select the Sticky Bar Form for the Site Wide option.
-		$I->fillSelect2MultipleField($I, '#select2-_wp_convertkit_settings_non_inline_form-container', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME']);
+		$I->fillSelect2MultipleField(
+			$I,
+			container: '#select2-_wp_convertkit_settings_non_inline_form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME']
+		);
 
 		// Open preview.
 		$I->click('a#convertkit-preview-non-inline-form');
@@ -337,7 +349,11 @@ class PluginSettingsGeneralCest
 		$I->closeTab();
 
 		// Select a second Modal Form for the Site Wide option.
-		$I->fillSelect2MultipleField($I, '#select2-_wp_convertkit_settings_non_inline_form-container', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME']);
+		$I->fillSelect2MultipleField(
+			$I,
+			container: '#select2-_wp_convertkit_settings_non_inline_form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME']
+		);
 
 		// Open preview.
 		$I->click('a#convertkit-preview-non-inline-form');
@@ -395,7 +411,11 @@ class PluginSettingsGeneralCest
 		$I->dontSeeElement('_wp_convertkit_settings[page_form_position_element]');
 
 		// Select Default Form for Pages, and change the Position.
-		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-_wp_convertkit_settings_page_form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 		$I->selectOption('_wp_convertkit_settings[page_form_position]', 'After element');
 
 		// Confirm the conditional fields display for Pages, now that 'After element' is selected.
@@ -410,7 +430,11 @@ class PluginSettingsGeneralCest
 		$I->dontSeeElement('select[name="_wp_convertkit_settings[post_form_position_element]"]');
 
 		// Select Default Form for Posts, and change the Position.
-		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_post_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-_wp_convertkit_settings_post_form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 		$I->selectOption('_wp_convertkit_settings[post_form_position]', 'After element');
 
 		// Confirm the conditional fields display for Posts, now that 'After element' is selected.
@@ -482,7 +506,11 @@ class PluginSettingsGeneralCest
 		$I->loadKitSettingsGeneralScreen($I);
 
 		// Select Default Form for Articles.
-		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_article_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-_wp_convertkit_settings_article_form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 
 		// Confirm no Default Form option is displayed for the Private CPT.
 		$I->dontSeeElementInDOM('#_wp_convertkit_settings_private_form');

--- a/tests/EndToEnd/general/plugin-screens/PluginSetupWizardCest.php
+++ b/tests/EndToEnd/general/plugin-screens/PluginSetupWizardCest.php
@@ -239,7 +239,11 @@ class PluginSetupWizardCest
 		$this->_seeExpectedSetupWizardScreen($I, 2, 'Display an email capture form');
 
 		// Select a Post Form.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-posts-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-form-posts-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 
 		// Open preview.
 		$I->click('a#convertkit-preview-form-post');
@@ -259,7 +263,11 @@ class PluginSetupWizardCest
 		$I->closeTab();
 
 		// Select a Page Form.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-pages-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-form-pages-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 
 		// Open preview.
 		$I->click('a#convertkit-preview-form-page');
@@ -331,7 +339,11 @@ class PluginSetupWizardCest
 		$this->_seeExpectedSetupWizardScreen($I, 2, 'Display an email capture form');
 
 		// Confirm we can select a Post Form.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-posts-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-form-posts-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
 	}
 
 	/**

--- a/tests/EndToEnd/integrations/divi-builder/DiviPluginBroadcastsCest.php
+++ b/tests/EndToEnd/integrations/divi-builder/DiviPluginBroadcastsCest.php
@@ -45,8 +45,8 @@ class DiviPluginBroadcastsCest
 		// Insert the Broadcasts module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Broadcasts',
-			'convertkit_broadcasts'
+			name: 'Kit Broadcasts',
+			programmaticName:'convertkit_broadcasts'
 		);
 
 		// Save Divi module and view the page on the frontend site.
@@ -91,8 +91,8 @@ class DiviPluginBroadcastsCest
 		// Insert the Broadcasts module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Broadcasts',
-			'convertkit_broadcasts'
+			name: 'Kit Broadcasts',
+			programmaticName: 'convertkit_broadcasts'
 		);
 
 		// Save Divi module and view the page on the frontend site.
@@ -129,8 +129,8 @@ class DiviPluginBroadcastsCest
 		// Insert the Broadcasts module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Broadcasts',
-			'convertkit_broadcasts'
+			name: 'Kit Broadcasts',
+			programmaticName: 'convertkit_broadcasts'
 		);
 
 		// Confirm the on screen message displays.
@@ -158,8 +158,8 @@ class DiviPluginBroadcastsCest
 		// Insert the Broadcasts module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Broadcasts',
-			'convertkit_broadcasts'
+			name: 'Kit Broadcasts',
+			programmaticName: 'convertkit_broadcasts'
 		);
 
 		// Confirm the on screen message displays.

--- a/tests/EndToEnd/integrations/divi-builder/DiviPluginFormCest.php
+++ b/tests/EndToEnd/integrations/divi-builder/DiviPluginFormCest.php
@@ -45,10 +45,10 @@ class DiviPluginFormCest
 		// Insert the Form module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Form',
-			'convertkit_form',
-			'form',
-			$_ENV['CONVERTKIT_API_FORM_ID']
+			name: 'Kit Form',
+			programmaticName: 'convertkit_form',
+			fieldName: 'form',
+			fieldValue: $_ENV['CONVERTKIT_API_FORM_ID']
 		);
 
 		// Save Divi module and view the page on the frontend site.
@@ -82,10 +82,10 @@ class DiviPluginFormCest
 		// Insert the Form module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Form',
-			'convertkit_form',
-			'form',
-			$_ENV['CONVERTKIT_API_FORM_ID']
+			name: 'Kit Form',
+			programmaticName: 'convertkit_form',
+			fieldName: 'form',
+			fieldValue: $_ENV['CONVERTKIT_API_FORM_ID']
 		);
 
 		// Save Divi module and view the page on the frontend site.
@@ -111,8 +111,8 @@ class DiviPluginFormCest
 		// Insert the Form module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Form',
-			'convertkit_form'
+			name: 'Kit Form',
+			programmaticName: 'convertkit_form'
 		);
 
 		// Confirm the on screen message displays.
@@ -140,8 +140,8 @@ class DiviPluginFormCest
 		// Insert the Form module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Form',
-			'convertkit_form'
+			name: 'Kit Form',
+			programmaticName: 'convertkit_form'
 		);
 
 		// Confirm the on screen message displays.
@@ -174,10 +174,10 @@ class DiviPluginFormCest
 		// Create Page with Form module in Divi.
 		$pageID = $I->createPageWithDiviModuleProgrammatically(
 			$I,
-			'Kit: Legacy Form: Divi Module: Valid Form Param',
-			'convertkit_form',
-			'form',
-			$_ENV['CONVERTKIT_API_LEGACY_FORM_ID']
+			title: 'Kit: Legacy Form: Divi Module: Valid Form Param',
+			programmaticName: 'convertkit_form',
+			fieldName: 'form',
+			fieldValue: $_ENV['CONVERTKIT_API_LEGACY_FORM_ID']
 		);
 
 		// Load Page.
@@ -206,10 +206,10 @@ class DiviPluginFormCest
 		// Create Page with Form module in Divi.
 		$pageID = $I->createPageWithDiviModuleProgrammatically(
 			$I,
-			'Kit: Legacy Form: Divi Module: No Form Param',
-			'convertkit_form',
-			'form',
-			''
+			title: 'Kit: Legacy Form: Divi Module: No Form Param',
+			programmaticName: 'convertkit_form',
+			fieldName: 'form',
+			fieldValue: ''
 		);
 
 		// Load Page.

--- a/tests/EndToEnd/integrations/divi-builder/DiviPluginFormTriggerCest.php
+++ b/tests/EndToEnd/integrations/divi-builder/DiviPluginFormTriggerCest.php
@@ -45,10 +45,10 @@ class DiviPluginFormTriggerCest
 		// Insert the Form module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Form Trigger',
-			'convertkit_formtrigger',
-			'form',
-			$_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID']
+			name: 'Kit Form Trigger',
+			programmaticName: 'convertkit_formtrigger',
+			fieldName: 'form',
+			fieldValue: $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID']
 		);
 
 		// Save Divi module and view the page on the frontend site.
@@ -85,10 +85,10 @@ class DiviPluginFormTriggerCest
 		// Insert the Form module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Form Trigger',
-			'convertkit_formtrigger',
-			'form',
-			$_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID']
+			name: 'Kit Form Trigger',
+			programmaticName: 'convertkit_formtrigger',
+			fieldName: 'form',
+			fieldValue: $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID']
 		);
 
 		// Save Divi module and view the page on the frontend site.
@@ -117,8 +117,8 @@ class DiviPluginFormTriggerCest
 		// Insert the Form module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Form Trigger',
-			'convertkit_formtrigger'
+			name: 'Kit Form Trigger',
+			programmaticName: 'convertkit_formtrigger'
 		);
 
 		// Confirm the on screen message displays.
@@ -146,8 +146,8 @@ class DiviPluginFormTriggerCest
 		// Insert the Form module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Form Trigger',
-			'convertkit_formtrigger'
+			name: 'Kit Form Trigger',
+			programmaticName: 'convertkit_formtrigger'
 		);
 
 		// Confirm the on screen message displays.
@@ -171,10 +171,10 @@ class DiviPluginFormTriggerCest
 		// Create Page with Form module in Divi.
 		$pageID = $I->createPageWithDiviModuleProgrammatically(
 			$I,
-			'Kit: Legacy Form Trigger: Divi Module: No Form Param',
-			'convertkit_formtrigger',
-			'form',
-			''
+			title: 'Kit: Legacy Form Trigger: Divi Module: No Form Param',
+			programmaticName: 'convertkit_formtrigger',
+			fieldName: 'form',
+			fieldValue: ''
 		);
 
 		// Load Page.

--- a/tests/EndToEnd/integrations/divi-builder/DiviPluginProductCest.php
+++ b/tests/EndToEnd/integrations/divi-builder/DiviPluginProductCest.php
@@ -45,10 +45,10 @@ class DiviPluginProductCest
 		// Insert the Product module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Product',
-			'convertkit_product',
-			'product',
-			$_ENV['CONVERTKIT_API_PRODUCT_ID']
+			name: 'Kit Product',
+			programmaticName: 'convertkit_product',
+			fieldName: 'product',
+			fieldValue: $_ENV['CONVERTKIT_API_PRODUCT_ID']
 		);
 
 		// Save Divi module and view the page on the frontend site.
@@ -81,10 +81,10 @@ class DiviPluginProductCest
 		// Insert the Product module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Product',
-			'convertkit_product',
-			'product',
-			$_ENV['CONVERTKIT_API_PRODUCT_ID']
+			name: 'Kit Product',
+			programmaticName: 'convertkit_product',
+			fieldName: 'product',
+			fieldValue: $_ENV['CONVERTKIT_API_PRODUCT_ID']
 		);
 
 		// Save Divi module and view the page on the frontend site.
@@ -109,8 +109,8 @@ class DiviPluginProductCest
 		// Insert the Product module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Product',
-			'convertkit_product'
+			name: 'Kit Product',
+			programmaticName: 'convertkit_product'
 		);
 
 		// Confirm the on screen message displays.
@@ -138,8 +138,8 @@ class DiviPluginProductCest
 		// Insert the Product module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Product',
-			'convertkit_product'
+			name: 'Kit Product',
+			programmaticName: 'convertkit_product'
 		);
 
 		// Confirm the on screen message displays.
@@ -163,10 +163,10 @@ class DiviPluginProductCest
 		// Create Page with Product module in Divi.
 		$pageID = $I->createPageWithDiviModuleProgrammatically(
 			$I,
-			'Kit: Product: Divi Module: No Product Param',
-			'convertkit_product',
-			'product',
-			''
+			title: 'Kit: Product: Divi Module: No Product Param',
+			programmaticName: 'convertkit_product',
+			fieldName: 'product',
+			fieldValue: ''
 		);
 
 		// Load Page.

--- a/tests/EndToEnd/integrations/divi-theme/DiviThemeBroadcastsCest.php
+++ b/tests/EndToEnd/integrations/divi-theme/DiviThemeBroadcastsCest.php
@@ -47,8 +47,8 @@ class DiviThemeBroadcastsCest
 		// Insert the Broadcasts module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Broadcasts',
-			'convertkit_broadcasts'
+			name: 'Kit Broadcasts',
+			programmaticName: 'convertkit_broadcasts'
 		);
 
 		// Save Divi module and view the page on the frontend site.
@@ -93,8 +93,8 @@ class DiviThemeBroadcastsCest
 		// Insert the Broadcasts module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Broadcasts',
-			'convertkit_broadcasts'
+			name: 'Kit Broadcasts',
+			programmaticName: 'convertkit_broadcasts'
 		);
 
 		// Save Divi module and view the page on the frontend site.
@@ -131,8 +131,8 @@ class DiviThemeBroadcastsCest
 		// Insert the Broadcasts module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Broadcasts',
-			'convertkit_broadcasts'
+			name: 'Kit Broadcasts',
+			programmaticName: 'convertkit_broadcasts'
 		);
 
 		// Confirm the on screen message displays.
@@ -160,8 +160,8 @@ class DiviThemeBroadcastsCest
 		// Insert the Broadcasts module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Broadcasts',
-			'convertkit_broadcasts'
+			name: 'Kit Broadcasts',
+			programmaticName: 'convertkit_broadcasts'
 		);
 
 		// Confirm the on screen message displays.

--- a/tests/EndToEnd/integrations/divi-theme/DiviThemeFormCest.php
+++ b/tests/EndToEnd/integrations/divi-theme/DiviThemeFormCest.php
@@ -45,10 +45,10 @@ class DiviThemeFormCest
 		// Insert the Form module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Form',
-			'convertkit_form',
-			'form',
-			$_ENV['CONVERTKIT_API_FORM_ID']
+			name: 'Kit Form',
+			programmaticName: 'convertkit_form',
+			fieldName: 'form',
+			fieldValue: $_ENV['CONVERTKIT_API_FORM_ID']
 		);
 
 		// Save Divi module and view the page on the frontend site.
@@ -82,10 +82,10 @@ class DiviThemeFormCest
 		// Insert the Form module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Form',
-			'convertkit_form',
-			'form',
-			$_ENV['CONVERTKIT_API_FORM_ID']
+			name: 'Kit Form',
+			programmaticName: 'convertkit_form',
+			fieldName: 'form',
+			fieldValue: $_ENV['CONVERTKIT_API_FORM_ID']
 		);
 
 		// Save Divi module and view the page on the frontend site.
@@ -111,8 +111,8 @@ class DiviThemeFormCest
 		// Insert the Form module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Form',
-			'convertkit_form'
+			name: 'Kit Form',
+			programmaticName: 'convertkit_form'
 		);
 
 		// Confirm the on screen message displays.
@@ -140,8 +140,8 @@ class DiviThemeFormCest
 		// Insert the Form module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Form',
-			'convertkit_form'
+			name: 'Kit Form',
+			programmaticName: 'convertkit_form'
 		);
 
 		// Confirm the on screen message displays.
@@ -174,10 +174,10 @@ class DiviThemeFormCest
 		// Create Page with Form module in Divi.
 		$pageID = $I->createPageWithDiviModuleProgrammatically(
 			$I,
-			'Kit: Legacy Form: Divi Module: Valid Form Param',
-			'convertkit_form',
-			'form',
-			$_ENV['CONVERTKIT_API_LEGACY_FORM_ID']
+			title: 'Kit: Legacy Form: Divi Module: Valid Form Param',
+			programmaticName: 'convertkit_form',
+			fieldName: 'form',
+			fieldValue: $_ENV['CONVERTKIT_API_LEGACY_FORM_ID']
 		);
 
 		// Load Page.
@@ -206,10 +206,10 @@ class DiviThemeFormCest
 		// Create Page with Form module in Divi.
 		$pageID = $I->createPageWithDiviModuleProgrammatically(
 			$I,
-			'Kit: Legacy Form: Divi Module: No Form Param',
-			'convertkit_form',
-			'form',
-			''
+			title: 'Kit: Legacy Form: Divi Module: No Form Param',
+			programmaticName: 'convertkit_form',
+			fieldName: 'form',
+			fieldValue: ''
 		);
 
 		// Load Page.

--- a/tests/EndToEnd/integrations/divi-theme/DiviThemeFormTriggerCest.php
+++ b/tests/EndToEnd/integrations/divi-theme/DiviThemeFormTriggerCest.php
@@ -45,10 +45,10 @@ class DiviThemeFormTriggerCest
 		// Insert the Form module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Form Trigger',
-			'convertkit_formtrigger',
-			'form',
-			$_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID']
+			name: 'Kit Form Trigger',
+			programmaticName: 'convertkit_formtrigger',
+			fieldName: 'form',
+			fieldValue: $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID']
 		);
 
 		// Save Divi module and view the page on the frontend site.
@@ -85,10 +85,10 @@ class DiviThemeFormTriggerCest
 		// Insert the Form module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Form Trigger',
-			'convertkit_formtrigger',
-			'form',
-			$_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID']
+			name: 'Kit Form Trigger',
+			programmaticName: 'convertkit_formtrigger',
+			fieldName: 'form',
+			fieldValue: $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID']
 		);
 
 		// Save Divi module and view the page on the frontend site.
@@ -117,8 +117,8 @@ class DiviThemeFormTriggerCest
 		// Insert the Form module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Form Trigger',
-			'convertkit_formtrigger'
+			name: 'Kit Form Trigger',
+			programmaticName: 'convertkit_formtrigger'
 		);
 
 		// Confirm the on screen message displays.
@@ -146,8 +146,8 @@ class DiviThemeFormTriggerCest
 		// Insert the Form module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Form Trigger',
-			'convertkit_formtrigger'
+			name: 'Kit Form Trigger',
+			programmaticName: 'convertkit_formtrigger'
 		);
 
 		// Confirm the on screen message displays.
@@ -171,10 +171,10 @@ class DiviThemeFormTriggerCest
 		// Create Page with Form module in Divi.
 		$pageID = $I->createPageWithDiviModuleProgrammatically(
 			$I,
-			'Kit: Legacy Form Trigger: Divi Module: No Form Param',
-			'convertkit_formtrigger',
-			'form',
-			''
+			title: 'Kit: Legacy Form Trigger: Divi Module: No Form Param',
+			programmaticName: 'convertkit_formtrigger',
+			fieldName: 'form',
+			fieldValue: ''
 		);
 
 		// Load Page.

--- a/tests/EndToEnd/integrations/divi-theme/DiviThemeProductCest.php
+++ b/tests/EndToEnd/integrations/divi-theme/DiviThemeProductCest.php
@@ -45,10 +45,10 @@ class DiviThemeProductCest
 		// Insert the Product module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Product',
-			'convertkit_product',
-			'product',
-			$_ENV['CONVERTKIT_API_PRODUCT_ID']
+			name: 'Kit Product',
+			programmaticName: 'convertkit_product',
+			fieldName: 'product',
+			fieldValue: $_ENV['CONVERTKIT_API_PRODUCT_ID']
 		);
 
 		// Save Divi module and view the page on the frontend site.
@@ -81,10 +81,10 @@ class DiviThemeProductCest
 		// Insert the Product module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Product',
-			'convertkit_product',
-			'product',
-			$_ENV['CONVERTKIT_API_PRODUCT_ID']
+			name: 'Kit Product',
+			programmaticName: 'convertkit_product',
+			fieldName: 'product',
+			fieldValue: $_ENV['CONVERTKIT_API_PRODUCT_ID']
 		);
 
 		// Save Divi module and view the page on the frontend site.
@@ -109,8 +109,8 @@ class DiviThemeProductCest
 		// Insert the Product module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Product',
-			'convertkit_product'
+			name: 'Kit Product',
+			programmaticName: 'convertkit_product'
 		);
 
 		// Confirm the on screen message displays.
@@ -138,8 +138,8 @@ class DiviThemeProductCest
 		// Insert the Product module.
 		$I->insertDiviRowWithModule(
 			$I,
-			'Kit Product',
-			'convertkit_product'
+			name: 'Kit Product',
+			programmaticName: 'convertkit_product'
 		);
 
 		// Confirm the on screen message displays.
@@ -163,10 +163,10 @@ class DiviThemeProductCest
 		// Create Page with Product module in Divi.
 		$pageID = $I->createPageWithDiviModuleProgrammatically(
 			$I,
-			'Kit: Product: Divi Module: No Product Param',
-			'convertkit_product',
-			'product',
-			''
+			title: 'Kit: Product: Divi Module: No Product Param',
+			programmaticName: 'convertkit_product',
+			fieldName: 'product',
+			fieldValue: ''
 		);
 
 		// Load Page.

--- a/tests/EndToEnd/integrations/other/ContactForm7FormCest.php
+++ b/tests/EndToEnd/integrations/other/ContactForm7FormCest.php
@@ -66,6 +66,9 @@ class ContactForm7FormCest
 			emailAddress: $emailAddress
 		);
 
+		// Wait for the API to update.
+		$I->wait(2);
+
 		// Confirm that the email address was added to Kit.
 		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
 
@@ -103,6 +106,9 @@ class ContactForm7FormCest
 			emailAddress: $emailAddress
 		);
 
+		// Wait for the API to update.
+		$I->wait(2);
+
 		// Confirm that the email address was added to Kit.
 		$I->apiCheckSubscriberExists($I, $emailAddress);
 	}
@@ -131,6 +137,9 @@ class ContactForm7FormCest
 			pageID: $pageID,
 			emailAddress: $emailAddress
 		);
+
+		// Wait for the API to update.
+		$I->wait(2);
 
 		// Confirm that the email address was added to Kit.
 		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
@@ -167,6 +176,9 @@ class ContactForm7FormCest
 			pageID: $pageID,
 			emailAddress: $emailAddress
 		);
+
+		// Wait for the API to update.
+		$I->wait(2);
 
 		// Confirm that the email address was added to Kit.
 		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
@@ -232,6 +244,9 @@ class ContactForm7FormCest
 			pageID: $pageID,
 			emailAddress: $emailAddress
 		);
+
+		// Wait for the API to update.
+		$I->wait(2);
 
 		// Confirm that the email address was added to Kit.
 		$I->apiCheckSubscriberExists($I, $emailAddress);

--- a/tests/EndToEnd/integrations/other/ContactForm7FormCest.php
+++ b/tests/EndToEnd/integrations/other/ContactForm7FormCest.php
@@ -62,8 +62,8 @@ class ContactForm7FormCest
 		// Complete and submit Contact Form 7 Form.
 		$this->_contactForm7CompleteAndSubmitForm(
 			$I,
-			$pageID,
-			$emailAddress
+			pageID: $pageID,
+			emailAddress: $emailAddress
 		);
 
 		// Confirm that the email address was added to Kit.
@@ -72,9 +72,9 @@ class ContactForm7FormCest
 		// Check that the subscriber has the expected form and referrer value set.
 		$I->apiCheckSubscriberHasForm(
 			$I,
-			$subscriberID,
-			$_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_ID'],
-			$_ENV['WORDPRESS_URL'] . $I->grabFromCurrentUrl()
+			subscriberID: $subscriberID,
+			formID: $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_ID'],
+			referrer: $_ENV['WORDPRESS_URL'] . $I->grabFromCurrentUrl()
 		);
 	}
 
@@ -99,8 +99,8 @@ class ContactForm7FormCest
 		// Complete and submit Contact Form 7 Form.
 		$this->_contactForm7CompleteAndSubmitForm(
 			$I,
-			$pageID,
-			$emailAddress
+			pageID: $pageID,
+			emailAddress: $emailAddress
 		);
 
 		// Confirm that the email address was added to Kit.
@@ -128,15 +128,19 @@ class ContactForm7FormCest
 		// Complete and submit Contact Form 7 Form.
 		$this->_contactForm7CompleteAndSubmitForm(
 			$I,
-			$pageID,
-			$emailAddress
+			pageID: $pageID,
+			emailAddress: $emailAddress
 		);
 
 		// Confirm that the email address was added to Kit.
 		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag(
+			$I,
+			subscriberID: $subscriberID,
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
 	}
 
 	/**
@@ -160,15 +164,19 @@ class ContactForm7FormCest
 		// Complete and submit Contact Form 7 Form.
 		$this->_contactForm7CompleteAndSubmitForm(
 			$I,
-			$pageID,
-			$emailAddress
+			pageID: $pageID,
+			emailAddress: $emailAddress
 		);
 
 		// Confirm that the email address was added to Kit.
 		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the sequence.
-		$I->apiCheckSubscriberHasSequence($I, $subscriberID, $_ENV['CONVERTKIT_API_SEQUENCE_ID']);
+		$I->apiCheckSubscriberHasSequence(
+			$I,
+			subscriberID: $subscriberID,
+			sequenceID: $_ENV['CONVERTKIT_API_SEQUENCE_ID']
+		);
 	}
 
 	/**
@@ -192,8 +200,8 @@ class ContactForm7FormCest
 		// Complete and submit Contact Form 7 Form.
 		$this->_contactForm7CompleteAndSubmitForm(
 			$I,
-			$pageID,
-			$emailAddress
+			pageID: $pageID,
+			emailAddress: $emailAddress
 		);
 
 		// Confirm that the email address was not added to Kit.
@@ -221,8 +229,8 @@ class ContactForm7FormCest
 		// Complete and submit Contact Form 7 Form.
 		$this->_contactForm7CompleteAndSubmitForm(
 			$I,
-			$pageID,
-			$emailAddress
+			pageID: $pageID,
+			emailAddress: $emailAddress
 		);
 
 		// Confirm that the email address was added to Kit.

--- a/tests/EndToEnd/integrations/other/ElementorBroadcastsCest.php
+++ b/tests/EndToEnd/integrations/other/ElementorBroadcastsCest.php
@@ -36,7 +36,10 @@ class ElementorBroadcastsCest
 	public function testBroadcastsWidgetIsRegistered(EndToEndTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Broadcasts: Elementor: Registered');
+		$I->addGutenbergPage(
+			I: $I,
+			title: 'Kit: Page: Broadcasts: Elementor: Registered'
+		);
 
 		// Click Edit with Elementor button.
 		$I->click('#elementor-switch-mode-button');
@@ -65,8 +68,8 @@ class ElementorBroadcastsCest
 		// Create Page with Broadcasts widget in Elementor.
 		$pageID = $this->_createPageWithBroadcastsWidget(
 			$I,
-			'Kit: Page: Broadcasts: Elementor Widget: Valid Params',
-			[
+			title: 'Kit: Page: Broadcasts: Elementor Widget: Valid Params',
+			settings: [
 				'date_format' => 'F j, Y',
 				'limit'       => 10,
 			]
@@ -106,8 +109,8 @@ class ElementorBroadcastsCest
 		// Create Page with Broadcasts widget in Elementor.
 		$pageID = $this->_createPageWithBroadcastsWidget(
 			$I,
-			'Kit: Page: Broadcasts: Elementor Widget: Date Format',
-			[
+			title: 'Kit: Page: Broadcasts: Elementor Widget: Date Format',
+			settings: [
 				'date_format' => 'Y-m-d',
 				'limit'       => 10,
 			]
@@ -147,8 +150,8 @@ class ElementorBroadcastsCest
 		// Create Page with Broadcasts widget in Elementor.
 		$pageID = $this->_createPageWithBroadcastsWidget(
 			$I,
-			'Kit: Page: Broadcasts: Elementor Widget: Limit',
-			[
+			title: 'Kit: Page: Broadcasts: Elementor Widget: Limit',
+			settings: [
 				'date_format' => 'F j, Y',
 				'limit'       => 2,
 			]
@@ -185,8 +188,8 @@ class ElementorBroadcastsCest
 		// Create Page with Broadcasts widget in Elementor.
 		$pageID = $this->_createPageWithBroadcastsWidget(
 			$I,
-			'Kit: Page: Broadcasts: Elementor Widget: Pagination',
-			[
+			title: 'Kit: Page: Broadcasts: Elementor Widget: Pagination',
+			settings: [
 				'date_format' => 'F j, Y',
 				'limit'       => 2,
 				'paginate'    => 1,
@@ -215,8 +218,8 @@ class ElementorBroadcastsCest
 		// Create Page with Broadcasts widget in Elementor.
 		$pageID = $this->_createPageWithBroadcastsWidget(
 			$I,
-			'Kit: Page: Broadcasts: Elementor Widget: Valid Params',
-			[
+			title: 'Kit: Page: Broadcasts: Elementor Widget: Valid Params',
+			settings: [
 				'date_format'         => 'F j, Y',
 				'limit'               => 2,
 				'paginate'            => 1,
@@ -252,8 +255,8 @@ class ElementorBroadcastsCest
 		// Create Page with Broadcasts widget in Elementor.
 		$pageID = $this->_createPageWithBroadcastsWidget(
 			$I,
-			'Kit: Page: Broadcasts: Elementor Widget: Hex Colors',
-			[
+			title: 'Kit: Page: Broadcasts: Elementor Widget: Hex Colors',
+			settings: [
 				'date_format'         => 'F j, Y',
 				'limit'               => 2,
 				'paginate'            => 1,

--- a/tests/EndToEnd/integrations/other/ElementorFormCest.php
+++ b/tests/EndToEnd/integrations/other/ElementorFormCest.php
@@ -38,7 +38,10 @@ class ElementorFormCest
 	public function testFormWidgetIsRegistered(EndToEndTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Elementor: Valid Form Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form: Elementor: Valid Form Param'
+		);
 
 		// Click Edit with Elementor button.
 		$I->click('#elementor-switch-mode-button');
@@ -65,7 +68,11 @@ class ElementorFormCest
 	public function testFormWidgetWithValidFormParameter(EndToEndTester $I)
 	{
 		// Create Page with Form widget in Elementor.
-		$pageID = $this->_createPageWithFormWidget($I, 'Kit: Page: Form: Elementor Widget: Valid Form Param', $_ENV['CONVERTKIT_API_FORM_ID']);
+		$pageID = $this->_createPageWithFormWidget(
+			$I,
+			title: 'Kit: Page: Form: Elementor Widget: Valid Form Param',
+			formID: $_ENV['CONVERTKIT_API_FORM_ID']
+		);
 
 		// Load Page.
 		$I->amOnPage('?p=' . $pageID);
@@ -100,7 +107,11 @@ class ElementorFormCest
 		);
 
 		// Create Page with Form widget in Elementor.
-		$pageID = $this->_createPageWithFormWidget($I, 'Kit: Legacy Form: Elementor Widget: Valid Form Param', $_ENV['CONVERTKIT_API_LEGACY_FORM_ID']);
+		$pageID = $this->_createPageWithFormWidget(
+			$I,
+			title: 'Kit: Legacy Form: Elementor Widget: Valid Form Param',
+			formID: $_ENV['CONVERTKIT_API_LEGACY_FORM_ID']
+		);
 
 		// Load Page.
 		$I->amOnPage('?p=' . $pageID);
@@ -122,7 +133,11 @@ class ElementorFormCest
 	public function testFormWidgetWithNoFormParameter(EndToEndTester $I)
 	{
 		// Create Page with Form widget in Elementor.
-		$pageID = $this->_createPageWithFormWidget($I, 'Kit: Page: Form: Elementor Widget: No Form Param', '');
+		$pageID = $this->_createPageWithFormWidget(
+			$I,
+			title: 'Kit: Page: Form: Elementor Widget: No Form Param',
+			formID: ''
+		);
 
 		// Load Page.
 		$I->amOnPage('?p=' . $pageID);

--- a/tests/EndToEnd/integrations/other/ElementorFormTriggerCest.php
+++ b/tests/EndToEnd/integrations/other/ElementorFormTriggerCest.php
@@ -36,7 +36,10 @@ class ElementorFormTriggerCest
 	public function testFormTriggerWidgetIsRegistered(EndToEndTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form Trigger: Elementor: Registered');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Trigger: Elementor: Registered'
+		);
 
 		// Click Edit with Elementor button.
 		$I->click('#elementor-switch-mode-button');
@@ -65,8 +68,8 @@ class ElementorFormTriggerCest
 		// Create Page with Form Trigger widget in Elementor.
 		$pageID = $this->_createPageWithFormTriggerWidget(
 			$I,
-			'Kit: Page: Form Trigger: Elementor Widget: Valid Params',
-			[
+			title: 'Kit: Page: Form Trigger: Elementor Widget: Valid Params',
+			settings: [
 				'form' => $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'],
 				'text' => 'Subscribe',
 			]
@@ -79,7 +82,11 @@ class ElementorFormTriggerCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the form trigger button displays.
-		$I->seeFormTriggerOutput($I, $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_URL'], 'Subscribe');
+		$I->seeFormTriggerOutput(
+			$I,
+			formURL: $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_URL'],
+			text: 'Subscribe'
+		);
 	}
 
 	/**
@@ -98,8 +105,8 @@ class ElementorFormTriggerCest
 		// Create Page with Form Trigger widget in Elementor.
 		$pageID = $this->_createPageWithFormTriggerWidget(
 			$I,
-			'Kit: Page: Form Trigger: Elementor Widget: Hex Colors',
-			[
+			title: 'Kit: Page: Form Trigger: Elementor Widget: Hex Colors',
+			settings: [
 				'form'             => $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'],
 				'text'             => 'Subscribe',
 				'background_color' => $backgroundColor,
@@ -114,7 +121,13 @@ class ElementorFormTriggerCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the form trigger button displays.
-		$I->seeFormTriggerOutput($I, $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_URL'], 'Subscribe', $textColor, $backgroundColor);
+		$I->seeFormTriggerOutput(
+			$I,
+			formURL: $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_URL'],
+			text: 'Subscribe',
+			textColor: $textColor,
+			backgroundColor: $backgroundColor
+		);
 	}
 
 	/**

--- a/tests/EndToEnd/integrations/other/ElementorProductCest.php
+++ b/tests/EndToEnd/integrations/other/ElementorProductCest.php
@@ -36,7 +36,10 @@ class ElementorProductCest
 	public function testProductWidgetIsRegistered(EndToEndTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Product: Elementor: Registered');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Product: Elementor: Registered'
+		);
 
 		// Click Edit with Elementor button.
 		$I->click('#elementor-switch-mode-button');
@@ -65,8 +68,8 @@ class ElementorProductCest
 		// Create Page with Product widget in Elementor.
 		$pageID = $this->_createPageWithProductWidget(
 			$I,
-			'Kit: Page: Product: Elementor Widget: Valid Params',
-			[
+			title: 'Kit: Page: Product: Elementor Widget: Valid Params',
+			settings: [
 				'product' => $_ENV['CONVERTKIT_API_PRODUCT_ID'],
 				'text'    => 'Buy my product',
 			]
@@ -98,8 +101,8 @@ class ElementorProductCest
 		// Create Page with Product widget in Elementor.
 		$pageID = $this->_createPageWithProductWidget(
 			$I,
-			'Kit: Page: Product: Elementor Widget: Hex Colors',
-			[
+			title: 'Kit: Page: Product: Elementor Widget: Hex Colors',
+			settings: [
 				'product'          => $_ENV['CONVERTKIT_API_PRODUCT_ID'],
 				'text'             => 'Buy my product',
 				'background_color' => $backgroundColor,
@@ -114,7 +117,13 @@ class ElementorProductCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the block displays.
-		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product', $textColor, $backgroundColor);
+		$I->seeProductOutput(
+			$I,
+			productURL: $_ENV['CONVERTKIT_API_PRODUCT_URL'],
+			text: 'Buy my product',
+			textColor: $textColor,
+			backgroundColor: $backgroundColor
+		);
 	}
 
 	/**

--- a/tests/EndToEnd/integrations/other/ForminatorCest.php
+++ b/tests/EndToEnd/integrations/other/ForminatorCest.php
@@ -62,8 +62,8 @@ class ForminatorCest
 		// Complete and submit Forminator Form.
 		$this->_forminatorCompleteAndSubmitForm(
 			$I,
-			$pageID,
-			$emailAddress
+			pageID: $pageID,
+			emailAddress: $emailAddress
 		);
 
 		// Confirm that the email address was added to Kit.
@@ -72,9 +72,9 @@ class ForminatorCest
 		// Check that the subscriber has the expected form and referrer value set.
 		$I->apiCheckSubscriberHasForm(
 			$I,
-			$subscriberID,
-			$_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_ID'],
-			$_ENV['WORDPRESS_URL'] . $I->grabFromCurrentUrl()
+			subscriberID: $subscriberID,
+			formID: $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_ID'],
+			referrer: $_ENV['WORDPRESS_URL'] . $I->grabFromCurrentUrl()
 		);
 	}
 
@@ -99,8 +99,8 @@ class ForminatorCest
 		// Complete and submit Forminator Form.
 		$this->_forminatorCompleteAndSubmitForm(
 			$I,
-			$pageID,
-			$emailAddress
+			pageID: $pageID,
+			emailAddress: $emailAddress
 		);
 
 		// Confirm that the email address was added to Kit.
@@ -128,15 +128,19 @@ class ForminatorCest
 		// Complete and submit Forminator Form.
 		$this->_forminatorCompleteAndSubmitForm(
 			$I,
-			$pageID,
-			$emailAddress
+			pageID: $pageID,
+			emailAddress: $emailAddress
 		);
 
 		// Confirm that the email address was added to Kit.
 		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag(
+			$I,
+			subscriberID: $subscriberID,
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
 	}
 
 	/**
@@ -160,8 +164,8 @@ class ForminatorCest
 		// Complete and submit Forminator Form.
 		$this->_forminatorCompleteAndSubmitForm(
 			$I,
-			$pageID,
-			$emailAddress
+			pageID: $pageID,
+			emailAddress: $emailAddress
 		);
 
 		// Confirm that the email address was added to Kit.
@@ -192,8 +196,8 @@ class ForminatorCest
 		// Complete and submit Forminator Form.
 		$this->_forminatorCompleteAndSubmitForm(
 			$I,
-			$pageID,
-			$emailAddress
+			pageID: $pageID,
+			emailAddress: $emailAddress
 		);
 
 		// Confirm that the email address was not added to Kit.
@@ -221,8 +225,8 @@ class ForminatorCest
 		// Complete and submit Forminator Form.
 		$this->_forminatorCompleteAndSubmitForm(
 			$I,
-			$pageID,
-			$emailAddress
+			pageID: $pageID,
+			emailAddress: $emailAddress
 		);
 
 		// Confirm that the email address was added to Kit.
@@ -250,8 +254,8 @@ class ForminatorCest
 		// Complete and submit Forminator Quiz.
 		$this->_forminatorCompleteAndSubmitQuiz(
 			$I,
-			$pageID,
-			$emailAddress
+			pageID: $pageID,
+			emailAddress: $emailAddress
 		);
 
 		// Confirm that the email address was added to Kit.
@@ -279,15 +283,19 @@ class ForminatorCest
 		// Complete and submit Forminator Quiz.
 		$this->_forminatorCompleteAndSubmitQuiz(
 			$I,
-			$pageID,
-			$emailAddress
+			pageID: $pageID,
+			emailAddress: $emailAddress
 		);
 
 		// Confirm that the email address was added to Kit.
 		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag(
+			$I,
+			subscriberID: $subscriberID,
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
 	}
 
 	/**
@@ -311,15 +319,19 @@ class ForminatorCest
 		// Complete and submit Forminator Quiz.
 		$this->_forminatorCompleteAndSubmitQuiz(
 			$I,
-			$pageID,
-			$emailAddress
+			pageID: $pageID,
+			emailAddress: $emailAddress
 		);
 
 		// Confirm that the email address was added to Kit.
 		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the sequence.
-		$I->apiCheckSubscriberHasSequence($I, $subscriberID, $_ENV['CONVERTKIT_API_SEQUENCE_ID']);
+		$I->apiCheckSubscriberHasSequence(
+			$I,
+			subscriberID: $subscriberID,
+			sequenceID: $_ENV['CONVERTKIT_API_SEQUENCE_ID']
+		);
 	}
 
 	/**
@@ -343,8 +355,8 @@ class ForminatorCest
 		// Complete and submit Forminator Quiz.
 		$this->_forminatorCompleteAndSubmitQuiz(
 			$I,
-			$pageID,
-			$emailAddress
+			pageID: $pageID,
+			emailAddress: $emailAddress
 		);
 
 		// Confirm that the email address was not added to Kit.
@@ -372,8 +384,8 @@ class ForminatorCest
 		// Complete and submit Forminator Quiz.
 		$this->_forminatorCompleteAndSubmitQuiz(
 			$I,
-			$pageID,
-			$emailAddress
+			pageID: $pageID,
+			emailAddress: $emailAddress
 		);
 
 		// Confirm that the email address was added to Kit.

--- a/tests/EndToEnd/integrations/other/ForminatorCest.php
+++ b/tests/EndToEnd/integrations/other/ForminatorCest.php
@@ -66,6 +66,9 @@ class ForminatorCest
 			emailAddress: $emailAddress
 		);
 
+		// Wait for the API to update.
+		$I->wait(2);
+
 		// Confirm that the email address was added to Kit.
 		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
 
@@ -103,6 +106,9 @@ class ForminatorCest
 			emailAddress: $emailAddress
 		);
 
+		// Wait for the API to update.
+		$I->wait(2);
+
 		// Confirm that the email address was added to Kit.
 		$I->apiCheckSubscriberExists($I, $emailAddress);
 	}
@@ -131,6 +137,9 @@ class ForminatorCest
 			pageID: $pageID,
 			emailAddress: $emailAddress
 		);
+
+		// Wait for the API to update.
+		$I->wait(2);
 
 		// Confirm that the email address was added to Kit.
 		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
@@ -167,6 +176,9 @@ class ForminatorCest
 			pageID: $pageID,
 			emailAddress: $emailAddress
 		);
+
+		// Wait for the API to update.
+		$I->wait(2);
 
 		// Confirm that the email address was added to Kit.
 		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
@@ -258,6 +270,9 @@ class ForminatorCest
 			emailAddress: $emailAddress
 		);
 
+		// Wait for the API to update.
+		$I->wait(2);
+
 		// Confirm that the email address was added to Kit.
 		$I->apiCheckSubscriberExists($I, $emailAddress);
 	}
@@ -286,6 +301,9 @@ class ForminatorCest
 			pageID: $pageID,
 			emailAddress: $emailAddress
 		);
+
+		// Wait for the API to update.
+		$I->wait(2);
 
 		// Confirm that the email address was added to Kit.
 		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
@@ -322,6 +340,9 @@ class ForminatorCest
 			pageID: $pageID,
 			emailAddress: $emailAddress
 		);
+
+		// Wait for the API to update.
+		$I->wait(2);
 
 		// Confirm that the email address was added to Kit.
 		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
@@ -387,6 +408,9 @@ class ForminatorCest
 			pageID: $pageID,
 			emailAddress: $emailAddress
 		);
+
+		// Wait for the API to update.
+		$I->wait(2);
 
 		// Confirm that the email address was added to Kit.
 		$I->apiCheckSubscriberExists($I, $emailAddress);

--- a/tests/EndToEnd/integrations/woocommerce/WooCommerceProductFormCest.php
+++ b/tests/EndToEnd/integrations/woocommerce/WooCommerceProductFormCest.php
@@ -262,9 +262,9 @@ class WooCommerceProductFormCest
 		// Quick Edit the Product in the Products WP_List_Table.
 		$I->quickEdit(
 			$I,
-			'product',
-			$productID,
-			[
+			postType: 'product',
+			postID: $productID,
+			configuration: [
 				'form' => [ 'select', 'Default' ],
 			]
 		);
@@ -305,9 +305,9 @@ class WooCommerceProductFormCest
 		// Quick Edit the Product in the Products WP_List_Table.
 		$I->quickEdit(
 			$I,
-			'product',
-			$productID,
-			[
+			postType: 'product',
+			postID: $productID,
+			configuration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);

--- a/tests/EndToEnd/integrations/woocommerce/WooCommerceProductFormCest.php
+++ b/tests/EndToEnd/integrations/woocommerce/WooCommerceProductFormCest.php
@@ -356,9 +356,9 @@ class WooCommerceProductFormCest
 		// Bulk Edit the Products in the Products WP_List_Table.
 		$I->bulkEdit(
 			$I,
-			'product',
-			$productIDs,
-			[
+			postType: 'product',
+			postIDs: $productIDs,
+			configuration: [
 				'form' => [ 'select', 'Default' ],
 			]
 		);
@@ -410,9 +410,9 @@ class WooCommerceProductFormCest
 		// Bulk Edit the Products in the Products WP_List_Table.
 		$I->bulkEdit(
 			$I,
-			'product',
-			$productIDs,
-			[
+			postType: 'product',
+			postIDs: $productIDs,
+			configuration: [
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -478,9 +478,9 @@ class WooCommerceProductFormCest
 		// Bulk Edit the Products in the Products WP_List_Table.
 		$I->bulkEdit(
 			$I,
-			'product',
-			$productIDs,
-			[
+			postType: 'product',
+			postIDs: $productIDs,
+			configuration: [
 				'form' => [ 'select', '— No Change —' ],
 			]
 		);

--- a/tests/Support/Helper/KitForms.php
+++ b/tests/Support/Helper/KitForms.php
@@ -19,9 +19,9 @@ class KitForms extends \Codeception\Module
 	 * @param   int            $formID         Form ID.
 	 * @param   bool|string    $position       Position of the form in the DOM relative to the content.
 	 * @param   bool|string    $element        Element the form should display after.
-	 * @param   bool|string    $element_index  Number of elements before the form should display.
+	 * @param   bool|string    $elementIndex   Number of elements before the form should display.
 	 */
-	public function seeFormOutput($I, $formID, $position = false, $element = false, $element_index = 0)
+	public function seeFormOutput($I, $formID, $position = false, $element = false, $elementIndex = 0)
 	{
 		// Calculate how many times the Form should be in the DOM.
 		$count = ( ( $position === 'before_after_content' ) ? 2 : 1 );
@@ -53,16 +53,16 @@ class KitForms extends \Codeception\Module
 				// The block editor automatically adds CSS classes to some elements.
 				switch ( $element ) {
 					case 'p':
-						$I->seeInSource('<' . $element . '>Item #' . $element_index . '</' . $element . '><form action="https://app.kit.com/forms/' . $formID . '/subscriptions" ');
+						$I->seeInSource('<' . $element . '>Item #' . $elementIndex . '</' . $element . '><form action="https://app.kit.com/forms/' . $formID . '/subscriptions" ');
 						break;
 
 					case 'img':
-						$I->seeInSource('<' . $element . ' decoding="async" src="https://placehold.co/600x400" alt="Image #' . $element_index . '"><form action="https://app.kit.com/forms/' . $formID . '/subscriptions" ');
+						$I->seeInSource('<' . $element . ' decoding="async" src="https://placehold.co/600x400" alt="Image #' . $elementIndex . '"><form action="https://app.kit.com/forms/' . $formID . '/subscriptions" ');
 						break;
 
 					// Headings.
 					default:
-						$I->seeInSource('<' . $element . ' class="wp-block-heading">Item #' . $element_index . '</' . $element . '><form action="https://app.kit.com/forms/' . $formID . '/subscriptions" ');
+						$I->seeInSource('<' . $element . ' class="wp-block-heading">Item #' . $elementIndex . '</' . $element . '><form action="https://app.kit.com/forms/' . $formID . '/subscriptions" ');
 						break;
 				}
 				break;


### PR DESCRIPTION
## Summary

Continues adding named arguments to tests, based on https://github.com/Kit/convertkit-wordpress/pull/825.

Adds some delays to Contact Form 7 and Forminator tests when checking the API for a subscriber, to reduce test failures and hitting API rate limits.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)