### PR TITLE
Tests: Use Named Arguments, Part 3

### DIFF
--- a/tests/EndToEnd/landing-pages/PageLandingPageCest.php
+++ b/tests/EndToEnd/landing-pages/PageLandingPageCest.php
@@ -39,13 +39,16 @@ class PageLandingPageCest
 	public function testAddNewPageUsingNoLandingPage(EndToEndTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Landing Page: None');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Landing Page: None'
+		);
 
 		// Check the order of the Landing Page resources are alphabetical, with the None option prepending the Landing Pages.
 		$I->checkSelectLandingPageOptionOrder(
 			$I,
-			'#wp-convertkit-landing_page',
-			[
+			selectElement: '#wp-convertkit-landing_page',
+			prependOptions:[
 				'None',
 			]
 		);
@@ -53,8 +56,8 @@ class PageLandingPageCest
 		// Configure metabox's Landing Page setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'landing_page' => [ 'select2', 'None' ],
 			]
 		);
@@ -78,13 +81,16 @@ class PageLandingPageCest
 	public function testAddNewPageUsingDefinedLandingPage(EndToEndTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME']);
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME']
+		);
 
 		// Configure metabox's Landing Page setting to value specified in the .env file.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME'] ],
 			]
 		);
@@ -125,13 +131,16 @@ class PageLandingPageCest
 		$I->haveOptionInDatabase('site_icon', $imageID);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Landing Page: Site Icon: ' . $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME']);
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Landing Page: Site Icon: ' . $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME']
+		);
 
 		// Configure metabox's Landing Page setting to value specified in the .env file.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME'] ],
 			]
 		);
@@ -167,13 +176,16 @@ class PageLandingPageCest
 	public function testLandingPageCharacterEncoding(EndToEndTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LANDING_PAGE_CHARACTER_ENCODING_NAME']);
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LANDING_PAGE_CHARACTER_ENCODING_NAME']
+		);
 
 		// Configure metabox's Landing Page setting to value specified in the .env file.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_CHARACTER_ENCODING_NAME'] ],
 			]
 		);
@@ -202,13 +214,16 @@ class PageLandingPageCest
 	public function testAddNewPageUsingDefinedLegacyLandingPage(EndToEndTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME']);
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME']
+		);
 
 		// Configure metabox's Landing Page setting to value specified in the .env file.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME'] ],
 			]
 		);
@@ -242,13 +257,16 @@ class PageLandingPageCest
 		$I->haveOptionInDatabase('site_icon', $imageID);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Legacy Landing Page: Site Icon: ' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME']);
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Legacy Landing Page: Site Icon: ' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME']
+		);
 
 		// Configure metabox's Landing Page setting to value specified in the .env file.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME'] ],
 			]
 		);
@@ -347,13 +365,16 @@ class PageLandingPageCest
 		);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Landing Page: Perfmatters: ' . $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME']);
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Landing Page: Perfmatters: ' . $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME']
+		);
 
 		// Configure metabox's Landing Page setting to value specified in the .env file.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME'] ],
 			]
 		);
@@ -402,13 +423,16 @@ class PageLandingPageCest
 		$I->enableWPRocketLazyLoad($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Landing Page: WP Rocket: ' . $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME']);
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Landing Page: WP Rocket: ' . $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME']
+		);
 
 		// Configure metabox's Landing Page setting to value specified in the .env file.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME'] ],
 			]
 		);

--- a/tests/EndToEnd/landing-pages/PageLandingPageSetupWizardCest.php
+++ b/tests/EndToEnd/landing-pages/PageLandingPageSetupWizardCest.php
@@ -185,7 +185,11 @@ class PageLandingPageSetupWizardCest
 		$this->_setupAndLoadAddNewLandingPageScreen($I);
 
 		// Select a landing page and enter a slug.
-		$I->fillSelect2Field($I, '#select2-landing_page-container', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-landing_page-container',
+			value: $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME']
+		);
 		$I->fillField('post_name', 'landing-page-setup-wizard');
 
 		// Click create button.
@@ -226,7 +230,11 @@ class PageLandingPageSetupWizardCest
 		$this->_setupAndLoadAddNewLandingPageScreen($I);
 
 		// Select a landing page and enter a slug.
-		$I->fillSelect2Field($I, '#select2-landing_page-container', $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME']);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-landing_page-container',
+			value: $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME']
+		);
 		$I->fillField('post_name', 'landing-page-setup-wizard');
 
 		// Click create button.

--- a/tests/EndToEnd/landing-pages/PostLandingPageCest.php
+++ b/tests/EndToEnd/landing-pages/PostLandingPageCest.php
@@ -40,7 +40,11 @@ class PostLandingPageCest
 	public function testAddNewPostDoesNotDisplayLandingPageOption(EndToEndTester $I)
 	{
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Landing Page');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'post',
+			title: 'Kit: Post: Landing Page'
+		);
 
 		// Check that the metabox is displayed.
 		$I->seeElementInDOM('#wp-convertkit-meta-box');
@@ -51,8 +55,8 @@ class PostLandingPageCest
 		// Configure metabox's Form setting = Default.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'Default' ],
 			]
 		);

--- a/tests/EndToEnd/products/PageBlockFormatterProductLinkCest.php
+++ b/tests/EndToEnd/products/PageBlockFormatterProductLinkCest.php
@@ -37,13 +37,16 @@ class PageBlockFormatterProductLinkCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Product Link Formatter');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Product Link Formatter'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
@@ -57,9 +60,9 @@ class PageBlockFormatterProductLinkCest
 		// Apply formatter to link the selected text.
 		$I->applyGutenbergFormatter(
 			$I,
-			'Kit Product Trigger',
-			'convertkit-product-link',
-			[
+			formatterName: 'Kit Product Trigger',
+			formatterProgrammaticName:'convertkit-product-link',
+			formatterConfiguration:[
 				// Product.
 				'data-id' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			]
@@ -87,13 +90,16 @@ class PageBlockFormatterProductLinkCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Product Link Formatter: Product Toggle');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Product Link Formatter: Product Toggle'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
@@ -107,9 +113,9 @@ class PageBlockFormatterProductLinkCest
 		// Apply formatter to link the selected text.
 		$I->applyGutenbergFormatter(
 			$I,
-			'Kit Product Trigger',
-			'convertkit-product-link',
-			[
+			formatterName: 'Kit Product Trigger',
+			formatterProgrammaticName:'convertkit-product-link',
+			formatterConfiguration:[
 				// Product.
 				'data-id' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			]
@@ -118,9 +124,9 @@ class PageBlockFormatterProductLinkCest
 		// Apply the formatter again, this time selecting the 'None' option.
 		$I->applyGutenbergFormatter(
 			$I,
-			'Kit Product Trigger',
-			'convertkit-product-link',
-			[
+			formatterName: 'Kit Product Trigger',
+			formatterProgrammaticName:'convertkit-product-link',
+			formatterConfiguration:[
 				// Form.
 				'data-id' => [ 'select', 'None' ],
 			]
@@ -147,13 +153,16 @@ class PageBlockFormatterProductLinkCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Product Link Formatter: No Product');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Product Link Formatter: No Product'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
@@ -167,9 +176,9 @@ class PageBlockFormatterProductLinkCest
 		// Apply formatter to link the selected text.
 		$I->applyGutenbergFormatter(
 			$I,
-			'Kit Product Trigger',
-			'convertkit-product-link',
-			[
+			formatterName: 'Kit Product Trigger',
+			formatterProgrammaticName:'convertkit-product-link',
+			formatterConfiguration:[
 				// Form.
 				'data-id' => [ 'select', 'None' ],
 			]
@@ -192,7 +201,10 @@ class PageBlockFormatterProductLinkCest
 	public function testProductLinkFormatterNotRegisteredWhenNoProductsExist(EndToEndTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Product Link Formatter: No Products Exist');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Product Link Formatter: No Products Exist'
+		);
 
 		// Add paragraph to Page.
 		$I->addGutenbergParagraphBlock($I, 'Subscribe');

--- a/tests/EndToEnd/products/PageBlockProductCest.php
+++ b/tests/EndToEnd/products/PageBlockProductCest.php
@@ -37,13 +37,16 @@ class PageBlockProductCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Product: Valid Product Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Product: Valid Product Param'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
@@ -51,9 +54,9 @@ class PageBlockProductCest
 		// Add block to Page, setting the Product setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Product',
-			'convertkit-product',
-			[
+			blockName: 'Kit Product',
+			blockProgrammaticName: 'convertkit-product',
+			blockConfiguration: [
 				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			]
 		);
@@ -62,7 +65,11 @@ class PageBlockProductCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the block displays.
-		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
+		$I->seeProductOutput(
+			$I,
+			productURL: $_ENV['CONVERTKIT_API_PRODUCT_URL'],
+			text: 'Buy my product'
+		);
 	}
 
 	/**
@@ -79,19 +86,26 @@ class PageBlockProductCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Product: No Product Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Product: No Product Param'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Product', 'convertkit-product');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Product',
+			blockProgrammaticName: 'convertkit-product'
+		);
 
 		// Confirm that the Product block displays instructions to the user on how to select a Product.
 		$I->seeBlockHasNoContentMessage($I, 'Select a Product using the Product option in the Gutenberg sidebar.');
@@ -117,14 +131,17 @@ class PageBlockProductCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Product: Text Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Product: Text Param'
+		);
 
 		// Add block to Page, setting the date format.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Product',
-			'convertkit-product',
-			[
+			blockName: 'Kit Product',
+			blockProgrammaticName: 'convertkit-product',
+			blockConfiguration: [
 				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 				'text'    => [ 'text', 'Buy Now' ],
 			]
@@ -134,7 +151,11 @@ class PageBlockProductCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the block displays.
-		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy Now');
+		$I->seeProductOutput(
+			$I,
+			productURL: $_ENV['CONVERTKIT_API_PRODUCT_URL'],
+			text: 'Buy Now'
+		);
 	}
 
 	/**
@@ -151,14 +172,17 @@ class PageBlockProductCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Product: Blank Text Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Product: Blank Text Param'
+		);
 
 		// Add block to Page, setting the date format.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Product',
-			'convertkit-product',
-			[
+			blockName: 'Kit Product',
+			blockProgrammaticName: 'convertkit-product',
+			blockConfiguration: [
 				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 				'text'    => [ 'text', '' ],
 			]
@@ -168,7 +192,11 @@ class PageBlockProductCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the block displays.
-		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
+		$I->seeProductOutput(
+			$I,
+			productURL: $_ENV['CONVERTKIT_API_PRODUCT_URL'],
+			text: 'Buy my product'
+		);
 	}
 
 	/**
@@ -185,13 +213,16 @@ class PageBlockProductCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Product: Valid Discount Code Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Product: Valid Discount Code Param'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
@@ -199,9 +230,9 @@ class PageBlockProductCest
 		// Add block to Page, setting the Product setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Product',
-			'convertkit-product',
-			[
+			blockName: 'Kit Product',
+			blockProgrammaticName: 'convertkit-product',
+			blockConfiguration: [
 				'product'       => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 				'discount_code' => [ 'text', $_ENV['CONVERTKIT_API_PRODUCT_DISCOUNT_CODE'] ],
 			]
@@ -211,7 +242,11 @@ class PageBlockProductCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the block displays.
-		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
+		$I->seeProductOutput(
+			$I,
+			productURL: $_ENV['CONVERTKIT_API_PRODUCT_URL'],
+			text: 'Buy my product'
+		);
 
 		// Confirm the discount code has been applied.
 		$I->switchToIFrame('iframe[data-active]');
@@ -233,13 +268,16 @@ class PageBlockProductCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Product: Invalid Discount Code Param');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Product: Invalid Discount Code Param'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
@@ -247,9 +285,9 @@ class PageBlockProductCest
 		// Add block to Page, setting the Product setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Product',
-			'convertkit-product',
-			[
+			blockName: 'Kit Product',
+			blockProgrammaticName: 'convertkit-product',
+			blockConfiguration: [
 				'product'       => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 				'discount_code' => [ 'text', 'fake' ],
 			]
@@ -259,7 +297,11 @@ class PageBlockProductCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the block displays.
-		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
+		$I->seeProductOutput(
+			$I,
+			productURL: $_ENV['CONVERTKIT_API_PRODUCT_URL'],
+			text: 'Buy my product'
+		);
 
 		// Confirm the discount code is not valid, but the modal displays so the user can still purchase.
 		$I->switchToIFrame('iframe[data-active]');
@@ -282,13 +324,16 @@ class PageBlockProductCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Product: Checkout Step');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Product: Checkout Step'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
@@ -296,9 +341,9 @@ class PageBlockProductCest
 		// Add block to Page, setting the Product setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Product',
-			'convertkit-product',
-			[
+			blockName: 'Kit Product',
+			blockProgrammaticName: 'convertkit-product',
+			blockConfiguration: [
 				'product'                     => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 				'#inspector-toggle-control-0' => [ 'toggle', true ],
 			]
@@ -308,7 +353,11 @@ class PageBlockProductCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the Kit Product is displayed.
-		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
+		$I->seeProductOutput(
+			$I,
+			productURL: $_ENV['CONVERTKIT_API_PRODUCT_URL'],
+			text: 'Buy my product'
+		);
 
 		// Confirm the checkout step is displayed.
 		$I->switchToIFrame('iframe[data-active]');
@@ -331,13 +380,16 @@ class PageBlockProductCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Product: Disable Modal on Mobile');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Product: Disable Modal on Mobile'
+		);
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form' => [ 'select2', 'None' ],
 			]
 		);
@@ -345,9 +397,9 @@ class PageBlockProductCest
 		// Add block to Page, setting the Product setting to the value specified in the .env file.
 		$I->addGutenbergBlock(
 			$I,
-			'Kit Product',
-			'convertkit-product',
-			[
+			blockName: 'Kit Product',
+			blockProgrammaticName: 'convertkit-product',
+			blockConfiguration: [
 				'product'                     => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 				'#inspector-toggle-control-1' => [ 'toggle', true ],
 			]
@@ -412,7 +464,10 @@ class PageBlockProductCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the block displays.
-		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL']);
+		$I->seeProductOutput(
+			$I,
+			productURL: $_ENV['CONVERTKIT_API_PRODUCT_URL']
+		);
 
 		// Confirm that the chosen colors are applied as CSS styles.
 		$I->seeInSource('class="wp-block-button__link convertkit-product has-text-color has-' . $textColor . '-color has-background has-' . $backgroundColor . '-background-color');
@@ -456,7 +511,13 @@ class PageBlockProductCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the block displays.
-		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product', $textColor, $backgroundColor);
+		$I->seeProductOutput(
+			$I,
+			productURL: $_ENV['CONVERTKIT_API_PRODUCT_URL'],
+			text: 'Buy my product',
+			textColor: $textColor,
+			backgroundColor: $backgroundColor
+		);
 	}
 
 	/**
@@ -470,16 +531,23 @@ class PageBlockProductCest
 	public function testProductBlockWhenNoCredentials(EndToEndTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Product: Block: No API Key');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Product: Block: No API Key'
+		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Product', 'convertkit-product');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Product',
+			blockProgrammaticName: 'convertkit-product'
+		);
 
 		// Test that the popup window works.
 		$I->testBlockNoCredentialsPopupWindow(
 			$I,
-			'convertkit-product',
-			'Select a Product using the Product option in the Gutenberg sidebar.'
+			blockName: 'convertkit-product',
+			expectedMessage:'Select a Product using the Product option in the Gutenberg sidebar.'
 		);
 
 		// Save page to avoid alert box when _passed() runs to deactivate the Plugin.
@@ -501,10 +569,17 @@ class PageBlockProductCest
 		$I->setupKitPluginResourcesNoData($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Product: Block: No Products');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Product: Block: No Products'
+		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Product', 'convertkit-product');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Product',
+			blockProgrammaticName: 'convertkit-product'
+		);
 
 		// Confirm that the Product block displays instructions to the user on how to add a Product in Kit.
 		$I->seeBlockHasNoContentMessage($I, 'No products exist in Kit.');
@@ -530,10 +605,17 @@ class PageBlockProductCest
 		$I->setupKitPluginResourcesNoData($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Product: Refresh Button');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Product: Refresh Button'
+		);
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'Kit Product', 'convertkit-product');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Product',
+			blockProgrammaticName: 'convertkit-product'
+		);
 
 		// Setup Plugin with a valid API Key and resources, as if the user performed the necessary steps to authenticate
 		// and create a product.
@@ -586,7 +668,11 @@ class PageBlockProductCest
 		$I->dontSeeInSource('style="color:red" onmouseover="alert(1)""');
 
 		// Confirm that the Kit Product is displayed.
-		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
+		$I->seeProductOutput(
+			$I,
+			productURL: $_ENV['CONVERTKIT_API_PRODUCT_URL'],
+			text: 'Buy my product'
+		);
 	}
 
 	/**

--- a/tests/EndToEnd/products/PageShortcodeProductCest.php
+++ b/tests/EndToEnd/products/PageShortcodeProductCest.php
@@ -38,23 +38,30 @@ class PageShortcodeProductCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Product: Shortcode: Visual Editor');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Product: Shortcode: Visual Editor'
+		);
 
 		// Add shortcode to Page, setting the Product setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Product',
-			[
+			shortcodeName: 'Kit Product',
+			shortcodeConfiguration: [
 				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			],
-			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" checkout="0" disable_modal_on_mobile="0"]'
+			expectedShortcodeOutput: '[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" checkout="0" disable_modal_on_mobile="0"]'
 		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the Kit Product is displayed.
-		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
+		$I->seeProductOutput(
+			$I,
+			productURL: $_ENV['CONVERTKIT_API_PRODUCT_URL'],
+			text: 'Buy my product'
+		);
 	}
 
 	/**
@@ -72,23 +79,30 @@ class PageShortcodeProductCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Product: Shortcode: Text Editor');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Product: Shortcode: Text Editor'
+		);
 
 		// Add shortcode to Page, setting the Product setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
-			'convertkit-product',
-			[
+			shortcodeProgrammaticName: 'convertkit-product',
+			shortcodeConfiguration: [
 				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			],
-			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" checkout="0" disable_modal_on_mobile="0"]'
+			expectedShortcodeOutput: '[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" checkout="0" disable_modal_on_mobile="0"]'
 		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the Kit Product is displayed.
-		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
+		$I->seeProductOutput(
+			$I,
+			productURL: $_ENV['CONVERTKIT_API_PRODUCT_URL'],
+			text: 'Buy my product'
+		);
 	}
 
 	/**
@@ -136,24 +150,31 @@ class PageShortcodeProductCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Product: Shortcode: Text Param');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Product: Shortcode: Text Param'
+		);
 
 		// Add shortcode to Page, setting the Product setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Product',
-			[
+			shortcodeName: 'Kit Product',
+			shortcodeConfiguration: [
 				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 				'text'    => [ 'input', 'Buy now' ],
 			],
-			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy now" checkout="0" disable_modal_on_mobile="0"]'
+			expectedShortcodeOutput: '[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy now" checkout="0" disable_modal_on_mobile="0"]'
 		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the Kit Product is displayed.
-		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy now');
+		$I->seeProductOutput(
+			$I,
+			productURL: $_ENV['CONVERTKIT_API_PRODUCT_URL'],
+			text: 'Buy now'
+		);
 	}
 
 	/**
@@ -170,24 +191,31 @@ class PageShortcodeProductCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Product: Shortcode: Blank Text Param');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Product: Shortcode: Blank Text Param'
+		);
 
 		// Add shortcode to Page, setting the Product setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Product',
-			[
+			shortcodeName: 'Kit Product',
+			shortcodeConfiguration: [
 				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 				'text'    => [ 'input', '' ],
 			],
-			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" checkout="0" disable_modal_on_mobile="0"]'
+			expectedShortcodeOutput: '[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" checkout="0" disable_modal_on_mobile="0"]'
 		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the Kit Product is displayed.
-		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
+		$I->seeProductOutput(
+			$I,
+			productURL: $_ENV['CONVERTKIT_API_PRODUCT_URL'],
+			text: 'Buy my product'
+		);
 	}
 
 	/**
@@ -204,24 +232,31 @@ class PageShortcodeProductCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Product: Shortcode: Valid Discount Code Param');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Product: Shortcode: Valid Discount Code Param'
+		);
 
 		// Add shortcode to Page, setting the Product setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Product',
-			[
+			shortcodeName: 'Kit Product',
+			shortcodeConfiguration: [
 				'product'       => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 				'discount_code' => [ 'input', $_ENV['CONVERTKIT_API_PRODUCT_DISCOUNT_CODE'] ],
 			],
-			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" discount_code="' . $_ENV['CONVERTKIT_API_PRODUCT_DISCOUNT_CODE'] . '" checkout="0" disable_modal_on_mobile="0"]'
+			expectedShortcodeOutput: '[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" discount_code="' . $_ENV['CONVERTKIT_API_PRODUCT_DISCOUNT_CODE'] . '" checkout="0" disable_modal_on_mobile="0"]'
 		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the Kit Product is displayed.
-		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
+		$I->seeProductOutput(
+			$I,
+			productURL: $_ENV['CONVERTKIT_API_PRODUCT_URL'],
+			text: 'Buy my product'
+		);
 
 		// Confirm the discount code has been applied.
 		$I->switchToIFrame('iframe[data-active]');
@@ -243,24 +278,31 @@ class PageShortcodeProductCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Product: Shortcode: Valid Discount Code Param');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Product: Shortcode: Valid Discount Code Param'
+		);
 
 		// Add shortcode to Page, setting the Product setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Product',
-			[
+			shortcodeName: 'Kit Product',
+			shortcodeConfiguration: [
 				'product'       => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 				'discount_code' => [ 'input', 'fake' ],
 			],
-			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" discount_code="fake" checkout="0" disable_modal_on_mobile="0"]'
+			expectedShortcodeOutput: '[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" discount_code="fake" checkout="0" disable_modal_on_mobile="0"]'
 		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the Kit Product is displayed.
-		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
+		$I->seeProductOutput(
+			$I,
+			productURL: $_ENV['CONVERTKIT_API_PRODUCT_URL'],
+			text: 'Buy my product'
+		);
 
 		// Confirm the discount code is not valid, but the modal displays so the user can still purchase.
 		$I->switchToIFrame('iframe[data-active]');
@@ -283,24 +325,31 @@ class PageShortcodeProductCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Product: Shortcode: Checkout Step');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Product: Shortcode: Checkout Step'
+		);
 
 		// Add shortcode to Page, setting the Product setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Product',
-			[
+			shortcodeName: 'Kit Product',
+			shortcodeConfiguration: [
 				'product'  => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 				'checkout' => [ 'toggle', 'Yes' ],
 			],
-			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" checkout="1" disable_modal_on_mobile="0"]'
+			expectedShortcodeOutput: '[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" checkout="1" disable_modal_on_mobile="0"]'
 		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the Kit Product is displayed.
-		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
+		$I->seeProductOutput(
+			$I,
+			productURL: $_ENV['CONVERTKIT_API_PRODUCT_URL'],
+			text: 'Buy my product'
+		);
 
 		// Confirm the checkout step is displayed.
 		$I->switchToIFrame('iframe[data-active]');
@@ -323,17 +372,20 @@ class PageShortcodeProductCest
 		$I->setupKitPluginResources($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Product: Shortcode: Disable Modal on Mobile');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Product: Shortcode: Disable Modal on Mobile'
+		);
 
 		// Add shortcode to Page, setting the Product setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Product',
-			[
+			shortcodeName: 'Kit Product',
+			shortcodeConfiguration: [
 				'product'                 => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 				'disable_modal_on_mobile' => [ 'toggle', 'Yes' ],
 			],
-			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" checkout="0" disable_modal_on_mobile="1"]'
+			expectedShortcodeOutput: '[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" checkout="0" disable_modal_on_mobile="1"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -398,7 +450,13 @@ class PageShortcodeProductCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the Kit Product is displayed.
-		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product', $textColor, $backgroundColor);
+		$I->seeProductOutput(
+			$I,
+			productURL: $_ENV['CONVERTKIT_API_PRODUCT_URL'],
+			text: 'Buy my product',
+			textColor: $textColor,
+			backgroundColor: $backgroundColor
+		);
 	}
 
 	/**
@@ -437,7 +495,11 @@ class PageShortcodeProductCest
 		$I->dontSeeInSource('style="color:red" onmouseover="alert(1)""');
 
 		// Confirm that the Kit Product is displayed.
-		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
+		$I->seeProductOutput(
+			$I,
+			productURL: $_ENV['CONVERTKIT_API_PRODUCT_URL'],
+			text: 'Buy my product'
+		);
 	}
 
 	/**
@@ -451,12 +513,15 @@ class PageShortcodeProductCest
 	public function testProductShortcodeWhenNoCredentials(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Product: Shortcode: No API Key');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Product: Shortcode: No API Key'
+		);
 
 		// Open Visual Editor modal for the shortcode.
 		$I->openVisualEditorShortcodeModal(
 			$I,
-			'Kit Product'
+			shortcodeName:'Kit Product'
 		);
 
 		// Confirm an error notice displays.
@@ -509,12 +574,15 @@ class PageShortcodeProductCest
 		$I->setupKitPluginResourcesNoData($I);
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Product: Shortcode: No Products');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Product: Shortcode: No Products'
+		);
 
 		// Open Visual Editor modal for the shortcode.
 		$I->openVisualEditorShortcodeModal(
 			$I,
-			'Kit Product'
+			shortcodeName: 'Kit Product'
 		);
 
 		// Confirm an error notice displays.

--- a/tests/EndToEnd/restrict-content/general/RestrictContentCacheCest.php
+++ b/tests/EndToEnd/restrict-content/general/RestrictContentCacheCest.php
@@ -85,7 +85,11 @@ class RestrictContentCacheCest
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// to confirm caching does not show the incorrect content.
-		$I->setRestrictContentCookieAndReload($I, $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID'], $pageID);
+		$I->setRestrictContentCookieAndReload(
+			$I,
+			subscriberID: $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID'],
+			urlOrPageID: $pageID
+		);
 		$I->testRestrictContentDisplaysContent($I);
 
 		// Deactivate Litespeed Cache Plugin.
@@ -150,7 +154,11 @@ class RestrictContentCacheCest
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// to confirm caching does not show the incorrect content.
-		$I->setRestrictContentCookieAndReload($I, $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID'], $pageID);
+		$I->setRestrictContentCookieAndReload(
+			$I,
+			subscriberID: $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID'],
+			urlOrPageID: $pageID
+		);
 		$I->testRestrictContentDisplaysContent($I);
 
 		// Deactivate W3 Total Cache Plugin.
@@ -224,7 +232,11 @@ class RestrictContentCacheCest
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// to confirm caching does not show the incorrect content.
-		$I->setRestrictContentCookieAndReload($I, $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID'], $pageID);
+		$I->setRestrictContentCookieAndReload(
+			$I,
+			subscriberID: $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID'],
+			urlOrPageID: $pageID
+		);
 		$I->testRestrictContentDisplaysContent($I);
 
 		// Deactivate WP Fastest Cache Plugin.
@@ -289,7 +301,11 @@ class RestrictContentCacheCest
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// to confirm caching does not show the incorrect content.
-		$I->setRestrictContentCookieAndReload($I, $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID'], $pageID);
+		$I->setRestrictContentCookieAndReload(
+			$I,
+			subscriberID: $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID'],
+			urlOrPageID: $pageID
+		);
 		$I->testRestrictContentDisplaysContent($I);
 
 		// Deactivate WP-Optimize Cache Plugin.
@@ -354,7 +370,11 @@ class RestrictContentCacheCest
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// to confirm caching does not show the incorrect content.
-		$I->setRestrictContentCookieAndReload($I, $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID'], $pageID);
+		$I->setRestrictContentCookieAndReload(
+			$I,
+			subscriberID: $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID'],
+			urlOrPageID: $pageID
+		);
 		$I->testRestrictContentDisplaysContent($I);
 
 		// Deactivate WP Super Cache Plugin.
@@ -410,7 +430,11 @@ class RestrictContentCacheCest
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// to confirm caching does not show the incorrect content.
-		$I->setRestrictContentCookieAndReload($I, $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID'], $pageID);
+		$I->setRestrictContentCookieAndReload(
+			$I,
+			subscriberID: $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID'],
+			urlOrPageID: $pageID
+		);
 		$I->testRestrictContentDisplaysContent($I);
 
 		// Deactivate WP Super Cache Plugin.

--- a/tests/EndToEnd/restrict-content/general/RestrictContentFormCest.php
+++ b/tests/EndToEnd/restrict-content/general/RestrictContentFormCest.php
@@ -38,7 +38,10 @@ class RestrictContentFormCest
 		$I->setupKitPluginDisableJS($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Restrict Content: Form');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Restrict Content: Form'
+		);
 
 		// Configure metabox's Restrict Content setting = Form name.
 		$I->configureMetaboxSettings(
@@ -52,14 +55,22 @@ class RestrictContentFormCest
 
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
-		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'More',
+			blockProgrammaticName: 'more'
+		);
 		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Page.
 		$url = $I->publishGutenbergPage($I);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentByFormOnFrontend($I, $url, $_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->testRestrictedContentByFormOnFrontend(
+			$I,
+			urlOrPageID: $url,
+			formID: $_ENV['CONVERTKIT_API_FORM_ID']
+		);
 	}
 
 	/**
@@ -76,13 +87,16 @@ class RestrictContentFormCest
 		$I->setupKitPlugin($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Restrict Content: Form');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Restrict Content: Form'
+		);
 
 		// Configure metabox's Restrict Content setting = Form name.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration:[
 				'form'             => [ 'select2', 'None' ],
 				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
@@ -90,14 +104,22 @@ class RestrictContentFormCest
 
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
-		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'More',
+			blockProgrammaticName: 'more'
+		);
 		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Page.
 		$url = $I->publishGutenbergPage($I);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentByFormOnFrontendUsingLoginModal($I, $url, $_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->testRestrictedContentByFormOnFrontendUsingLoginModal(
+			$I,
+			urlOrPageID: $url,
+			formID: $_ENV['CONVERTKIT_API_FORM_ID']
+		);
 	}
 
 	/**
@@ -164,7 +186,11 @@ class RestrictContentFormCest
 		);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentByFormOnFrontend($I, $pageID, $_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->testRestrictedContentByFormOnFrontend(
+			$I,
+			urlOrPageID: $pageID,
+			formID: $_ENV['CONVERTKIT_API_FORM_ID']
+		);
 	}
 
 	/**
@@ -199,9 +225,9 @@ class RestrictContentFormCest
 		// Bulk Edit the Pages in the Pages WP_List_Table.
 		$I->bulkEdit(
 			$I,
-			'page',
-			$pageIDs,
-			[
+			postType: 'page',
+			postIDs: $pageIDs,
+			configuration: [
 				'restrict_content' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
@@ -209,7 +235,11 @@ class RestrictContentFormCest
 		// Iterate through Pages to run frontend tests.
 		foreach ($pageIDs as $pageID) {
 			// Test Restrict Content functionality.
-			$I->testRestrictedContentByFormOnFrontend($I, $pageID, $_ENV['CONVERTKIT_API_FORM_ID']);
+			$I->testRestrictedContentByFormOnFrontend(
+				$I,
+				urlOrPageID: $pageID,
+				formID: $_ENV['CONVERTKIT_API_FORM_ID']
+			);
 		}
 	}
 

--- a/tests/EndToEnd/restrict-content/general/RestrictContentSetupCest.php
+++ b/tests/EndToEnd/restrict-content/general/RestrictContentSetupCest.php
@@ -370,9 +370,9 @@ class RestrictContentSetupCest
 		// Test Restrict Content functionality.
 		$I->testRestrictedContentByTagOnFrontend(
 			$I,
-			$url,
-			$I->generateEmailAddress(),
-			[
+			urlOrPageID: $url,
+			emailAddress: $I->generateEmailAddress(),
+			options: [
 				'member_content' => 'The downloadable content (that is available when the visitor has paid for the Kit product) goes here.',
 			]
 		);
@@ -439,9 +439,9 @@ class RestrictContentSetupCest
 		// Test Restrict Content functionality.
 		$I->testRestrictedContentByTagOnFrontend(
 			$I,
-			$url,
-			$I->generateEmailAddress(),
-			[
+			urlOrPageID: $url,
+			emailAddress: $I->generateEmailAddress(),
+			options: [
 				'visible_content' => 'Some introductory text about lesson 1',
 				'member_content'  => 'Lesson 1 content (that is available when the visitor has paid for the Kit product) goes here.',
 			]

--- a/tests/EndToEnd/restrict-content/general/RestrictContentTagCest.php
+++ b/tests/EndToEnd/restrict-content/general/RestrictContentTagCest.php
@@ -38,13 +38,16 @@ class RestrictContentTagCest
 		$I->setupKitPluginDisableJS($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Restrict Content: Tag');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Restrict Content: Tag'
+		);
 
 		// Configure metabox's Restrict Content setting = Tag name.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form'             => [ 'select2', 'None' ],
 				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
 			]
@@ -52,14 +55,22 @@ class RestrictContentTagCest
 
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
-		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'More',
+			blockProgrammaticName: 'more'
+		);
 		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Page.
 		$url = $I->publishGutenbergPage($I);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentByTagOnFrontend($I, $url, $I->generateEmailAddress());
+		$I->testRestrictedContentByTagOnFrontend(
+			$I,
+			urlOrPageID: $url,
+			emailAddress: $I->generateEmailAddress()
+		);
 	}
 
 	/**
@@ -87,13 +98,16 @@ class RestrictContentTagCest
 		);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Restrict Content: Tag: Require Login');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Restrict Content: Tag: Require Login'
+		);
 
 		// Configure metabox's Restrict Content setting = Tag name.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form'             => [ 'select2', 'None' ],
 				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
 			]
@@ -101,14 +115,22 @@ class RestrictContentTagCest
 
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
-		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'More',
+			blockProgrammaticName: 'more'
+		);
 		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Page.
 		$url = $I->publishGutenbergPage($I);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentByTagOnFrontendWhenRequireLoginEnabled($I, $url, $I->generateEmailAddress());
+		$I->testRestrictedContentByTagOnFrontendWhenRequireLoginEnabled(
+			$I,
+			urlOrPageID: $url,
+			emailAddress: $I->generateEmailAddress()
+		);
 	}
 
 	/**
@@ -142,13 +164,16 @@ class RestrictContentTagCest
 		$I->setupKitPluginRestrictContent($I, $options['settings']);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Restrict Content: Tag: Recaptcha and Require Login');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Restrict Content: Tag: Recaptcha and Require Login'
+		);
 
 		// Configure metabox's Restrict Content setting = Tag name.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form'             => [ 'select2', 'None' ],
 				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
 			]
@@ -156,14 +181,23 @@ class RestrictContentTagCest
 
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
-		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'More',
+			blockProgrammaticName: 'more'
+		);
 		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Page.
 		$url = $I->publishGutenbergPage($I);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentByTagOnFrontendWhenRequireLoginEnabled($I, $url, $I->generateEmailAddress(), $options);
+		$I->testRestrictedContentByTagOnFrontendWhenRequireLoginEnabled(
+			$I,
+			urlOrPageID: $url,
+			emailAddress: $I->generateEmailAddress(),
+			options: $options
+		);
 	}
 
 	/**
@@ -194,13 +228,16 @@ class RestrictContentTagCest
 		$I->setupKitPluginRestrictContent($I, $options['settings']);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Restrict Content: Tag: Login Modal');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Restrict Content: Tag: Login Modal'
+		);
 
 		// Configure metabox's Restrict Content setting = Tag name.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form'             => [ 'select2', 'None' ],
 				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
 			]
@@ -208,14 +245,22 @@ class RestrictContentTagCest
 
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
-		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'More',
+			blockProgrammaticName: 'more'
+		);
 		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Page.
 		$url = $I->publishGutenbergPage($I);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentByTagOnFrontendUsingLoginModal($I, $url, $options);
+		$I->testRestrictedContentByTagOnFrontendUsingLoginModal(
+			$I,
+			urlOrPageID: $url,
+			options: $options
+		);
 	}
 
 	/**
@@ -276,13 +321,16 @@ class RestrictContentTagCest
 		$I->setupKitPluginRestrictContent($I, $options);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Restrict Content: Tag: reCAPTCHA');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Restrict Content: Tag: reCAPTCHA'
+		);
 
 		// Configure metabox's Restrict Content setting = Tag name.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form'             => [ 'select2', 'None' ],
 				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
 			]
@@ -290,14 +338,23 @@ class RestrictContentTagCest
 
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
-		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'More',
+			blockProgrammaticName: 'more'
+		);
 		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Page.
 		$url = $I->publishGutenbergPage($I);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentByTagOnFrontend($I, $url, $I->generateEmailAddress(), $options['settings']);
+		$I->testRestrictedContentByTagOnFrontend(
+			$I,
+			urlOrPageID: $url,
+			emailAddress: $I->generateEmailAddress(),
+			options: $options
+		);
 	}
 
 	/**
@@ -324,13 +381,16 @@ class RestrictContentTagCest
 		);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Restrict Content: Tag: reCAPTCHA High Min Score');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Restrict Content: Tag: reCAPTCHA High Min Score'
+		);
 
 		// Configure metabox's Restrict Content setting = Tag name.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form'             => [ 'select2', 'None' ],
 				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
 			]
@@ -338,7 +398,11 @@ class RestrictContentTagCest
 
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
-		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'More',
+			blockProgrammaticName: 'more'
+		);
 		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Page.
@@ -383,15 +447,19 @@ class RestrictContentTagCest
 		// Quick Edit the Page in the Pages WP_List_Table.
 		$I->quickEdit(
 			$I,
-			'page',
-			$pageID,
-			[
+			postType: 'page',
+			postID: $pageID,
+			configuration: [
 				'restrict_content' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
 			]
 		);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentByTagOnFrontend($I, $pageID, $I->generateEmailAddress());
+		$I->testRestrictedContentByTagOnFrontend(
+			$I,
+			urlOrPageID: $pageID,
+			emailAddress: $I->generateEmailAddress()
+		);
 	}
 
 	/**
@@ -426,9 +494,9 @@ class RestrictContentTagCest
 		// Bulk Edit the Pages in the Pages WP_List_Table.
 		$I->bulkEdit(
 			$I,
-			'page',
-			$pageIDs,
-			[
+			postType: 'page',
+			postIDs: $pageIDs,
+			configuration: [
 				'restrict_content' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
 			]
 		);

--- a/tests/EndToEnd/restrict-content/post-types/RestrictContentProductCPTCest.php
+++ b/tests/EndToEnd/restrict-content/post-types/RestrictContentProductCPTCest.php
@@ -40,11 +40,19 @@ class RestrictContentProductCPTCest
 		$I->setupKitPluginDisableJS($I);
 
 		// Add the CPT using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'article', 'Kit: Article: Restrict Content: Product');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'article',
+			title: 'Kit: Article: Restrict Content: Product'
+		);
 
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
-		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'More',
+			blockProgrammaticName: 'more'
+		);
 		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Article.
@@ -70,7 +78,11 @@ class RestrictContentProductCPTCest
 		$I->setupKitPluginDisableJS($I);
 
 		// Add the CPT using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'private', 'Kit: Private: Restrict Content');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'private',
+			title: 'Kit: Private: Restrict Content'
+		);
 
 		// Check that the metabox is not displayed.
 		$I->dontSeeElementInDOM('#wp-convertkit-meta-box');
@@ -93,13 +105,17 @@ class RestrictContentProductCPTCest
 		$I->setupKitPluginDisableJS($I);
 
 		// Add the CPT using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'article', 'Kit: Article: Restrict Content: Product');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'article',
+			title: 'Kit: Article: Restrict Content: Product'
+		);
 
 		// Configure metabox's Restrict Content setting = Product name.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form'             => [ 'select2', 'None' ],
 				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			]
@@ -107,7 +123,11 @@ class RestrictContentProductCPTCest
 
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
-		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'More',
+			blockProgrammaticName: 'more'
+		);
 		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Article.
@@ -132,13 +152,17 @@ class RestrictContentProductCPTCest
 		$I->setupKitPluginDisableJS($I);
 
 		// Add a CPT using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'article', 'Kit: Article: Restrict Content: Product');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'article',
+			title: 'Kit: Article: Restrict Content: Product'
+		);
 
 		// Configure metabox's Restrict Content setting = Product name.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form'             => [ 'select2', 'None' ],
 				'tag'              => [ 'select2', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
 				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
@@ -147,7 +171,11 @@ class RestrictContentProductCPTCest
 
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
-		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'More',
+			blockProgrammaticName: 'more'
+		);
 		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Article.
@@ -176,13 +204,17 @@ class RestrictContentProductCPTCest
 		$memberOnlyContent = 'Member-only content';
 
 		// Add the CPT using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'article', 'Kit: Article: Restrict Content: Product: Generated Excerpt');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'article',
+			title: 'Kit: Article: Restrict Content: Product: Generated Excerpt'
+		);
 
 		// Configure metabox's Restrict Content setting = Product name.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form'             => [ 'select2', 'None' ],
 				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			]
@@ -198,8 +230,8 @@ class RestrictContentProductCPTCest
 		// Test Restrict Content functionality.
 		$I->testRestrictedContentByProductOnFrontend(
 			$I,
-			$url,
-			[
+			urlOrPageID: $url,
+			options: [
 				'visible_content' => $visibleContent,
 				'member_content'  => $memberOnlyContent,
 			]
@@ -221,13 +253,17 @@ class RestrictContentProductCPTCest
 		$I->setupKitPlugin($I);
 
 		// Add the CPT using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'article', 'Kit: Article: Restrict Content: Product: Modal');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'article',
+			title: 'Kit: Article: Restrict Content: Product: Modal'
+		);
 
 		// Configure metabox's Restrict Content setting = Product name.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form'             => [ 'select2', 'None' ],
 				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			]
@@ -235,7 +271,11 @@ class RestrictContentProductCPTCest
 
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
-		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'More',
+			blockProgrammaticName: 'more'
+		);
 		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Article.
@@ -303,9 +343,9 @@ class RestrictContentProductCPTCest
 		// Quick Edit the CPT in the CPTs WP_List_Table.
 		$I->quickEdit(
 			$I,
-			'article',
-			$postID,
-			[
+			postType: 'article',
+			postID: $postID,
+			configuration: [
 				'restrict_content' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			]
 		);
@@ -348,9 +388,9 @@ class RestrictContentProductCPTCest
 		// Bulk Edit the CPTs in the CPTs WP_List_Table.
 		$I->bulkEdit(
 			$I,
-			'article',
-			$postIDs,
-			[
+			postType: 'article',
+			postIDs: $postIDs,
+			configuration: [
 				'restrict_content' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			]
 		);

--- a/tests/EndToEnd/restrict-content/post-types/RestrictContentProductPageCest.php
+++ b/tests/EndToEnd/restrict-content/post-types/RestrictContentProductPageCest.php
@@ -37,11 +37,18 @@ class RestrictContentProductPageCest
 		$I->setupKitPluginDisableJS($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Restrict Content: Product');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Restrict Content: Product'
+		);
 
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
-		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'More',
+			blockProgrammaticName: 'more'
+		);
 		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Page.
@@ -67,13 +74,16 @@ class RestrictContentProductPageCest
 		$I->setupKitPluginDisableJS($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Restrict Content: Product');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Restrict Content: Product'
+		);
 
 		// Configure metabox's Restrict Content setting = Product name.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form'             => [ 'select2', 'None' ],
 				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			]
@@ -81,7 +91,11 @@ class RestrictContentProductPageCest
 
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
-		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'More',
+			blockProgrammaticName: 'more'
+		);
 		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Page.
@@ -106,13 +120,16 @@ class RestrictContentProductPageCest
 		$I->setupKitPluginDisableJS($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Restrict Content: Product');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Restrict Content: Product'
+		);
 
 		// Configure metabox's Restrict Content setting = Product name.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form'             => [ 'select2', 'None' ],
 				'tag'              => [ 'select2', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
 				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
@@ -121,7 +138,11 @@ class RestrictContentProductPageCest
 
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
-		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'More',
+			blockProgrammaticName: 'more'
+		);
 		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Page.
@@ -150,13 +171,16 @@ class RestrictContentProductPageCest
 		$memberOnlyContent = 'Member-only content';
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Restrict Content: Product: Generated Excerpt');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Restrict Content: Product: Generated Excerpt'
+		);
 
 		// Configure metabox's Restrict Content setting = Product name.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form'             => [ 'select2', 'None' ],
 				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			]
@@ -172,8 +196,8 @@ class RestrictContentProductPageCest
 		// Test Restrict Content functionality.
 		$I->testRestrictedContentByProductOnFrontend(
 			$I,
-			$url,
-			[
+			urlOrPageID: $url,
+			options: [
 				'visible_content' => $visibleContent,
 				'member_content'  => $memberOnlyContent,
 			]
@@ -195,13 +219,16 @@ class RestrictContentProductPageCest
 		$I->setupKitPlugin($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Restrict Content: Product: Modal');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Restrict Content: Product: Modal'
+		);
 
 		// Configure metabox's Restrict Content setting = Product name.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form'             => [ 'select2', 'None' ],
 				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			]
@@ -209,7 +236,11 @@ class RestrictContentProductPageCest
 
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
-		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'More',
+			blockProgrammaticName: 'more'
+		);
 		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Page.
@@ -276,13 +307,16 @@ class RestrictContentProductPageCest
 		$I->activateThirdPartyPlugin($I, 'beaver-builder-lite-version');
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Restrict Content: Beaver Builder');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Restrict Content: Beaver Builder'
+		);
 
 		// Configure metabox's Restrict Content setting = Product name.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form'             => [ 'select2', 'None' ],
 				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			]
@@ -338,13 +372,16 @@ class RestrictContentProductPageCest
 		);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Restrict Content: Product: Search Engines');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Restrict Content: Product: Search Engines'
+		);
 
 		// Configure metabox's Restrict Content setting = Product name.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form'             => [ 'select2', 'None' ],
 				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			]
@@ -352,7 +389,11 @@ class RestrictContentProductPageCest
 
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
-		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'More',
+			blockProgrammaticName: 'more'
+		);
 		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Page.
@@ -389,9 +430,9 @@ class RestrictContentProductPageCest
 		// Quick Edit the Page in the Pages WP_List_Table.
 		$I->quickEdit(
 			$I,
-			'page',
-			$pageID,
-			[
+			postType: 'page',
+			postID: $pageID,
+			configuration: [
 				'restrict_content' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			]
 		);
@@ -432,9 +473,9 @@ class RestrictContentProductPageCest
 		// Bulk Edit the Pages in the Pages WP_List_Table.
 		$I->bulkEdit(
 			$I,
-			'page',
-			$pageIDs,
-			[
+			postType: 'page',
+			postIDs: $pageIDs,
+			configuration: [
 				'restrict_content' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			]
 		);

--- a/tests/EndToEnd/restrict-content/post-types/RestrictContentProductPostCest.php
+++ b/tests/EndToEnd/restrict-content/post-types/RestrictContentProductPostCest.php
@@ -37,11 +37,19 @@ class RestrictContentProductPostCest
 		$I->setupKitPluginDisableJS($I);
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Restrict Content: Product');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'post',
+			title: 'Kit: Post: Restrict Content: Product'
+		);
 
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
-		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'More',
+			blockProgrammaticName: 'more'
+		);
 		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Post.
@@ -67,13 +75,17 @@ class RestrictContentProductPostCest
 		$I->setupKitPluginDisableJS($I);
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Restrict Content: Product');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'post',
+			title: 'Kit: Post: Restrict Content: Product'
+		);
 
 		// Configure metabox's Restrict Content setting = Product name.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form'             => [ 'select2', 'None' ],
 				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			]
@@ -81,7 +93,11 @@ class RestrictContentProductPostCest
 
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
-		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'More',
+			blockProgrammaticName: 'more'
+		);
 		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Post.
@@ -106,13 +122,17 @@ class RestrictContentProductPostCest
 		$I->setupKitPluginDisableJS($I);
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Restrict Content: Product');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'post',
+			title: 'Kit: Post: Restrict Content: Product'
+		);
 
 		// Configure metabox's Restrict Content setting = Product name.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form'             => [ 'select2', 'None' ],
 				'tag'              => [ 'select2', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
 				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
@@ -121,7 +141,11 @@ class RestrictContentProductPostCest
 
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
-		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'More',
+			blockProgrammaticName: 'more'
+		);
 		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Post.
@@ -150,13 +174,17 @@ class RestrictContentProductPostCest
 		$memberOnlyContent = 'Member-only content';
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Restrict Content: Product: Generated Excerpt');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'post',
+			title: 'Kit: Post: Restrict Content: Product: Generated Excerpt'
+		);
 
 		// Configure metabox's Restrict Content setting = Product name.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form'             => [ 'select2', 'None' ],
 				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			]
@@ -172,8 +200,8 @@ class RestrictContentProductPostCest
 		// Test Restrict Content functionality.
 		$I->testRestrictedContentByProductOnFrontend(
 			$I,
-			$url,
-			[
+			urlOrPageID: $url,
+			options: [
 				'visible_content' => $visibleContent,
 				'member_content'  => $memberOnlyContent,
 			]
@@ -201,13 +229,17 @@ class RestrictContentProductPostCest
 		];
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Restrict Content: Product: Defined Excerpt');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'post',
+			title: 'Kit: Post: Restrict Content: Product: Defined Excerpt'
+		);
 
 		// Configure metabox's Restrict Content setting = Product name.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form'             => [ 'select2', 'None' ],
 				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			]
@@ -258,13 +290,17 @@ class RestrictContentProductPostCest
 		$I->setupKitPlugin($I);
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Restrict Content: Product: Modal');
+		$I->addGutenbergPage(
+			$I,
+			postType: 'post',
+			title: 'Kit: Post: Restrict Content: Product: Modal'
+		);
 
 		// Configure metabox's Restrict Content setting = Product name.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'form'             => [ 'select2', 'None' ],
 				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			]
@@ -272,7 +308,11 @@ class RestrictContentProductPostCest
 
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
-		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'More',
+			blockProgrammaticName: 'more'
+		);
 		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Post.
@@ -340,9 +380,9 @@ class RestrictContentProductPostCest
 		// Quick Edit the Post in the Posts WP_List_Table.
 		$I->quickEdit(
 			$I,
-			'post',
-			$postID,
-			[
+			postType: 'post',
+			postID: $postID,
+			configuration: [
 				'restrict_content' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			]
 		);
@@ -385,9 +425,9 @@ class RestrictContentProductPostCest
 		// Bulk Edit the Posts in the Posts WP_List_Table.
 		$I->bulkEdit(
 			$I,
-			'post',
-			$postIDs,
-			[
+			postType: 'post',
+			postIDs: $postIDs,
+			configuration: [
 				'restrict_content' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			]
 		);

--- a/tests/EndToEnd/restrict-content/post-types/RestrictContentProductThirdPartyThemeOrPageBuilderCest.php
+++ b/tests/EndToEnd/restrict-content/post-types/RestrictContentProductThirdPartyThemeOrPageBuilderCest.php
@@ -71,8 +71,8 @@ class RestrictContentProductThirdPartyThemeOrPageBuilderCest
 		// Test Restrict Content functionality.
 		$I->testRestrictedContentByProductOnFrontend(
 			$I,
-			$pageID,
-			[
+			urlOrPageID: $pageID,
+			options: [
 				'visible_content' => '',
 				'member_content'  => 'Member-only content.',
 			]
@@ -127,8 +127,8 @@ class RestrictContentProductThirdPartyThemeOrPageBuilderCest
 		// Test Restrict Content functionality.
 		$I->testRestrictedContentByProductOnFrontend(
 			$I,
-			$pageID,
-			[
+			urlOrPageID: $pageID,
+			options: [
 				'visible_content' => '',
 				'member_content'  => 'Member-only content.',
 			]

--- a/tests/EndToEnd/tags/PageShortcodeCustomContentCest.php
+++ b/tests/EndToEnd/tags/PageShortcodeCustomContentCest.php
@@ -37,16 +37,19 @@ class PageShortcodeCustomContentCest
 	public function testCustomContentShortcodeInVisualEditor(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Custom Content: Shortcode: Visual Editor');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Custom Content: Shortcode: Visual Editor'
+		);
 
 		// Add shortcode to Page, setting the Tag setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
-			'Kit Custom Content',
-			[
+			shortcodeName: 'Kit Custom Content',
+			shortcodeConfiguration: [
 				'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
 			],
-			'[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"][/convertkit_content]'
+			expectedShortcodeOutput: '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"][/convertkit_content]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -63,16 +66,19 @@ class PageShortcodeCustomContentCest
 	public function testCustomContentShortcodeInTextEditor(EndToEndTester $I)
 	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'Kit: Page: Custom Content: Shortcode: Text Editor');
+		$I->addClassicEditorPage(
+			$I,
+			title: 'Kit: Page: Custom Content: Shortcode: Text Editor'
+		);
 
 		// Add shortcode to Page, setting the Tag setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
-			'convertkit-content',
-			[
+			shortcodeProgrammaticName: 'convertkit-content',
+			shortcodeConfiguration: [
 				'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
 			],
-			'[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"][/convertkit_content]'
+			expectedShortcodeOutput: '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"][/convertkit_content]'
 		);
 
 		// Publish and view the Page on the frontend site.

--- a/tests/EndToEnd/tags/PageTagCest.php
+++ b/tests/EndToEnd/tags/PageTagCest.php
@@ -47,13 +47,16 @@ class PageTagCest
 		$subscriberID = $I->apiSubscribe($emailAddress, $_ENV['CONVERTKIT_API_FORM_ID']);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Tag: None');
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Tag: None'
+		);
 
 		// Check the order of the Tag resources are alphabetical, with the None option prepending the Tags.
 		$I->checkSelectTagOptionOrder(
 			$I,
-			'#wp-convertkit-tag',
-			[
+			selectElement: '#wp-convertkit-tag',
+			prependOptions:[
 				'None',
 			]
 		);
@@ -61,8 +64,8 @@ class PageTagCest
 		// Configure metabox's Tag setting = None.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'tag' => [ 'select2', 'None' ],
 			]
 		);
@@ -77,7 +80,7 @@ class PageTagCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check that the subscriber has not been assigned to the tag.
-		$I->apiCheckSubscriberHasNoTags($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasNoTags($I, $subscriberID);
 	}
 
 	/**
@@ -99,13 +102,16 @@ class PageTagCest
 		$subscriberID = $I->apiSubscribe($emailAddress, $_ENV['CONVERTKIT_API_FORM_ID']);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] );
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME']
+		);
 
 		// Configure metabox's Tag setting to the value specified in the .env file.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'tag' => [ 'select2', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
 			]
 		);
@@ -120,7 +126,11 @@ class PageTagCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check that the subscriber has been assigned to the tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag(
+			$I,
+			subscriberID: $subscriberID,
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
 	}
 
 	/**
@@ -135,13 +145,16 @@ class PageTagCest
 	public function testAddNewPageUsingDefinedTagWithInvalidSubscriberID(EndToEndTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Invalid Subscriber ID' );
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Invalid Subscriber ID'
+		);
 
 		// Configure metabox's Tag setting to the value specified in the .env file.
 		$I->configureMetaboxSettings(
 			$I,
-			'wp-convertkit-meta-box',
-			[
+			metabox: 'wp-convertkit-meta-box',
+			configuration: [
 				'tag' => [ 'select2', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
 			]
 		);
@@ -184,9 +197,9 @@ class PageTagCest
 		// Quick Edit the Page in the Pages WP_List_Table.
 		$I->quickEdit(
 			$I,
-			'page',
-			$pageID,
-			[
+			postType: 'page',
+			postID: $pageID,
+			configuration: [
 				'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
 			]
 		);
@@ -198,7 +211,11 @@ class PageTagCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check that the subscriber has been assigned to the tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag(
+			$I,
+			subscriberID: $subscriberID,
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
 	}
 
 	/**
@@ -230,9 +247,9 @@ class PageTagCest
 		// Bulk Edit the Pages in the Pages WP_List_Table.
 		$I->bulkEdit(
 			$I,
-			'page',
-			$pageIDs,
-			[
+			postType: 'page',
+			postIDs: $pageIDs,
+			configuration: [
 				'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
 			]
 		);
@@ -300,9 +317,9 @@ class PageTagCest
 		// Bulk Edit the Pages in the Pages WP_List_Table.
 		$I->bulkEdit(
 			$I,
-			'page',
-			$pageIDs,
-			[
+			postType: 'page',
+			postIDs: $pageIDs,
+			configuration: [
 				'tag' => [ 'select', '— No Change —' ],
 			]
 		);
@@ -323,7 +340,11 @@ class PageTagCest
 			$I->checkNoWarningsAndNoticesOnScreen($I);
 
 			// Check that the subscriber has been assigned to the tag.
-			$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
+			$I->apiCheckSubscriberHasTag(
+				$I,
+				subscriberID: $subscriberID,
+				tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+			);
 		}
 	}
 


### PR DESCRIPTION
## Summary

Continues adding named arguments to tests, based on https://github.com/Kit/convertkit-wordpress/pull/825 and https://github.com/Kit/convertkit-wordpress/pull/826

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)