### PR TITLE
Update Deployment Guide

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -8,9 +8,13 @@ Merge the approved Pull Request(s) to the `main` branch.
 
 An *approved* Pull Request is when a PR passes all tests **and** has been approved by **one or more** reviewers.
 
+## Create a Branch
+
+In your Git client / command line, create a new branch called `release-x.x.x`, where `x.x.x` is the version number.
+
 ## Generate Localization File and Action/Filter Documentation
 
-On your local machine, switch to the `main` branch.
+On your local machine, switch to the new release branch.
 
 Run the `.scripts/build.sh` script, which will:
 
@@ -38,7 +42,7 @@ Provide meaningful, verbose updates to the Changelog, in the following format:
 Generic changelog items such as `Fix: Various bugfixes` or `Several edge-case bug fixes` should be avoided.  They don't tell users (or us, as developers)
 what took place in this version.
 
-Each line in the changelog should start with `Added` or `Fix`.
+Each line in the changelog should start with `Added`, `Fix` or `Updated`.
 
 ## Commit Changes
 
@@ -49,17 +53,28 @@ Commit the updated files, which should comprise of:
 - `wp-convertkit.php`
 - `ACTIONS-FILTERS.md`
 
-## Create a New Release
+## Submit Release
 
-[Create a New Release](https://github.com/ConvertKit/convertkit-wordpress/releases/new), completing the following:
+Once your test(s) are written and successfully run locally, submit your branch via a new [Pull Request](https://github.com/ConvertKit/convertkit-wordpress/compare).
+
+It's best to create a Pull Request in draft mode, as this will trigger all tests to run as a GitHub Action, allowing you to
+double check all tests pass.
+
+If the PR tests fail, you can make code changes as necessary, pushing to the same branch.  This will trigger the tests to run again.
+
+If the PR tests pass, you can publish the PR, assigning some reviewers.
+
+## Publish Release
+
+Once the release branch is approved, merge it in to the `main` branch.
+
+Then navigate to [Create a New Release](https://github.com/ConvertKit/convertkit-wordpress/releases/new), completing the following:
 
 - Choose a tag: Click this button and enter the new version number (e.g. `1.9.6`)
 - Release title: The version number (e.g. `1.9.6`)
 - Describe this release: The changelog entered in the `readme.txt` file for this new version:
 
 ![New Release Screen](/.github/docs/new-release.png?raw=true)
-
-## Publish the Release
 
 When you're happy with the above, click `Publish Release`.
 


### PR DESCRIPTION
## Summary

`main` branch protection is now enabled, therefore bumping the Plugin version number and updating `readme.txt` must be submitted as a PR, rather than directly to the `main` branch.

This PR updates instructions to reflect the above when creating a new release. 

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)