### PR TITLE
Restrict Content: Setup Wizard: Add option to specify form

### DIFF
--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
@@ -42,6 +42,15 @@ class ConvertKit_Admin_Setup_Wizard_Restrict_Content extends ConvertKit_Admin_Se
 	public $type_label = '';
 
 	/**
+	 * Holds the ConvertKit Forms resource class.
+	 *
+	 * @since   2.8.3
+	 *
+	 * @var     bool|ConvertKit_Resource_Forms
+	 */
+	public $forms = false;
+
+	/**
 	 * Holds the ConvertKit Products resource class.
 	 *
 	 * @since   2.1.0
@@ -260,18 +269,20 @@ class ConvertKit_Admin_Setup_Wizard_Restrict_Content extends ConvertKit_Admin_Se
 		// Load data depending on the current step.
 		switch ( $step ) {
 			case 1:
-				// Fetch Products and Tags.
+				// Fetch Forms, Products and Tags.
+				$this->forms    = new ConvertKit_Resource_Forms( 'restrict_content_wizard' );
 				$this->products = new ConvertKit_Resource_Products( 'restrict_content_wizard' );
 				$this->tags     = new ConvertKit_Resource_Tags( 'restrict_content_wizard' );
 
-				// Refresh Products and Tags resources, in case the user just created their first Product or Tag
+				// Refresh Forms, Products and Tags resources, in case the user just created their first Form, Product or Tag
 				// in ConvertKit.
+				$this->forms->refresh();
 				$this->products->refresh();
 				$this->tags->refresh();
 
-				// If no Products and Tags exist in ConvertKit, change the next button label and make it a link to reload
+				// If no Forms, Products and Tags exist in ConvertKit, change the next button label and make it a link to reload
 				// the screen.
-				if ( ! $this->products->exist() && ! $this->tags->exist() ) {
+				if ( ! $this->forms->exist() && ! $this->products->exist() && ! $this->tags->exist() ) {
 					unset( $this->steps[1]['next_button'] );
 					$this->current_url = add_query_arg(
 						array(
@@ -315,7 +326,8 @@ class ConvertKit_Admin_Setup_Wizard_Restrict_Content extends ConvertKit_Admin_Se
 						break;
 				}
 
-				// Fetch Products and Tags.
+				// Fetch Forms, Products and Tags.
+				$this->forms    = new ConvertKit_Resource_Forms( 'restrict_content_wizard' );
 				$this->products = new ConvertKit_Resource_Products( 'restrict_content_wizard' );
 				$this->tags     = new ConvertKit_Resource_Tags( 'restrict_content_wizard' );
 				break;

--- a/tests/EndToEnd/restrict-content/general/RestrictContentSetupCest.php
+++ b/tests/EndToEnd/restrict-content/general/RestrictContentSetupCest.php
@@ -474,6 +474,150 @@ class RestrictContentSetupCest
 	}
 
 	/**
+	 * Test that the Add New Member Content > Downloads generates the expected Page
+	 * and restricts content by the selected Form.
+	 *
+	 * @since   2.8.3
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testAddNewMemberContentDownloadsByForm(EndToEndTester $I)
+	{
+		// Setup Plugin and navigate to Add New Member Content screen.
+		$this->_setupAndLoadAddNewMemberContentScreen($I);
+
+		// Click Downloads button.
+		$I->click('Download');
+
+		// Confirm the Configure Download screen is displayed.
+		$I->see('Configure Download');
+
+		// Enter a title and description.
+		$I->fillField('title', 'Kit: Member Content: Download: Form');
+		$I->fillField('description', 'Visible content.');
+
+		// Confirm that the limit option is not visible, as this is only for courses.
+		$I->dontSee('How many lessons does this course consist of?');
+
+		// Restrict by Form.
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-restrict_content-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+
+		// Click submit button.
+		$I->click('Submit');
+
+		// Wait for the WP_List_Table of Pages to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Confirm that one Page is listed in the WP_List_Table.
+		$I->see('Kit: Member Content: Download: Form');
+		$I->seeInSource('<span class="post-state">Kit Member Content</span>');
+
+		// Hover mouse over Post's table row.
+		$I->moveMouseOver('tr.iedit');
+
+		// Get link to Page.
+		$url = $I->grabAttributeFrom('tr.iedit span.view a', 'href');
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentByFormOnFrontend(
+			$I,
+			urlOrPageID: $url,
+			formID: $_ENV['CONVERTKIT_API_FORM_ID']
+		);
+	}
+
+	/**
+	 * Test that the Add New Member Content > Course generates the expected Pages
+	 * and restricts content by the selected Form.
+	 *
+	 * @since   2.8.3
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testAddNewMemberContentCourseByForm(EndToEndTester $I)
+	{
+		// Setup Plugin and navigate to Add New Member Content screen.
+		$this->_setupAndLoadAddNewMemberContentScreen($I);
+
+		// Click Course button.
+		$I->click('Course');
+
+		// Confirm the Configure Course screen is displayed.
+		$I->see('Configure Course');
+
+		// Enter a title, description and lesson count.
+		$I->fillField('title', 'Kit: Member Content: Course: Form');
+		$I->fillField('description', 'Visible content.');
+		$I->fillField('number_of_pages', '3');
+
+		// Restrict by Product.
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-restrict_content-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+
+		// Click submit button.
+		$I->click('Submit');
+
+		// Wait for the WP_List_Table of Pages to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Confirm that four Pages are listed in the WP_List_Table.
+		$I->see('Kit: Member Content: Course: Form');
+		$I->see('— Kit: Member Content: Course: Form: 1/3');
+		$I->see('— Kit: Member Content: Course: Form: 2/3');
+		$I->see('— Kit: Member Content: Course: Form: 3/3');
+		$I->see('Kit Member Content | Parent Page: Kit: Member Content: Course: Form');
+
+		// Hover mouse over Post's table row.
+		$I->moveMouseOver('tr.iedit:first-child');
+
+		// Wait for View link to be visible.
+		$I->waitForElementVisible('tr.iedit:first-child span.view a');
+
+		// Click View link.
+		$I->click('tr.iedit:first-child span.view a');
+
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible('body.page-template-default');
+
+		// Confirm the Start Course button exists.
+		$I->see('Start Course');
+
+		// Get URL to first restricted content page.
+		$url = $I->grabAttributeFrom('.wp-block-button a', 'href');
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentByFormOnFrontend(
+			$I,
+			urlOrPageID: $url,
+			formID: $_ENV['CONVERTKIT_API_FORM_ID']
+		);
+
+		// Test Next / Previous links.
+		$I->click('Next Lesson');
+		$I->waitForElementVisible('body.page-template-default');
+		$I->see('Kit: Member Content: Course: Form: 2/3');
+		$I->see('Some introductory text about lesson 2');
+		$I->see('Lesson 2 content (that is available when the visitor has paid for the Kit product) goes here');
+
+		$I->click('Next Lesson');
+		$I->waitForElementVisible('body.page-template-default');
+		$I->see('Kit: Member Content: Course: Form: 3/3');
+		$I->see('Some introductory text about lesson 3');
+		$I->see('Lesson 3 content (that is available when the visitor has paid for the Kit product) goes here');
+
+		$I->click('Previous Lesson');
+		$I->waitForElementVisible('body.page-template-default');
+		$I->see('Kit: Member Content: Course: Form: 2/3');
+		$I->see('Some introductory text about lesson 2');
+		$I->see('Lesson 2 content (that is available when the visitor has paid for the Kit product) goes here');
+
+		$I->click('Previous Lesson');
+		$I->waitForElementVisible('body.page-template-default');
+		$I->see('Kit: Member Content: Course: Form: 1/3');
+		$I->see('Some introductory text about lesson 1');
+		$I->see('Lesson 1 content (that is available when the visitor has paid for the Kit product) goes here');
+	}
+
+	/**
 	 * Sets up the Kit Plugin, and starts the Setup Wizard for Member Content.
 	 *
 	 * @since   2.1.0

--- a/views/backend/setup-wizard/convertkit-restrict-content-setup/content-1.php
+++ b/views/backend/setup-wizard/convertkit-restrict-content-setup/content-1.php
@@ -71,7 +71,7 @@ if ( ! $this->products->exist() && ! $this->tags->exist() ) {
 				<?php esc_html_e( 'Download', 'convertkit' ); ?>
 			</a>
 			<span class="description">
-				<?php esc_html_e( 'Require visitors to purchase a Kit product, or subscribe to a Kit tag, granting access to a single Page\'s content, which includes downloadable assets.', 'convertkit' ); ?>
+				<?php esc_html_e( 'Require visitors to purchase a Kit product, or subscribe to a Kit tag or form, granting access to a single Page\'s content, which includes downloadable assets.', 'convertkit' ); ?>
 			</span>
 		</div>
 
@@ -80,7 +80,7 @@ if ( ! $this->products->exist() && ! $this->tags->exist() ) {
 				<?php esc_html_e( 'Course', 'convertkit' ); ?>
 			</a>
 			<span class="description">
-				<?php esc_html_e( 'Require visitors to purchase a Kit product, or subscribe to a Kit tag, granting access to a sequential series of Pages, such as a course, lessons or tutorials.', 'convertkit' ); ?>
+				<?php esc_html_e( 'Require visitors to purchase a Kit product, or subscribe to a Kit tag or form, granting access to a sequential series of Pages, such as a course, lessons or tutorials.', 'convertkit' ); ?>
 			</span>
 		</div>
 	</div>

--- a/views/backend/setup-wizard/convertkit-restrict-content-setup/content-2.php
+++ b/views/backend/setup-wizard/convertkit-restrict-content-setup/content-2.php
@@ -53,42 +53,64 @@ if ( $this->type === 'course' ) {
 
 <div>
 	<label for="wp-convertkit-restrict_content">
-		<?php esc_html_e( 'The Kit Product or Tag the visitor must subscribe to, in order to see the content', 'convertkit' ); ?>
+		<?php esc_html_e( 'The Kit Product, Tag or Form the visitor must subscribe to, in order to see the content', 'convertkit' ); ?>
 	</label>
 
 	<div class="convertkit-select2-container">
 		<select name="restrict_content" id="wp-convertkit-restrict_content" class="convertkit-select2 widefat">
-			<?php
-			// Tags.
-			if ( $this->tags->exist() ) {
+			<optgroup label="<?php esc_attr_e( 'Forms', 'convertkit' ); ?>" data-resource="forms">
+				<?php
+				// Forms.
+				if ( $this->forms->inline_exist() ) {
+					foreach ( $this->forms->get_inline() as $convertkit_form ) {
+						printf(
+							'<option value="form_%s">%s [%s]</option>',
+							esc_attr( $convertkit_form['id'] ),
+							esc_attr( $convertkit_form['name'] ),
+							( ! empty( $convertkit_form['format'] ) ? esc_attr( $convertkit_form['format'] ) : 'inline' )
+						);
+					}
+				}
 				?>
-				<optgroup label="<?php esc_attr_e( 'Tags', 'convertkit' ); ?>" data-resource="tags">
-					<?php
+			</optgroup>
+
+			<optgroup label="<?php esc_attr_e( 'Tags', 'convertkit' ); ?>" data-resource="tags">
+				<?php
+				// Tags.
+				if ( $this->tags->exist() ) {
 					foreach ( $this->tags->get() as $convertkit_tag ) {
 						?>
 						<option value="tag_<?php echo esc_attr( $convertkit_tag['id'] ); ?>"><?php echo esc_attr( $convertkit_tag['name'] ); ?></option>
 						<?php
 					}
-					?>
-				</optgroup>
-				<?php
-			}
-
-			// Products.
-			if ( $this->products->exist() ) {
+				}
 				?>
-				<optgroup label="<?php esc_attr_e( 'Products', 'convertkit' ); ?>" data-resource="products">
-					<?php
+			</optgroup>
+
+			<optgroup label="<?php esc_attr_e( 'Products', 'convertkit' ); ?>" data-resource="products">
+				<?php
+				// Products.
+				if ( $this->products->exist() ) {
 					foreach ( $this->products->get() as $product ) {
 						?>
 						<option value="product_<?php echo esc_attr( $product['id'] ); ?>"><?php echo esc_attr( $product['name'] ); ?></option>
 						<?php
 					}
-					?>
-				</optgroup>
-				<?php
-			}
-			?>
+				}
+				?>
+			</optgroup>
 		</select>
+		<p class="description">
+			<?php esc_html_e( 'Select the Kit form, tag or product that the visitor must be subscribed to, permitting them access to view this members only content.', 'convertkit' ); ?>
+			<br />
+			<code><?php esc_html_e( 'Form', 'convertkit' ); ?></code>
+			<?php esc_html_e( ': Displays the Kit form. On submission, the email address will be subscribed to the selected form, granting access to the members only content. Useful to gate free content in return for an email address.', 'convertkit' ); ?>
+			<br />
+			<code><?php esc_html_e( 'Tag', 'convertkit' ); ?></code>
+			<?php esc_html_e( ': Displays a WordPress styled subscription form. On submission, the email address will be subscribed to the selected tag, granting access to the members only content. Useful to gate free content in return for an email address.', 'convertkit' ); ?>
+			<br />
+			<code><?php esc_html_e( 'Product', 'convertkit' ); ?></code>
+			<?php esc_html_e( ': Displays a link to the Kit product, and a login form. Useful to gate content that can only be accessed by purchasing the Kit product.', 'convertkit' ); ?>
+		</p>
 	</div>
 </div>


### PR DESCRIPTION
## Summary

Support for gating content by subscribing to a Kit Form [was added in this PR](https://github.com/Kit/convertkit-wordpress/pull/771), but it wasn't included in the setup wizard.

This PR resolves by adding support for Kit Forms to the dropdown when using the setup wizard for gating content, and uses the same field description as used on the Post / Page meta box.

<img width="938" alt="Screenshot 2025-06-20 at 01 48 38" src="https://github.com/user-attachments/assets/3346600d-525c-477f-bae8-630ef6b5bb06" />

## Testing

- `testAddNewMemberContentDownloadsByForm`:  Test that the Add New Member Content > Downloads generates the expected Page and restricts content by the selected Form.
- `testAddNewMemberContentCourseByForm`: Test that the Add New Member Content > Course generates the expected Pages and restricts content by the selected Form.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)