### PR TITLE
Member Content: Replace “Members only” with “member-only”

### DIFF
--- a/tests/Support/Helper/KitRestrictContent.php
+++ b/tests/Support/Helper/KitRestrictContent.php
@@ -163,7 +163,7 @@ class KitRestrictContent extends \Codeception\Module
 				'post_type'    => $options['post_type'],
 				'post_title'   => $options['post_title'],
 
-				// Emulate Gutenberg content with visible and members only content sections.
+				// Emulate Gutenberg content with visible and member-only content sections.
 				'post_content' => '<!-- wp:paragraph --><p>' . $options['visible_content'] . '</p><!-- /wp:paragraph -->
 <!-- wp:more --><!--more--><!-- /wp:more -->
 <!-- wp:paragraph -->' . $options['member_content'] . '<!-- /wp:paragraph -->',

--- a/views/backend/post/bulk-edit.php
+++ b/views/backend/post/bulk-edit.php
@@ -80,7 +80,7 @@
 				// Therefore, we use -2 to denote 'No Change', even though this setting is for the Tag, so we're at least consistent.
 				?>
 				<option value="-2" data-preserve-on-refresh="1"><?php esc_html_e( '— No Change —', 'convertkit' ); ?></option>
-				<option value="0" data-preserve-on-refresh="1"><?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?></option>
+				<option value="0" data-preserve-on-refresh="1"><?php esc_html_e( 'Don\'t restrict content to member-only.', 'convertkit' ); ?></option>
 
 				<optgroup label="<?php esc_attr_e( 'Forms', 'convertkit' ); ?>" data-resource="forms">
 					<?php

--- a/views/backend/post/meta-box.php
+++ b/views/backend/post/meta-box.php
@@ -143,7 +143,7 @@
 			<td>
 				<div class="convertkit-select2-container convertkit-select2-container-grid">
 					<select name="wp-convertkit[restrict_content]" id="wp-convertkit-restrict_content" class="convertkit-select2">
-						<option value="0"<?php selected( '', $convertkit_post->get_restrict_content() ); ?> data-preserve-on-refresh="1"><?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?></option>
+						<option value="0"<?php selected( '', $convertkit_post->get_restrict_content() ); ?> data-preserve-on-refresh="1"><?php esc_html_e( 'Don\'t restrict content to member-only.', 'convertkit' ); ?></option>
 
 						<optgroup label="<?php esc_attr_e( 'Forms', 'convertkit' ); ?>" data-resource="forms">
 							<?php
@@ -192,13 +192,13 @@
 						<span class="dashicons dashicons-update"></span>
 					</button>
 					<p class="description">
-						<?php esc_html_e( 'Select the Kit form, tag or product that the visitor must be subscribed to, permitting them access to view this members only content.', 'convertkit' ); ?>
+						<?php esc_html_e( 'Select the Kit form, tag or product that the visitor must be subscribed to, permitting them access to view this member-only content.', 'convertkit' ); ?>
 						<br />
 						<code><?php esc_html_e( 'Form', 'convertkit' ); ?></code>
-						<?php esc_html_e( ': Displays the Kit form. On submission, the email address will be subscribed to the selected form, granting access to the members only content. Useful to gate free content in return for an email address.', 'convertkit' ); ?>
+						<?php esc_html_e( ': Displays the Kit form. On submission, the email address will be subscribed to the selected form, granting access to the member-only content. Useful to gate free content in return for an email address.', 'convertkit' ); ?>
 						<br />
 						<code><?php esc_html_e( 'Tag', 'convertkit' ); ?></code>
-						<?php esc_html_e( ': Displays a WordPress styled subscription form. On submission, the email address will be subscribed to the selected tag, granting access to the members only content. Useful to gate free content in return for an email address.', 'convertkit' ); ?>
+						<?php esc_html_e( ': Displays a WordPress styled subscription form. On submission, the email address will be subscribed to the selected tag, granting access to the member-only content. Useful to gate free content in return for an email address.', 'convertkit' ); ?>
 						<br />
 						<code><?php esc_html_e( 'Product', 'convertkit' ); ?></code>
 						<?php esc_html_e( ': Displays a link to the Kit product, and a login form. Useful to gate content that can only be accessed by purchasing the Kit product.', 'convertkit' ); ?>

--- a/views/backend/post/quick-edit.php
+++ b/views/backend/post/quick-edit.php
@@ -58,7 +58,7 @@
 		<label for="wp-convertkit-quick-edit-restrict_content">
 			<span class="title convertkit-icon-restrict-content"><?php esc_html_e( 'Member', 'convertkit' ); ?></span>
 			<select name="wp-convertkit[restrict_content]" id="wp-convertkit-quick-edit-restrict_content" size="1">
-				<option value="0" data-preserve-on-refresh="1"><?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?></option>
+				<option value="0" data-preserve-on-refresh="1"><?php esc_html_e( 'Don\'t restrict content to member-only.', 'convertkit' ); ?></option>
 
 				<optgroup label="<?php esc_attr_e( 'Forms', 'convertkit' ); ?>" data-resource="forms">
 					<?php

--- a/views/backend/setup-wizard/convertkit-restrict-content-setup/content-2.php
+++ b/views/backend/setup-wizard/convertkit-restrict-content-setup/content-2.php
@@ -101,13 +101,13 @@ if ( $this->type === 'course' ) {
 			</optgroup>
 		</select>
 		<p class="description">
-			<?php esc_html_e( 'Select the Kit form, tag or product that the visitor must be subscribed to, permitting them access to view this members only content.', 'convertkit' ); ?>
+			<?php esc_html_e( 'Select the Kit form, tag or product that the visitor must be subscribed to, permitting them access to view this member-only content.', 'convertkit' ); ?>
 			<br />
 			<code><?php esc_html_e( 'Form', 'convertkit' ); ?></code>
-			<?php esc_html_e( ': Displays the Kit form. On submission, the email address will be subscribed to the selected form, granting access to the members only content. Useful to gate free content in return for an email address.', 'convertkit' ); ?>
+			<?php esc_html_e( ': Displays the Kit form. On submission, the email address will be subscribed to the selected form, granting access to the member-only content. Useful to gate free content in return for an email address.', 'convertkit' ); ?>
 			<br />
 			<code><?php esc_html_e( 'Tag', 'convertkit' ); ?></code>
-			<?php esc_html_e( ': Displays a WordPress styled subscription form. On submission, the email address will be subscribed to the selected tag, granting access to the members only content. Useful to gate free content in return for an email address.', 'convertkit' ); ?>
+			<?php esc_html_e( ': Displays a WordPress styled subscription form. On submission, the email address will be subscribed to the selected tag, granting access to the member-only content. Useful to gate free content in return for an email address.', 'convertkit' ); ?>
 			<br />
 			<code><?php esc_html_e( 'Product', 'convertkit' ); ?></code>
 			<?php esc_html_e( ': Displays a link to the Kit product, and a login form. Useful to gate content that can only be accessed by purchasing the Kit product.', 'convertkit' ); ?>


### PR DESCRIPTION
## Summary

Replaces some errant `members only` strings with the correct `member-only` text, as raised [here](https://github.com/Kit/convertkit-wordpress/pull/833#discussion_r2162390559).

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)