### PR TITLE
Restrict Content: Filters: Add `All member-only content` option

### DIFF
--- a/tests/EndToEnd/restrict-content/general/RestrictContentFilterCPTCest.php
+++ b/tests/EndToEnd/restrict-content/general/RestrictContentFilterCPTCest.php
@@ -243,6 +243,93 @@ class RestrictContentFilterCPTCest
 	}
 
 	/**
+	 * Test that filtering by 'All member-only content' works on the CPT screen.
+	 *
+	 * @since   2.8.3
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFilterByAllMemberOnlyContent(EndToEndTester $I)
+	{
+		// Setup Plugin.
+		$I->setupKitPlugin($I);
+
+		// Create a mix of Posts restricted and not restricted to Forms, Tags and Products.
+		$I->createRestrictedContentPage(
+			$I,
+			[
+				'post_type'                => 'article',
+				'post_title'               => 'Kit: Article: Restricted Content: Form: Filter Test',
+				'restrict_content_setting' => 'form_' . $_ENV['CONVERTKIT_API_FORM_ID'],
+			]
+		);
+		$I->createRestrictedContentPage(
+			$I,
+			[
+				'post_type'                => 'article',
+				'post_title'               => 'Kit: Article: Restricted Content: Tag: Filter Test',
+				'restrict_content_setting' => 'tag_' . $_ENV['CONVERTKIT_API_TAG_ID'],
+			]
+		);
+		$I->createRestrictedContentPage(
+			$I,
+			[
+				'post_type'                => 'article',
+				'post_title'               => 'Kit: Article: Restricted Content: Product: Filter Test',
+				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+			]
+		);
+		$I->havePostInDatabase(
+			[
+				'post_type'  => 'article',
+				'post_title' => 'Kit: Article: Standard',
+				'meta_input' => [
+					'_wp_convertkit_post_meta' => [
+						'form'             => '0',
+						'landing_page'     => '',
+						'tag'              => '',
+						'restrict_content' => '0',
+					],
+				],
+			]
+		);
+		$I->havePostInDatabase(
+			[
+				'post_type'  => 'article',
+				'post_title' => 'Kit: Article: Standard: No Meta',
+			]
+		);
+
+		// Navigate to Articles.
+		$I->amOnAdminPage('edit.php?post_type=article');
+
+		// Wait for the WP_List_Table of Articles to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Filter by All member-only content.
+		$I->selectOption('#wp-convertkit-restrict-content-filter', 'All member-only content');
+		$I->click('Filter');
+
+		// Wait for the WP_List_Table of Articles to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Restrict Content Articles are listed.
+		$I->see('Kit: Article: Restricted Content: Form: Filter Test');
+		$I->see('Kit: Article: Restricted Content: Tag: Filter Test');
+		$I->see('Kit: Article: Restricted Content: Product: Filter Test');
+
+		// Confirm that no non-Restrict Content Posts are not listed.
+		$I->dontSee('Kit: Article: Standard');
+		$I->dontSee('Kit: Article: Standard: No Meta');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/EndToEnd/restrict-content/general/RestrictContentFilterPageCest.php
+++ b/tests/EndToEnd/restrict-content/general/RestrictContentFilterPageCest.php
@@ -165,7 +165,7 @@ class RestrictContentFilterPageCest
 	}
 
 	/**
-	 * Test that filtering by Form works on the Posts screen.
+	 * Test that filtering by Form works on the Pages screen.
 	 *
 	 * @since   2.7.3
 	 *
@@ -180,16 +180,16 @@ class RestrictContentFilterPageCest
 		$I->createRestrictedContentPage(
 			$I,
 			[
-				'post_type'                => 'post',
+				'post_type'                => 'page',
 				'post_title'               => 'Kit: Page: Restricted Content: Form: Filter Test',
 				'restrict_content_setting' => 'form_' . $_ENV['CONVERTKIT_API_FORM_ID'],
 			]
 		);
 
-		// Navigate to Posts.
-		$I->amOnAdminPage('edit.php?post_type=post');
+		// Navigate to Pages.
+		$I->amOnAdminPage('edit.php?post_type=page');
 
-		// Wait for the WP_List_Table of Posts to load.
+		// Wait for the WP_List_Table of Pages to load.
 		$I->waitForElementVisible('tbody#the-list');
 
 		// Check that no PHP warnings or notices were output.
@@ -203,7 +203,7 @@ class RestrictContentFilterPageCest
 		$I->selectOption('#wp-convertkit-restrict-content-filter', $_ENV['CONVERTKIT_API_FORM_NAME']);
 		$I->click('Filter');
 
-		// Wait for the WP_List_Table of Posts to load.
+		// Wait for the WP_List_Table of Pages to load.
 		$I->waitForElementVisible('tbody#the-list');
 
 		// Check that no PHP warnings or notices were output.
@@ -212,6 +212,93 @@ class RestrictContentFilterPageCest
 		// Confirm that the Page is still listed, and has the 'Kit Member Content' label.
 		$I->see('Kit: Page: Restricted Content: Form: Filter Test');
 		$I->see('Kit Member Content');
+	}
+
+	/**
+	 * Test that filtering by 'All member-only content' works on the Pages screen.
+	 *
+	 * @since   2.8.3
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFilterByAllMemberOnlyContent(EndToEndTester $I)
+	{
+		// Setup Plugin.
+		$I->setupKitPlugin($I);
+
+		// Create a mix of Pages restricted and not restricted to Forms, Tags and Products.
+		$I->createRestrictedContentPage(
+			$I,
+			[
+				'post_type'                => 'page',
+				'post_title'               => 'Kit: Page: Restricted Content: Form: Filter Test',
+				'restrict_content_setting' => 'form_' . $_ENV['CONVERTKIT_API_FORM_ID'],
+			]
+		);
+		$I->createRestrictedContentPage(
+			$I,
+			[
+				'post_type'                => 'page',
+				'post_title'               => 'Kit: Page: Restricted Content: Tag: Filter Test',
+				'restrict_content_setting' => 'tag_' . $_ENV['CONVERTKIT_API_TAG_ID'],
+			]
+		);
+		$I->createRestrictedContentPage(
+			$I,
+			[
+				'post_type'                => 'page',
+				'post_title'               => 'Kit: Page: Restricted Content: Product: Filter Test',
+				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+			]
+		);
+		$I->havePostInDatabase(
+			[
+				'post_type'  => 'page',
+				'post_title' => 'Kit: Page: Standard',
+				'meta_input' => [
+					'_wp_convertkit_post_meta' => [
+						'form'             => '0',
+						'landing_page'     => '',
+						'tag'              => '',
+						'restrict_content' => '0',
+					],
+				],
+			]
+		);
+		$I->havePostInDatabase(
+			[
+				'post_type'  => 'page',
+				'post_title' => 'Kit: Page: Standard: No Meta',
+			]
+		);
+
+		// Navigate to Pages.
+		$I->amOnAdminPage('edit.php?post_type=page');
+
+		// Wait for the WP_List_Table of Pages to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Filter by All member-only content.
+		$I->selectOption('#wp-convertkit-restrict-content-filter', 'All member-only content');
+		$I->click('Filter');
+
+		// Wait for the WP_List_Table of Pages to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Restrict Content Pages are listed.
+		$I->see('Kit: Page: Restricted Content: Form: Filter Test');
+		$I->see('Kit: Page: Restricted Content: Tag: Filter Test');
+		$I->see('Kit: Page: Restricted Content: Product: Filter Test');
+
+		// Confirm that no non-Restrict Content Pages are not listed.
+		$I->dontSee('Kit: Page: Standard');
+		$I->dontSee('Kit: Page: Standard: No Meta');
 	}
 
 	/**

--- a/views/backend/post/wp-list-table-filter.php
+++ b/views/backend/post/wp-list-table-filter.php
@@ -9,6 +9,7 @@
 ?>
 <select name="convertkit_restrict_content" id="wp-convertkit-restrict-content-filter">
 	<option value="0"><?php esc_html_e( 'All content', 'convertkit' ); ?></option>
+	<option value="all-member-only"<?php selected( $this->restrict_content_filter, 'all-member-only' ); ?>><?php esc_html_e( 'All member-only content', 'convertkit' ); ?></option>
 
 	<?php
 	// Forms.


### PR DESCRIPTION
## Summary

When working on [this issue](https://linear.app/kit/issue/WP-46/wordpress-med-subscribers-being-added-to-kit-via-wp-plugin) to find any content that has Member Content functionality enabled, it was difficult using the current filter on the WP_List_Table, as current filters only permit filtering by a specific Form, Tag or Product:

![Screenshot 2025-06-25 at 12 57 30](https://github.com/user-attachments/assets/398b703d-68d2-4c67-92e5-00a924507bf0)

This PR resolves by adding an `All member-only content` option to the filter dropdown.

![Screenshot 2025-06-25 at 14 03 04](https://github.com/user-attachments/assets/12a9399c-f991-416f-a405-9e19258424fe)

## Testing

- `RestrictContentFilterCPTCest:testFilterByAllMemberOnlyContent`: Test that filtering by 'All member-only content' works on the CPT screen.
- `RestrictContentFilterPageCest:testFilterByAllMemberOnlyContent`: Test that filtering by 'All member-only content' works on the Pages screen.
- `RestrictContentFiltePostCest:testFilterByAllMemberOnlyContent`: Test that filtering by 'All member-only content' works on the Posts screen.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)