### PR TITLE
OAuth: Automatically Refresh Token on Expiry

### DIFF
--- a/includes/class-convertkit-settings.php
+++ b/includes/class-convertkit-settings.php
@@ -46,6 +46,7 @@ class ConvertKit_Settings {
 		}
 
 		// Update Access Token when refreshed by the API class.
+		add_action( 'convertkit_api_get_access_token', array( $this, 'update_credentials' ), 10, 2 );
 		add_action( 'convertkit_api_refresh_token', array( $this, 'update_credentials' ), 10, 2 );
 
 	}
@@ -500,10 +501,10 @@ class ConvertKit_Settings {
 	}
 
 	/**
-	 * Saves the new access token, refresh token and its expiry when the API
-	 * class automatically refreshes an outdated access token.
+	 * Saves the new access token, refresh token and its expiry, and schedules
+	 * a WordPress Cron event to refresh the token on expiry.
 	 *
-	 * @since   2.5.0
+	 * @since   2.8.3
 	 *
 	 * @param   array  $result      New Access Token, Refresh Token and Expiry.
 	 * @param   string $client_id   OAuth Client ID used for the Access and Refresh Tokens.
@@ -511,7 +512,7 @@ class ConvertKit_Settings {
 	public function update_credentials( $result, $client_id ) {
 
 		// Don't save these credentials if they're not for this Client ID.
-		// They're for another ConvertKit Plugin that uses OAuth.
+		// They're for another Kit Plugin that uses OAuth.
 		if ( $client_id !== CONVERTKIT_OAUTH_CLIENT_ID ) {
 			return;
 		}
@@ -523,6 +524,12 @@ class ConvertKit_Settings {
 				'token_expires' => ( $result['created_at'] + $result['expires_in'] ),
 			)
 		);
+
+		// Clear any existing scheduled WordPress Cron event.
+		wp_clear_scheduled_hook( 'convertkit_refresh_token' );
+
+		// Schedule a WordPress Cron event to refresh the token on expiry.
+		wp_schedule_single_event( ( $result['created_at'] + $result['expires_in'] ), 'convertkit_refresh_token' );
 
 	}
 

--- a/includes/cron-functions.php
+++ b/includes/cron-functions.php
@@ -7,6 +7,57 @@
  */
 
 /**
+ * Refresh the OAuth access token, triggered by WordPress' Cron.
+ *
+ * @since   2.8.3
+ */
+function convertkit_refresh_token() {
+
+	// Get Settings and Log classes.
+	$settings = new ConvertKit_Settings();
+
+	// Bail if no existing access and refresh token exists.
+	if ( ! $settings->has_access_token() ) {
+		return;
+	}
+	if ( ! $settings->has_refresh_token() ) {
+		return;
+	}
+
+	// Initialize the API.
+	$api = new ConvertKit_API_V4(
+		CONVERTKIT_OAUTH_CLIENT_ID,
+		CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
+		$settings->get_access_token(),
+		$settings->get_refresh_token(),
+		$settings->debug_enabled(),
+		'cron_refresh_token'
+	);
+
+	// Refresh the token.
+	$result = $api->refresh_token();
+
+	// If an error occured, don't save the new tokens.
+	// Logging is handled by the ConvertKit_API_V4 class.
+	if ( is_wp_error( $result ) ) {
+		return;
+	}
+
+	$settings->save(
+		array(
+			'access_token'  => $result['access_token'],
+			'refresh_token' => $result['refresh_token'],
+			'token_expires' => ( $result['created_at'] + $result['expires_in'] ),
+		)
+	);
+
+}
+
+// Register action to run above function; this action is created by WordPress' wp_schedule_event() function
+// in update_credentials() in the ConvertKit_Settings class.
+add_action( 'convertkit_refresh_token', 'convertkit_refresh_token' );
+
+/**
  * Refresh the Posts Resource cache, triggered by WordPress' Cron.
  *
  * @since   1.9.7.4


### PR DESCRIPTION
## Summary

Reduces [the likelihood of 401 unauthorized requests](https://linear.app/kit/issue/WP-48/wordpress-investigate-high-count-of-401-unauthorized-errors) being sent to the Kit API by scheduling a WordPress cron event to refresh an expired access token on its expiry.

Presently, the Plugin relies on logic to check if an API request returns a 401 error with the message `The access token expired`.  On lower traffic sites - for example, where there are not many customers subscribing or purchases being sent to Kit - this isn't a reliable method, as a call to the API won't always be triggered.

## Testing

- `testCronEventCreatedWhenAccessTokenObtained`: Test that the `convertkit_refresh_token` event is scheduled when OAuth first completes and the Plugin receives access and refresh tokens.
- `testCronEventCreatedWhenTokenRefreshed`: Test that the `convertkit_refresh_token` event is scheduled when the access token is refreshed.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)