### PR TITLE
OAuth: Fix Refresh Token Scheduled Time

### DIFF
--- a/includes/class-convertkit-settings.php
+++ b/includes/class-convertkit-settings.php
@@ -521,7 +521,7 @@ class ConvertKit_Settings {
 			array(
 				'access_token'  => $result['access_token'],
 				'refresh_token' => $result['refresh_token'],
-				'token_expires' => ( $result['created_at'] + $result['expires_in'] ),
+				'token_expires' => ( time() + $result['expires_in'] ),
 			)
 		);
 
@@ -529,7 +529,7 @@ class ConvertKit_Settings {
 		wp_clear_scheduled_hook( 'convertkit_refresh_token' );
 
 		// Schedule a WordPress Cron event to refresh the token on expiry.
-		wp_schedule_single_event( ( $result['created_at'] + $result['expires_in'] ), 'convertkit_refresh_token' );
+		wp_schedule_single_event( ( time() + $result['expires_in'] ), 'convertkit_refresh_token' );
 
 	}
 

--- a/tests/Integration/APITest.php
+++ b/tests/Integration/APITest.php
@@ -211,8 +211,8 @@ class APITest extends WPTestCase
 					'access_token'  => $_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
 					'refresh_token' => $_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN'],
 					'token_type'    => 'bearer',
-					'created_at'    => $this->now,
-					'expires_in'    => 10000,
+					'created_at'    => 1735660800, // When the access token was created.
+					'expires_in'    => 10000, // When the access token will expire, relative to the time the request was made.
 					'scope'         => 'public',
 				)
 			),

--- a/tests/Integration/APITest.php
+++ b/tests/Integration/APITest.php
@@ -28,16 +28,6 @@ class APITest extends WPTestCase
 	private $api;
 
 	/**
-	 * Holds the current timestamp, defined in setUp to fix
-	 * it for all tests.
-	 *
-	 * @since   2.8.3
-	 *
-	 * @var     int
-	 */
-	private $now = 0;
-
-	/**
 	 * Performs actions before each test.
 	 *
 	 * @since   2.0.8
@@ -45,9 +35,6 @@ class APITest extends WPTestCase
 	public function setUp(): void
 	{
 		parent::setUp();
-
-		// Set the current timestamp to the start of the test.
-		$this->now = strtotime( 'now' );
 
 		// Activate Plugin, to include the Plugin's constants in tests.
 		activate_plugins('convertkit/wp-convertkit.php');
@@ -118,7 +105,7 @@ class APITest extends WPTestCase
 		// Confirm the Cron event to refresh the access token was created, and the timestamp to
 		// run the refresh token call matches the expiry of the access token.
 		$nextScheduledTimestamp = wp_next_scheduled( 'convertkit_refresh_token' );
-		$this->assertEquals( $nextScheduledTimestamp, $this->now + 10000 );
+		$this->assertGreaterThanOrEqual( $nextScheduledTimestamp, time() + 10000 );
 	}
 
 	/**
@@ -138,7 +125,7 @@ class APITest extends WPTestCase
 		// Confirm the Cron event to refresh the access token was created, and the timestamp to
 		// run the refresh token call matches the expiry of the access token.
 		$nextScheduledTimestamp = wp_next_scheduled( 'convertkit_refresh_token' );
-		$this->assertEquals( $nextScheduledTimestamp, $this->now + 10000 );
+		$this->assertGreaterThanOrEqual( $nextScheduledTimestamp, time() + 10000 );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

#839 incorrectly added the `expires_in` response parameter value to the token's `created_at` time, instead of the current timestamp (`time()`), resulting in the WordPress cron event to refresh the token being scheduled in the past:

![Screenshot 2025-06-27 at 09 00 48](https://github.com/user-attachments/assets/c15e6bf0-0a70-4939-af34-e1639c2ec89c)

Tests did not detect this as tests mock making a call to refresh an 'expired' access token, setting the API's `created_at` response parameter as the current date and time, instead of when the access token was created.

This PR resolves by:
- scheduling the WordPress cron event to next refresh the token on expiry of the current access token, relative to the current date and time,
- updated tests to reflect API functionality when calling the `refresh_token` method

![Screenshot 2025-06-27 at 08 39 01](https://github.com/user-attachments/assets/f9643248-0200-43fd-b359-62adce43ba01)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)