### PR TITLE
WordPress Playground: Set Tokens before Plugin Activation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,10 +52,26 @@ jobs:
       fail-fast: false
       matrix:
         wp-versions: [ 'latest' ] #[ '6.1.1', 'latest' ]
-        php-versions: [ '8.1' ] #[ '7.4', '8.0', '8.1' ]
+        php-versions: [ '8.1', '8.2', '8.3', '8.4' ] #[ '7.4', '8.0', '8.1' ]
 
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
+          'EndToEnd/broadcasts/blocks-shortcodes',
+          'EndToEnd/broadcasts/import-export',
+          'EndToEnd/forms/blocks-shortcodes',
+          'EndToEnd/forms/general',
+          'EndToEnd/forms/post-types',
+          'EndToEnd/general/other',
+          'EndToEnd/general/plugin-screens',
+          'EndToEnd/integrations/divi-builder',
+          'EndToEnd/integrations/divi-theme',
+          'EndToEnd/integrations/other',
+          'EndToEnd/integrations/wlm',
+          'EndToEnd/integrations/woocommerce',
+          'EndToEnd/landing-pages',
+          'EndToEnd/products',
+          'EndToEnd/restrict-content/general',
+          'EndToEnd/restrict-content/post-types',
           'EndToEnd/tags'
         ]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,26 +52,10 @@ jobs:
       fail-fast: false
       matrix:
         wp-versions: [ 'latest' ] #[ '6.1.1', 'latest' ]
-        php-versions: [ '8.1', '8.2', '8.3', '8.4' ] #[ '7.4', '8.0', '8.1' ]
+        php-versions: [ '8.1' ] #[ '7.4', '8.0', '8.1' ]
 
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
-          'EndToEnd/broadcasts/blocks-shortcodes',
-          'EndToEnd/broadcasts/import-export',
-          'EndToEnd/forms/blocks-shortcodes',
-          'EndToEnd/forms/general',
-          'EndToEnd/forms/post-types',
-          'EndToEnd/general/other',
-          'EndToEnd/general/plugin-screens',
-          'EndToEnd/integrations/divi-builder',
-          'EndToEnd/integrations/divi-theme',
-          'EndToEnd/integrations/other',
-          'EndToEnd/integrations/wlm',
-          'EndToEnd/integrations/woocommerce',
-          'EndToEnd/landing-pages',
-          'EndToEnd/products',
-          'EndToEnd/restrict-content/general',
-          'EndToEnd/restrict-content/post-types',
           'EndToEnd/tags'
         ]
 
@@ -395,7 +379,7 @@ jobs:
       # Create ZIP file
       - name: Create ZIP File
         run: |
-          zip -r ${{ env.PLUGIN_SLUG }}.zip . -x ".git/*" ".github/*" ".scripts/*" ".wordpress-org/*" "log/*" "tests/*" "*.md" "*.yml" "*.json" "*.neon" "*.lock" "*.xml" "*.dist" "*.example"
+          zip -r ${{ env.PLUGIN_SLUG }}.zip . -x ".git/*" ".github/*" ".scripts/*" ".wordpress-org/*" "log/*" "tests/*" "*.md" "*.yml" "*.json" "*.neon" "*.lock" "*.xml" "*.dist" "*.example" "*.testing" "vendor/convertkit/convertkit-wordpress-libraries/.git/*"
 
       # Exchange API Keys and Secrets for OAuth Tokens.
       - name: Exchange API Key and Secret for OAuth Tokens
@@ -412,7 +396,7 @@ jobs:
       - name: Create Blueprint JSON, Base64 Encoded
         id: blueprint
         run: |
-          echo "blueprint_json_base64=$(echo -n '{"landingPage":"/wp-admin/index.php","login":true,"features":{"networking":true},"steps":[{"step":"installPlugin","pluginData":{"resource":"url","url":"https://${{ env.AWS_BUCKET }}.s3.${{ env.AWS_REGION }}.amazonaws.com/${{ env.PLUGIN_SLUG }}/${{ github.event.pull_request.number }}/${{ env.PLUGIN_SLUG }}.zip"}},{"step":"setSiteOptions","options":{"_wp_convertkit_settings":{"access_token":"${{ env.CONVERTKIT_OAUTH_ACCESS_TOKEN }}","refresh_token":"${{ env.CONVERTKIT_OAUTH_REFRESH_TOKEN }}"}}}]}' | base64 -w 0)" >> $GITHUB_OUTPUT
+          echo "blueprint_json_base64=$(echo -n '{"landingPage":"/wp-admin/index.php","login":true,"features":{"networking":true},"steps":[{"step":"setSiteOptions","options":{"_wp_convertkit_settings":{"access_token":"${{ env.CONVERTKIT_OAUTH_ACCESS_TOKEN }}","refresh_token":"${{ env.CONVERTKIT_OAUTH_REFRESH_TOKEN }}"}}},{"step":"installPlugin","pluginData":{"resource":"url","url":"https://${{ env.AWS_BUCKET }}.s3.${{ env.AWS_REGION }}.amazonaws.com/${{ env.PLUGIN_SLUG }}/${{ github.event.pull_request.number }}/${{ env.PLUGIN_SLUG }}.zip"}}]}' | base64 -w 0)" >> $GITHUB_OUTPUT
 
       # Upload to S3
       - name: Upload to S3


### PR DESCRIPTION
## Summary

Fixes the WordPress Playground instances used when previewing a PR by setting the OAuth tokens before activating the Plugin.

Previously, Playground WASM would throw errors, resulting in Playground not displaying:

![Screenshot 2025-07-08 at 20 06 51](https://github.com/user-attachments/assets/01688d6a-104f-4b09-90aa-268003d0c06c)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)