### PR TITLE
WordPress Playground: Only run on PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -348,6 +348,9 @@ jobs:
     # Require the tests workflow to have run successfully.
     needs: tests
 
+    # Only run on pull requests, not when merging to main branch
+    if: github.event_name == 'pull_request'
+
     # Virtual Environment to use.
     # @see: https://github.com/actions/virtual-environments
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a condition to only run the WordPress Playground step for PRs, not when merging to the `main` branch.

![Screenshot 2025-07-09 at 12 43 08](https://github.com/user-attachments/assets/880e7298-64b2-4228-b5a0-f773bcdf40d8)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)