### PR TITLE
Blocks: Add Typography Support

### DIFF
--- a/includes/blocks/broadcasts/block.json
+++ b/includes/blocks/broadcasts/block.json
@@ -62,6 +62,10 @@
             "background": true,
             "text": true
         },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true
+        },
         "spacing": {
             "margin": true,
             "padding": true

--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -236,6 +236,9 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 			'textColor'            => array(
 				'type' => 'string',
 			),
+			'fontSize'             => array(
+				'type' => 'string',
+			),
 
 			// Always required for Gutenberg.
 			'is_gutenberg_example' => array(

--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -226,7 +226,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 				'default' => $this->get_default_value( 'paginate_label_next' ),
 			),
 
-			// get_supports() color attribute.
+			// get_supports() style, color and typography attributes.
 			'style'                => array(
 				'type' => 'object',
 			),
@@ -256,13 +256,17 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 	public function get_supports() {
 
 		return array(
-			'className' => true,
-			'color'     => array(
+			'className'  => true,
+			'color'      => array(
 				'link'       => true,
 				'background' => true,
 				'text'       => true,
 			),
-			'spacing'   => array(
+			'typography' => array(
+				'fontSize'   => true,
+				'lineHeight' => true,
+			),
+			'spacing'    => array(
 				'margin'  => true,
 				'padding' => true,
 			),

--- a/includes/blocks/class-convertkit-block-form-trigger.php
+++ b/includes/blocks/class-convertkit-block-form-trigger.php
@@ -159,40 +159,15 @@ class ConvertKit_Block_Form_Trigger extends ConvertKit_Block {
 
 			// The below are built in Gutenberg attributes registered in get_supports().
 
-			// Color.
+			// get_supports() style, color and typography attributes.
+			'style'                => array(
+				'type' => 'object',
+			),
 			'backgroundColor'      => array(
 				'type' => 'string',
 			),
 			'textColor'            => array(
 				'type' => 'string',
-			),
-
-			// Typography.
-			'fontSize'             => array(
-				'type' => 'string',
-			),
-
-			// Spacing/Dimensions > Padding.
-			'style'                => array(
-				'type'        => 'object',
-				'visualizers' => array(
-					'type'    => 'object',
-					'padding' => array(
-						'type'   => 'object',
-						'top'    => array(
-							'type' => 'boolean',
-						),
-						'bottom' => array(
-							'type' => 'boolean',
-						),
-						'left'   => array(
-							'type' => 'boolean',
-						),
-						'right'  => array(
-							'type' => 'boolean',
-						),
-					),
-				),
 			),
 
 			// Always required for Gutenberg.
@@ -225,7 +200,8 @@ class ConvertKit_Block_Form_Trigger extends ConvertKit_Block {
 				'__experimentalSkipSerialization' => true,
 			),
 			'typography' => array(
-				'fontSize' => true,
+				'fontSize'   => true,
+				'lineHeight' => true,
 			),
 			'spacing'    => array(
 				'margin'  => true,

--- a/includes/blocks/class-convertkit-block-form-trigger.php
+++ b/includes/blocks/class-convertkit-block-form-trigger.php
@@ -169,6 +169,9 @@ class ConvertKit_Block_Form_Trigger extends ConvertKit_Block {
 			'textColor'            => array(
 				'type' => 'string',
 			),
+			'fontSize'             => array(
+				'type' => 'string',
+			),
 
 			// Always required for Gutenberg.
 			'is_gutenberg_example' => array(

--- a/includes/blocks/class-convertkit-block-product.php
+++ b/includes/blocks/class-convertkit-block-product.php
@@ -195,40 +195,15 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 
 			// The below are built in Gutenberg attributes registered in get_supports().
 
-			// Color.
+			// get_supports() style, color and typography attributes.
+			'style'                   => array(
+				'type' => 'object',
+			),
 			'backgroundColor'         => array(
 				'type' => 'string',
 			),
 			'textColor'               => array(
 				'type' => 'string',
-			),
-
-			// Typography.
-			'fontSize'                => array(
-				'type' => 'string',
-			),
-
-			// Spacing/Dimensions > Padding.
-			'style'                   => array(
-				'type'        => 'object',
-				'visualizers' => array(
-					'type'    => 'object',
-					'padding' => array(
-						'type'   => 'object',
-						'top'    => array(
-							'type' => 'boolean',
-						),
-						'bottom' => array(
-							'type' => 'boolean',
-						),
-						'left'   => array(
-							'type' => 'boolean',
-						),
-						'right'  => array(
-							'type' => 'boolean',
-						),
-					),
-				),
 			),
 
 			// Always required for Gutenberg.
@@ -250,8 +225,8 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 	public function get_supports() {
 
 		return array(
-			'className' => true,
-			'color'     => array(
+			'className'  => true,
+			'color'      => array(
 				'background'                      => true,
 				'text'                            => true,
 
@@ -260,7 +235,11 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 				// See: https://github.com/WordPress/gutenberg/issues/32417.
 				'__experimentalSkipSerialization' => true,
 			),
-			'spacing'   => array(
+			'typography' => array(
+				'fontSize'   => true,
+				'lineHeight' => true,
+			),
+			'spacing'    => array(
 				'margin'  => true,
 				'padding' => true,
 			),

--- a/includes/blocks/class-convertkit-block-product.php
+++ b/includes/blocks/class-convertkit-block-product.php
@@ -205,6 +205,9 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 			'textColor'               => array(
 				'type' => 'string',
 			),
+			'fontSize'                => array(
+				'type' => 'string',
+			),
 
 			// Always required for Gutenberg.
 			'is_gutenberg_example'    => array(

--- a/includes/blocks/formtrigger/block.json
+++ b/includes/blocks/formtrigger/block.json
@@ -37,6 +37,10 @@
             "background": true,
             "text": true
         },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true
+        },
         "spacing": {
             "margin": true,
             "padding": true

--- a/includes/blocks/product/block.json
+++ b/includes/blocks/product/block.json
@@ -37,6 +37,10 @@
             "background": true,
             "text": true
         },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true
+        },
         "spacing": {
             "margin": true,
             "padding": true

--- a/tests/EndToEnd/broadcasts/blocks-shortcodes/PageBlockBroadcastsCest.php
+++ b/tests/EndToEnd/broadcasts/blocks-shortcodes/PageBlockBroadcastsCest.php
@@ -789,6 +789,54 @@ class PageBlockBroadcastsCest
 	}
 
 	/**
+	 * Test the Broadcasts block's typography parameters works.
+	 *
+	 * @since   2.8.4
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testBroadcastsBlockWithTypographyParameters(EndToEndTester $I)
+	{
+		// Setup Plugin and enable debug log.
+		$I->setupKitPlugin($I);
+		$I->setupKitPluginResources($I);
+
+		// It's tricky to interact with Gutenberg's typography pickers, so we programmatically create the Page
+		// instead to then confirm the settings apply on the output.
+		// We don't need to test the typography picker itself, as it's a Gutenberg supplied component, and our
+		// other End To End tests confirm that the block can be added in Gutenberg etc.
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'kit-page-broadcasts-block-typography-params',
+				'post_content' => '<!-- wp:convertkit/broadcasts {"date_format":"m/d/Y","limit":' . $_ENV['CONVERTKIT_API_BROADCAST_COUNT'] . ',"style":{"typography":{"lineHeight":"2"}},"fontSize":"large"} /-->',
+			]
+		);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/kit-page-broadcasts-block-typography-params');
+
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible('body.page-template-default');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the block displays correctly with the expected number of Broadcasts.
+		$I->seeBroadcastsOutput(
+			$I,
+			[
+				'number_posts' => $_ENV['CONVERTKIT_API_BROADCAST_COUNT'],
+			]
+		);
+
+		// Confirm that our stylesheet loaded.
+		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="' . $_ENV['WORDPRESS_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
+
+		// Confirm that the chosen typography settings are applied as CSS styles.
+		$I->seeInSource('<div class="convertkit-broadcasts wp-block-convertkit-broadcasts has-large-font-size" style="line-height:2"');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormTriggerCest.php
+++ b/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormTriggerCest.php
@@ -385,6 +385,50 @@ class PageBlockFormTriggerCest
 	}
 
 	/**
+	 * Test the Form Trigger block's typography parameters works.
+	 *
+	 * @since   2.8.4
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormTriggerBlockWithTypographyParameters(EndToEndTester $I)
+	{
+		// Setup Plugin and enable debug log.
+		$I->setupKitPlugin($I);
+		$I->setupKitPluginResources($I);
+
+		// It's tricky to interact with Gutenberg's typography pickers, so we programmatically create the Page
+		// instead to then confirm the settings apply on the output.
+		// We don't need to test the typography picker itself, as it's a Gutenberg supplied component, and our
+		// other End To End tests confirm that the block can be added in Gutenberg etc.
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'kit-page-form-trigger-block-typography-params',
+				'post_content' => '<!-- wp:convertkit/formtrigger {"form":"' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '","style":{"typography":{"lineHeight":"2"}},"fontSize":"large"} /-->',
+			]
+		);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/kit-page-form-trigger-block-typography-params');
+
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible('body.page-template-default');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the block displays and has the inline styles applied.
+		$I->seeFormTriggerOutput(
+			$I,
+			formURL: $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_URL'],
+			text: 'Subscribe',
+			cssClasses: 'has-large-font-size',
+			styles: 'line-height:2',
+			isBlock: true
+		);
+	}
+
+	/**
 	 * Test the Form Trigger block displays a message with a link to the Plugin's
 	 * settings screen, when the Plugin has no credentials specified.
 	 *

--- a/tests/EndToEnd/products/PageBlockProductCest.php
+++ b/tests/EndToEnd/products/PageBlockProductCest.php
@@ -565,6 +565,50 @@ class PageBlockProductCest
 	}
 
 	/**
+	 * Test the Product block's typography parameters works.
+	 *
+	 * @since   2.8.4
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testProductBlockWithTypographyParameters(EndToEndTester $I)
+	{
+		// Setup Plugin and enable debug log.
+		$I->setupKitPlugin($I);
+		$I->setupKitPluginResources($I);
+
+		// It's tricky to interact with Gutenberg's typography pickers, so we programmatically create the Page
+		// instead to then confirm the settings apply on the output.
+		// We don't need to test the typography picker itself, as it's a Gutenberg supplied component, and our
+		// other End To End tests confirm that the block can be added in Gutenberg etc.
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'kit-page-product-block-typography-params',
+				'post_content' => '<!-- wp:convertkit/product {"product":"36377","style":{"typography":{"lineHeight":"2"}},"fontSize":"large"} /-->',
+			]
+		);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/kit-page-product-block-typography-params');
+
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible('body.page-template-default');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the block displays and has the inline styles applied.
+		$I->seeProductOutput(
+			$I,
+			productURL: $_ENV['CONVERTKIT_API_PRODUCT_URL'],
+			text: 'Buy my product',
+			cssClasses: 'has-large-font-size',
+			styles: 'line-height:2',
+			isBlock: true
+		);
+	}
+
+	/**
 	 * Test the Product block displays a message with a link to the Plugin's
 	 * settings screen, when the Plugin has Not connected to Kit.
 	 *

--- a/tests/Support/Helper/KitForms.php
+++ b/tests/Support/Helper/KitForms.php
@@ -76,15 +76,16 @@ class KitForms extends \Codeception\Module
 	 *
 	 * @since   2.2.0
 	 *
-	 * @param   EndToEndTester $I              Tester.
-	 * @param   string         $formURL        Form URL.
-	 * @param   bool|string    $text           Test if the button text matches the given value.
-	 * @param   bool|string    $textColor      Test if the given text color is applied.
+	 * @param   EndToEndTester $I               Tester.
+	 * @param   string         $formURL         Form URL.
+	 * @param   bool|string    $text            Test if the button text matches the given value.
+	 * @param   bool|string    $textColor       Test if the given text color is applied.
 	 * @param   bool|string    $backgroundColor Test is the given background color is applied.
-	 * @param   bool|string    $styles         Test if the given styles are applied.
-	 * @param   bool           $isBlock        Test if this is a form trigger block or shortcode.
+	 * @param   bool|string    $cssClasses      Test if the given CSS classes are applied.
+	 * @param   bool|string    $styles          Test if the given styles are applied.
+	 * @param   bool           $isBlock         Test if this is a form trigger block or shortcode.
 	 */
-	public function seeFormTriggerOutput($I, $formURL, $text = false, $textColor = false, $backgroundColor = false, $styles = false, $isBlock = false)
+	public function seeFormTriggerOutput($I, $formURL, $text = false, $textColor = false, $backgroundColor = false, $cssClasses = false, $styles = false, $isBlock = false)
 	{
 		// Confirm that the button stylesheet loaded.
 		$I->seeInSource('<link rel="stylesheet" id="convertkit-button-css" href="' . $_ENV['WORDPRESS_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/button.css');
@@ -128,6 +129,14 @@ class KitForms extends \Codeception\Module
 					);
 					break;
 			}
+		}
+
+		// Confirm that the CSS classes are as expected.
+		if ($cssClasses !== false) {
+			$I->assertStringContainsString(
+				$cssClasses,
+				$I->grabAttributeFrom('a.convertkit-formtrigger', 'class')
+			);
 		}
 
 		// Confirm that the styles are as expected.

--- a/tests/Support/Helper/KitProducts.php
+++ b/tests/Support/Helper/KitProducts.php
@@ -49,15 +49,16 @@ class KitProducts extends \Codeception\Module
 	 *
 	 * @since   1.9.8.5
 	 *
-	 * @param   EndToEndTester $I              Tester.
-	 * @param   string         $productURL     Product URL.
-	 * @param   bool|string    $text           Test if the button text matches the given value.
-	 * @param   bool|string    $textColor      Test if the given text color is applied.
+	 * @param   EndToEndTester $I               Tester.
+	 * @param   string         $productURL      Product URL.
+	 * @param   bool|string    $text            Test if the button text matches the given value.
+	 * @param   bool|string    $textColor       Test if the given text color is applied.
 	 * @param   bool|string    $backgroundColor Test is the given background color is applied.
-	 * @param   bool|string    $styles         Test if the given styles are applied.
-	 * @param   bool           $isBlock        Test if this is a product block or shortcode.
+	 * @param   bool|string    $cssClasses      Test if the given CSS classes are applied.
+	 * @param   bool|string    $styles          Test if the given styles are applied.
+	 * @param   bool           $isBlock         Test if this is a product block or shortcode.
 	 */
-	public function seeProductOutput($I, $productURL, $text = false, $textColor = false, $backgroundColor = false, $styles = false, $isBlock = false)
+	public function seeProductOutput($I, $productURL, $text = false, $textColor = false, $backgroundColor = false, $cssClasses = false, $styles = false, $isBlock = false)
 	{
 		// Confirm that the product stylesheet loaded.
 		$I->seeInSource('<link rel="stylesheet" id="convertkit-button-css" href="' . $_ENV['WORDPRESS_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/button.css');
@@ -103,6 +104,14 @@ class KitProducts extends \Codeception\Module
 					);
 					break;
 			}
+		}
+
+		// Confirm that the CSS classes are as expected.
+		if ($cssClasses !== false) {
+			$I->assertStringContainsString(
+				$cssClasses,
+				$I->grabAttributeFrom('a.convertkit-product', 'class')
+			);
 		}
 
 		// Confirm that the styles are as expected.


### PR DESCRIPTION
## Summary

Building on #844, adds the block editor's native typography controls to the Broadcasts, Form Trigger and Product blocks.

Also cleans up supports() and attributes() to be standardised, removing some now deprecated properties.

Before (e.g. Broadcasts block with no font size or line height options):

![Screenshot 2025-07-09 at 14 48 01](https://github.com/user-attachments/assets/7024d1cc-8ad3-4300-b715-cbc5f4946634)

After (e.g. Broadcasts block with an XL font size and line height specified):

![Screenshot 2025-07-09 at 14 49 42](https://github.com/user-attachments/assets/5abc548a-a15d-4e19-897c-2a22f95f4c69)

![Screenshot 2025-07-09 at 14 49 49](https://github.com/user-attachments/assets/fb354199-188e-4ae4-b24f-d8b5dac62b11)

## Testing

- `testBroadcastsBlockWithTypographyParameters`: Test the Broadcasts block's typography parameters work.
- `testFormTriggerBlockWithTypographyParameters`: Test the Form Trigger block's typography parameters work.
- `testProductBlockWithTypographyParameters`: Test the Product block's typography parameters work.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)