### PR TITLE
Blocks: Improve Rendering Accuracy

### DIFF
--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -498,13 +498,27 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 		}
 
 		// Build HTML.
-		$html = $this->build_html(
-			$posts,
-			$atts,
-			! $this->is_block_editor_request(),
-			$this->get_css_classes(),
-			$this->get_css_styles( $atts )
-		);
+		if ( $this->is_block_editor_request() ) {
+			// For the block editor, don't include compiled CSS classes and styles,
+			// as the block editor will add these to the parent container.
+			// Otherwise the block will render incorrectly with double padding, double margins etc.
+			$html = $this->build_html(
+				$posts,
+				$atts,
+				true,
+				array(
+					'convertkit-' . $this->get_name(),
+				)
+			);
+		} else {
+			$html = $this->build_html(
+				$posts,
+				$atts,
+				true,
+				$this->get_css_classes(),
+				$this->get_css_styles( $atts )
+			);
+		}
 
 		/**
 		 * Filter the block's content immediately before it is output.

--- a/includes/blocks/class-convertkit-block-form-trigger.php
+++ b/includes/blocks/class-convertkit-block-form-trigger.php
@@ -55,6 +55,9 @@ class ConvertKit_Block_Form_Trigger extends ConvertKit_Block {
 
 		wp_enqueue_style( 'convertkit-button', CONVERTKIT_PLUGIN_URL . 'resources/frontend/css/button.css', array(), CONVERTKIT_PLUGIN_VERSION );
 
+		// Enqueue the block button CSS.
+		wp_enqueue_style( 'wp-block-button' );
+
 	}
 
 	/**

--- a/includes/blocks/class-convertkit-block-product.php
+++ b/includes/blocks/class-convertkit-block-product.php
@@ -77,6 +77,9 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 
 		wp_enqueue_style( 'convertkit-button', CONVERTKIT_PLUGIN_URL . 'resources/frontend/css/button.css', array(), CONVERTKIT_PLUGIN_VERSION );
 
+		// Enqueue the block button CSS.
+		wp_enqueue_style( 'wp-block-button' );
+
 	}
 
 	/**

--- a/tests/Support/Helper/KitForms.php
+++ b/tests/Support/Helper/KitForms.php
@@ -90,6 +90,9 @@ class KitForms extends \Codeception\Module
 		// Confirm that the button stylesheet loaded.
 		$I->seeInSource('<link rel="stylesheet" id="convertkit-button-css" href="' . $_ENV['WORDPRESS_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/button.css');
 
+		// Confirm that the block button CSS loaded.
+		$I->seeInSource('<style id="wp-block-button-inline-css">');
+
 		// Confirm that the block displays.
 		$I->seeElementInDOM('a.convertkit-formtrigger.wp-block-button__link');
 

--- a/tests/Support/Helper/KitProducts.php
+++ b/tests/Support/Helper/KitProducts.php
@@ -63,6 +63,9 @@ class KitProducts extends \Codeception\Module
 		// Confirm that the product stylesheet loaded.
 		$I->seeInSource('<link rel="stylesheet" id="convertkit-button-css" href="' . $_ENV['WORDPRESS_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/button.css');
 
+		// Confirm that the block button CSS loaded.
+		$I->seeInSource('<style id="wp-block-button-inline-css">');
+
 		// Confirm that the block displays.
 		$I->seeElementInDOM('a.convertkit-product.wp-block-button__link');
 


### PR DESCRIPTION
## Summary

Improves the rendering accuracy between the block editor and frontend site.

## Broadcasts

Editor: Include the container div, so that settings such as `Display order` and `Display as grid` are reflected in the block editor. These always correctly display on the frontend site, but failed to display since introducing #842, which removed the container div in the block editor to prevent double margins/paddings rendering.

Before:
<img width="975" height="366" alt="broadcasts-before" src="https://github.com/user-attachments/assets/b9ee2fb7-057e-481e-9f05-e060d58d5c43" />

After:
<img width="970" height="395" alt="broadcasts-after" src="https://github.com/user-attachments/assets/d33385e7-b4df-45c1-8140-7c77d9118e91" />

## Form Trigger and Product

Frontend: Enqueue the `wp-block-button` stylesheet, so that buttons render the same (i.e. with border radius) as the standard WordPress button block, on which the Form Trigger + Product buttons are based.

Before:
<img width="692" height="181" alt="Screenshot 2025-07-12 at 11 51 34" src="https://github.com/user-attachments/assets/6fd683e6-f849-45d4-8368-d82b5fe8ba80" />

After:
<img width="680" height="175" alt="Screenshot 2025-07-12 at 11 50 54" src="https://github.com/user-attachments/assets/b5b0b2a1-895f-4e52-8f99-2ede5ccb5443" />

## Testing

Updated Form Trigger and Product tests to confirm WordPress' button block styles are included in frontend output.
Visual tests performed to confirm output accurate between the block editor and frontend.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)