### PR TITLE
Form Block: Add Margin, Padding and Background Color Options

### DIFF
--- a/includes/blocks/class-convertkit-block-form.php
+++ b/includes/blocks/class-convertkit-block-form.php
@@ -412,7 +412,8 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 		// For the block editor, don't include compiled CSS classes and styles,
 		// as the block editor will add these to the parent container.
 		// Otherwise the block will render incorrectly with double padding, double margins etc.
-		if ( ! $this->is_block_editor_request() ) {
+		// If there's no Form HTML, it's a non-inline form, so don't render any output.
+		if ( ! $this->is_block_editor_request() && ! empty( $form ) ) {
 			$form = sprintf(
 				'<div class="%s" style="%s">%s</div>',
 				implode( ' ', map_deep( $this->get_css_classes(), 'sanitize_html_class' ) ),

--- a/includes/blocks/class-convertkit-block-form.php
+++ b/includes/blocks/class-convertkit-block-form.php
@@ -185,11 +185,6 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 			'form'                 => array(
 				'type' => 'string',
 			),
-
-			// The below are built in Gutenberg attributes registered in get_supports().
-			'align'                => array(
-				'type' => 'string',
-			),
 			
 			// get_supports() style, color and typography attributes.
 			'style'                => array(
@@ -218,7 +213,6 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 	public function get_supports() {
 
 		return array(
-			'align'      => true,
 			'className'  => true,
 			'color'      => array(
 				'link'       => false,

--- a/includes/blocks/class-convertkit-block-form.php
+++ b/includes/blocks/class-convertkit-block-form.php
@@ -185,7 +185,7 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 			'form'                 => array(
 				'type' => 'string',
 			),
-			
+
 			// get_supports() style, color and typography attributes.
 			'style'                => array(
 				'type' => 'object',
@@ -213,13 +213,13 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 	public function get_supports() {
 
 		return array(
-			'className'  => true,
-			'color'      => array(
+			'className' => true,
+			'color'     => array(
 				'link'       => false,
 				'background' => true,
 				'text'       => false,
 			),
-			'spacing'    => array(
+			'spacing'   => array(
 				'margin'  => true,
 				'padding' => true,
 			),

--- a/includes/blocks/class-convertkit-block-form.php
+++ b/includes/blocks/class-convertkit-block-form.php
@@ -186,10 +186,48 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 				'type' => 'string',
 			),
 
+			// The below are built in Gutenberg attributes registered in get_supports().
+			'align'                => array(
+				'type' => 'string',
+			),
+			
+			// get_supports() style, color and typography attributes.
+			'style'                => array(
+				'type' => 'object',
+			),
+			'backgroundColor'      => array(
+				'type' => 'string',
+			),
+
 			// Always required for Gutenberg.
 			'is_gutenberg_example' => array(
 				'type'    => 'boolean',
 				'default' => false,
+			),
+		);
+
+	}
+
+	/**
+	 * Returns this block's supported built-in Attributes.
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @return  array   Supports
+	 */
+	public function get_supports() {
+
+		return array(
+			'align'      => true,
+			'className'  => true,
+			'color'      => array(
+				'link'       => false,
+				'background' => true,
+				'text'       => false,
+			),
+			'spacing'    => array(
+				'margin'  => true,
+				'padding' => true,
 			),
 		);
 
@@ -368,6 +406,19 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 			}
 
 			return '';
+		}
+
+		// Build HTML.
+		// For the block editor, don't include compiled CSS classes and styles,
+		// as the block editor will add these to the parent container.
+		// Otherwise the block will render incorrectly with double padding, double margins etc.
+		if ( ! $this->is_block_editor_request() ) {
+			$form = sprintf(
+				'<div class="%s" style="%s">%s</div>',
+				implode( ' ', map_deep( $this->get_css_classes(), 'sanitize_html_class' ) ),
+				implode( ';', map_deep( $this->get_css_styles( $atts ), 'esc_attr' ) ),
+				$form
+			);
 		}
 
 		/**

--- a/includes/blocks/form/block.json
+++ b/includes/blocks/form/block.json
@@ -23,7 +23,17 @@
         }
     },
     "supports": {
-        "className": true
+        "align": true,
+        "className": true,
+        "color": {
+            "link": false,
+            "background": true,
+            "text": false
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true
+        }
     },
     "editorScript": "convertkit-gutenberg"
 }

--- a/includes/blocks/form/block.json
+++ b/includes/blocks/form/block.json
@@ -23,7 +23,6 @@
         }
     },
     "supports": {
-        "align": true,
         "className": true,
         "color": {
             "link": false,

--- a/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormCest.php
+++ b/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormCest.php
@@ -1088,6 +1088,158 @@ class PageBlockFormCest
 	}
 
 	/**
+	 * Test the Form block's theme color parameters works.
+	 *
+	 * @since   2.8.6
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormBlockWithThemeColorParameters(EndToEndTester $I)
+	{
+		// Setup Plugin and enable debug log.
+		$I->setupKitPlugin($I);
+		$I->setupKitPluginResources($I);
+
+		// Define theme color.
+		$backgroundColor = 'accent-5';
+
+		// Create a Page as if it were create in Gutenberg with the Form block
+		// set to display an inline form.
+		$pageID = $I->havePostInDatabase(
+			[
+				'post_type'    => 'page',
+				'post_title'   => 'Kit: Page: Form: Block: Theme Color',
+				'post_content' => '<!-- wp:convertkit/form {"form":"' . $_ENV['CONVERTKIT_API_FORM_ID'] . '","style":{"color":{"background":"' . $backgroundColor . '"}}} /-->',
+				'meta_input'   => [
+					// Configure Kit Plugin to not display a default Form.
+					'_wp_convertkit_post_meta' => [
+						'form'         => '0',
+						'landing_page' => '',
+						'tag'          => '',
+					],
+				],
+			]
+		);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible('body.page-template-default');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that one Kit Form is output in the DOM.
+		// This confirms that there is only one script on the page for this form, which renders the form.
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
+
+		// Confirm that the chosen colors are applied as CSS styles.
+		$I->seeInSource('<div class="convertkit-form wp-block-convertkit-form has-background" style="background-color:' . $backgroundColor . '"');
+	}
+
+	/**
+	 * Test the Form block's hex color parameters works.
+	 *
+	 * @since   2.8.6
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormBlockWithHexColorParameters(EndToEndTester $I)
+	{
+		// Setup Plugin and enable debug log.
+		$I->setupKitPlugin($I);
+		$I->setupKitPluginResources($I);
+
+		// Define colors.
+		$backgroundColor = '#ee1616';
+
+		// Create a Page as if it were create in Gutenberg with the Form block
+		// set to display an inline form.
+		$pageID = $I->havePostInDatabase(
+			[
+				'post_type'    => 'page',
+				'post_name'    => 'kit-page-form-block-hex-color-params',
+				'post_content' => '<!-- wp:convertkit/form {"form":"' . $_ENV['CONVERTKIT_API_FORM_ID'] . '","style":{"color":{"background":"' . $backgroundColor . '"}}} /-->',
+				'meta_input'   => [
+					// Configure Kit Plugin to not display a default Form.
+					'_wp_convertkit_post_meta' => [
+						'form'         => '0',
+						'landing_page' => '',
+						'tag'          => '',
+					],
+				],
+			]
+		);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible('body.page-template-default');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that one Kit Form is output in the DOM.
+		// This confirms that there is only one script on the page for this form, which renders the form.
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
+
+		// Confirm that the chosen colors are applied as CSS styles.
+		$I->seeInSource('<div class="convertkit-form wp-block-convertkit-form has-background" style="background-color:' . $backgroundColor . '"');
+	}
+
+	/**
+	 * Test the Form block's margin and padding parameters works.
+	 *
+	 * @since   2.8.6
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormBlockWithMarginAndPaddingParameters(EndToEndTester $I)
+	{
+		// Setup Plugin and enable debug log.
+		$I->setupKitPlugin($I);
+		$I->setupKitPluginResources($I);
+
+		// It's tricky to interact with Gutenberg's margin and padding pickers, so we programmatically create the Page
+		// instead to then confirm the settings apply on the output.
+		// We don't need to test the margin and padding pickers themselves, as they are Gutenberg supplied components, and our
+		// other End To End tests confirm that the block can be added in Gutenberg etc.
+		$pageID = $I->havePostInDatabase(
+			[
+				'post_type'    => 'page',
+				'post_name'    => 'kit-page-form-block-margin-padding-params',
+				'post_content' => '<!-- wp:convertkit/form {"form":"' . $_ENV['CONVERTKIT_API_FORM_ID'] . '","style":{"spacing":{"padding":{"top":"var:preset|spacing|30"},"margin":{"top":"var:preset|spacing|30"}}}} /-->',
+				'meta_input'   => [
+					// Configure Kit Plugin to not display a default Form.
+					'_wp_convertkit_post_meta' => [
+						'form'         => '0',
+						'landing_page' => '',
+						'tag'          => '',
+					],
+				],
+			]
+		);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible('body.page-template-default');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that one Kit Form is output in the DOM.
+		// This confirms that there is only one script on the page for this form, which renders the form.
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
+
+		// Confirm that the chosen margin and padding are applied as CSS styles.
+		$I->seeInSource('<div class="convertkit-form wp-block-convertkit-form" style="padding-top:var(--wp--preset--spacing--30);margin-top:var(--wp--preset--spacing--30)"');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.


### PR DESCRIPTION
## Summary

Adds margin, padding and background color options to the Form Block:

<img width="1108" height="889" alt="Screenshot 2025-07-22 at 17 53 58" src="https://github.com/user-attachments/assets/be7f6567-286c-41a0-a1c0-edc33ffe81c7" />

## Testing

- testFormBlockWithThemeColorParameters:  Test the Form block's theme color parameters works.
- testFormBlockWithHexColorParameters: Test the Form block's hex color parameters works.
- testFormBlockWithMarginAndPaddingParameters: Test the Form block's margin and padding parameters works.

## Checklist

* [ ] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [ ] I have [run all tests](TESTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)