### PR TITLE
Member Content: Don’t filter WP_List_Table when no Member Content Filter selected

### DIFF
--- a/admin/class-convertkit-admin-restrict-content.php
+++ b/admin/class-convertkit-admin-restrict-content.php
@@ -98,6 +98,11 @@ class ConvertKit_Admin_Restrict_Content {
 			return;
 		}
 
+		// Bail if the filter is empty.
+		if ( empty( filter_input( INPUT_GET, 'convertkit_restrict_content', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) ) {
+			return;
+		}
+
 		// Don't filter if we're not querying a Post Type that supports Restricted Content.
 		if ( ! in_array( $query->get( 'post_type' ), convertkit_get_supported_post_types(), true ) ) {
 			return;

--- a/admin/class-multi-value-field-table.php
+++ b/admin/class-multi-value-field-table.php
@@ -200,13 +200,13 @@ class Multi_Value_Field_Table extends WP_List_Table {
 			$data,
 			function ( $a, $b ) {
 
-				if ( ! filter_has_var( INPUT_GET, 'orderby' ) ) {
+				if ( ! filter_has_var( INPUT_GET, 'orderby' ) || empty( filter_input( INPUT_GET, 'orderby', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) ) {
 					$orderby = 'title';
 				} else {
 					$orderby = sanitize_sql_orderby( filter_input( INPUT_GET, 'orderby', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 				}
 
-				if ( ! filter_has_var( INPUT_GET, 'order' ) ) {
+				if ( ! filter_has_var( INPUT_GET, 'order' ) || empty( filter_input( INPUT_GET, 'order', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) ) {
 					$order = 'asc';
 				} else {
 					$order = filter_input( INPUT_GET, 'order', FILTER_SANITIZE_FULL_SPECIAL_CHARS );

--- a/tests/EndToEnd/restrict-content/general/RestrictContentFilterCPTCest.php
+++ b/tests/EndToEnd/restrict-content/general/RestrictContentFilterCPTCest.php
@@ -330,6 +330,90 @@ class RestrictContentFilterCPTCest
 	}
 
 	/**
+	 * Test that no filtering takes place when the filter is set to All Content on the CPT screen.
+	 *
+	 * @since   2.8.6
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testNoFilteringWhenAllContentSelected(EndToEndTester $I)
+	{
+		// Setup Plugin.
+		$I->setupKitPlugin($I);
+
+		// Create a mix of Posts restricted and not restricted to Forms, Tags and Products.
+		$I->createRestrictedContentPage(
+			$I,
+			[
+				'post_type'                => 'article',
+				'post_title'               => 'Kit: Article: Restricted Content: Form: No Filter Test',
+				'restrict_content_setting' => 'form_' . $_ENV['CONVERTKIT_API_FORM_ID'],
+			]
+		);
+		$I->createRestrictedContentPage(
+			$I,
+			[
+				'post_type'                => 'article',
+				'post_title'               => 'Kit: Article: Restricted Content: Tag: No Filter Test',
+				'restrict_content_setting' => 'tag_' . $_ENV['CONVERTKIT_API_TAG_ID'],
+			]
+		);
+		$I->createRestrictedContentPage(
+			$I,
+			[
+				'post_type'                => 'article',
+				'post_title'               => 'Kit: Article: Restricted Content: Product: No Filter Test',
+				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+			]
+		);
+		$I->havePostInDatabase(
+			[
+				'post_type'  => 'article',
+				'post_title' => 'Kit: Article: Standard',
+				'meta_input' => [
+					'_wp_convertkit_post_meta' => [
+						'form'             => '0',
+						'landing_page'     => '',
+						'tag'              => '',
+						'restrict_content' => '0',
+					],
+				],
+			]
+		);
+		$I->havePostInDatabase(
+			[
+				'post_type'  => 'article',
+				'post_title' => 'Kit: Article: Standard: No Meta',
+			]
+		);
+
+		// Navigate to Articles.
+		$I->amOnAdminPage('edit.php?post_type=article');
+
+		// Wait for the WP_List_Table of Articles to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Click the Filter button with no changes made.
+		$I->click('Filter');
+
+		// Wait for the WP_List_Table of Articles to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that all 5 Articles still display.
+		$I->see('Kit: Article: Restricted Content: Form: No Filter Test');
+		$I->see('Kit: Article: Restricted Content: Tag: No Filter Test');
+		$I->see('Kit: Article: Restricted Content: Product: No Filter Test');
+		$I->see('Kit: Article: Standard');
+		$I->see('Kit: Article: Standard: No Meta');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/EndToEnd/restrict-content/general/RestrictContentFilterPageCest.php
+++ b/tests/EndToEnd/restrict-content/general/RestrictContentFilterPageCest.php
@@ -302,6 +302,90 @@ class RestrictContentFilterPageCest
 	}
 
 	/**
+	 * Test that no filtering takes place when the filter is set to All Content on the Pages screen.
+	 *
+	 * @since   2.8.6
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testNoFilteringWhenAllContentSelected(EndToEndTester $I)
+	{
+		// Setup Plugin.
+		$I->setupKitPlugin($I);
+
+		// Create a mix of Posts restricted and not restricted to Forms, Tags and Products.
+		$I->createRestrictedContentPage(
+			$I,
+			[
+				'post_type'                => 'page',
+				'post_title'               => 'Kit: Page: Restricted Content: Form: No Filter Test',
+				'restrict_content_setting' => 'form_' . $_ENV['CONVERTKIT_API_FORM_ID'],
+			]
+		);
+		$I->createRestrictedContentPage(
+			$I,
+			[
+				'post_type'                => 'page',
+				'post_title'               => 'Kit: Page: Restricted Content: Tag: No Filter Test',
+				'restrict_content_setting' => 'tag_' . $_ENV['CONVERTKIT_API_TAG_ID'],
+			]
+		);
+		$I->createRestrictedContentPage(
+			$I,
+			[
+				'post_type'                => 'page',
+				'post_title'               => 'Kit: Page: Restricted Content: Product: No Filter Test',
+				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+			]
+		);
+		$I->havePostInDatabase(
+			[
+				'post_type'  => 'page',
+				'post_title' => 'Kit: Page: Standard',
+				'meta_input' => [
+					'_wp_convertkit_post_meta' => [
+						'form'             => '0',
+						'landing_page'     => '',
+						'tag'              => '',
+						'restrict_content' => '0',
+					],
+				],
+			]
+		);
+		$I->havePostInDatabase(
+			[
+				'post_type'  => 'page',
+				'post_title' => 'Kit: Page: Standard: No Meta',
+			]
+		);
+
+		// Navigate to Pages.
+		$I->amOnAdminPage('edit.php?post_type=page');
+
+		// Wait for the WP_List_Table of Pages to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Click the Filter button with no changes made.
+		$I->click('Filter');
+
+		// Wait for the WP_List_Table of Pages to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that all 5 Pages still display.
+		$I->see('Kit: Page: Restricted Content: Form: No Filter Test');
+		$I->see('Kit: Page: Restricted Content: Tag: No Filter Test');
+		$I->see('Kit: Page: Restricted Content: Product: No Filter Test');
+		$I->see('Kit: Page: Standard');
+		$I->see('Kit: Page: Standard: No Meta');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/EndToEnd/restrict-content/general/RestrictContentFilterPostCest.php
+++ b/tests/EndToEnd/restrict-content/general/RestrictContentFilterPostCest.php
@@ -304,6 +304,90 @@ class RestrictContentFilterPostCest
 	}
 
 	/**
+	 * Test that no filtering takes place when the filter is set to All Content on the Posts screen.
+	 *
+	 * @since   2.8.6
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testNoFilteringWhenAllContentSelected(EndToEndTester $I)
+	{
+		// Setup Plugin.
+		$I->setupKitPlugin($I);
+
+		// Create a mix of Posts restricted and not restricted to Forms, Tags and Products.
+		$I->createRestrictedContentPage(
+			$I,
+			[
+				'post_type'                => 'post',
+				'post_title'               => 'Kit: Post: Restricted Content: Form: No Filter Test',
+				'restrict_content_setting' => 'form_' . $_ENV['CONVERTKIT_API_FORM_ID'],
+			]
+		);
+		$I->createRestrictedContentPage(
+			$I,
+			[
+				'post_type'                => 'post',
+				'post_title'               => 'Kit: Post: Restricted Content: Tag: No Filter Test',
+				'restrict_content_setting' => 'tag_' . $_ENV['CONVERTKIT_API_TAG_ID'],
+			]
+		);
+		$I->createRestrictedContentPage(
+			$I,
+			[
+				'post_type'                => 'post',
+				'post_title'               => 'Kit: Post: Restricted Content: Product: No Filter Test',
+				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+			]
+		);
+		$I->havePostInDatabase(
+			[
+				'post_type'  => 'post',
+				'post_title' => 'Kit: Post: Standard',
+				'meta_input' => [
+					'_wp_convertkit_post_meta' => [
+						'form'             => '0',
+						'landing_page'     => '',
+						'tag'              => '',
+						'restrict_content' => '0',
+					],
+				],
+			]
+		);
+		$I->havePostInDatabase(
+			[
+				'post_type'  => 'post',
+				'post_title' => 'Kit: Post: Standard: No Meta',
+			]
+		);
+
+		// Navigate to Posts.
+		$I->amOnAdminPage('edit.php?post_type=post');
+
+		// Wait for the WP_List_Table of Posts to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Click the Filter button with no changes made.
+		$I->click('Filter');
+
+		// Wait for the WP_List_Table of Posts to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that all 5 Posts still display.
+		$I->see('Kit: Post: Restricted Content: Form: No Filter Test');
+		$I->see('Kit: Post: Restricted Content: Tag: No Filter Test');
+		$I->see('Kit: Post: Restricted Content: Product: No Filter Test');
+		$I->see('Kit: Post: Standard');
+		$I->see('Kit: Post: Standard: No Meta');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://linear.app/kit/issue/WP-52/wp-p3-posts-not-displaying-when-using-kit-plugin-v285) introduced in [this PR change](https://github.com/Kit/convertkit-wordpress/pull/851/files#diff-d6630bc83a6df4608fc924b4e626f22a5b6c4cf954c7d8d4828cab2b44dd5165L96-L102), that removed the check for whether the `convertkit_restrict_content` query parameter had a non-empty value.

This regression wasn’t caught earlier because there were no existing tests covering the behaviour of the WP_List_Table when the Filter button is clicked with the Member Content dropdown set to All content.

<img width="893" height="360" alt="Screenshot_2025-07-23_at_11_15_01" src="https://github.com/user-attachments/assets/07537b11-6476-4d42-be17-3a09f1154ef2" />

## Testing

- `RestrictContentFilterPostCest:testNoFilteringWhenAllContentSelected`: Test that no filtering takes place when the filter is set to All Content on the Posts screen.
- `RestrictContentFilterPageCest:testNoFilteringWhenAllContentSelected`: Test that no filtering takes place when the filter is set to All Content on the Pages screen.
- `RestrictContentFilterCPTCest:testNoFilteringWhenAllContentSelected`: Test that no filtering takes place when the filter is set to All Content on a CPT screen.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)