### PR TITLE
Exclude `.devcontainer` and `phpstan-dev.neon` from releases

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,3 +1,4 @@
+/.devcontainer
 /.git
 /.github
 /.scripts
@@ -27,6 +28,7 @@ LICENSE
 log.txt
 phpcs.xml
 phpcs.tests.xml
+phpstan-dev.neon
 phpstan.neon
 phpstan.neon.dist
 phpstan.neon.example


### PR DESCRIPTION
## Summary

Exclude `.devcontainer` and `phpstan-dev.neon` when the GitHub action publishes a new Plugin version / release to wordpress.org

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)