### PR TITLE
Forms: Debugging: Add `data-kit-source-post-id` Attribute

### DIFF
--- a/includes/blocks/class-convertkit-block-form.php
+++ b/includes/blocks/class-convertkit-block-form.php
@@ -291,6 +291,10 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 	 */
 	public function render( $atts ) {
 
+		global $post;
+
+		$post_id = is_a( $post, 'WP_Post' ) ? $post->ID : 0;
+
 		// Check if the Block Visibility Plugin permits displaying this block.
 		if ( ! $this->is_block_visible( $atts ) ) {
 			// Block should not be displayed due to Block Visibility Plugin conditions.
@@ -328,7 +332,7 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 
 		// Get Form HTML.
 		$forms = new ConvertKit_Resource_Forms( 'output_form' );
-		$form  = $forms->get_html( $form_id );
+		$form  = $forms->get_html( $form_id, $post_id );
 
 		// If an error occured, it might be that we're requesting a Form ID that exists in ConvertKit
 		// but does not yet exist in the Plugin's Form Resources.
@@ -338,7 +342,7 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 			$forms->refresh();
 
 			// Get Form HTML again.
-			$form = $forms->get_html( $form_id );
+			$form = $forms->get_html( $form_id, $post_id );
 		}
 
 		// If an error still occured, the shortcode might be from the ConvertKit App for a Legacy Form ID

--- a/includes/class-convertkit-output-restrict-content.php
+++ b/includes/class-convertkit-output-restrict-content.php
@@ -1323,7 +1323,7 @@ class ConvertKit_Output_Restrict_Content {
 			case 'form':
 				// Display the Form.
 				$forms = new ConvertKit_Resource_Forms( 'restrict_content' );
-				$form  = $forms->get_html( $this->resource_id );
+				$form  = $forms->get_html( $this->resource_id, $post_id );
 
 				// If scripts are enabled, output the email login form in a modal, which will be displayed
 				// when the 'log in' link is clicked.

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -311,7 +311,7 @@ class ConvertKit_Output {
 		}
 
 		// Get Form HTML.
-		$form = $this->forms->get_html( $form_id );
+		$form = $this->forms->get_html( $form_id, $post_id );
 
 		// If an error occured, it could be because the specified Form ID for the Post either:
 		// - belongs to another ConvertKit account (i.e. API credentials were changed in the Plugin, but this Post's specified Form was not changed), or
@@ -335,7 +335,7 @@ class ConvertKit_Output {
 			}
 
 			// Get Form HTML.
-			$form = $this->forms->get_html( $form_id );
+			$form = $this->forms->get_html( $form_id, $post_id );
 
 			// If an error occured again, the default form doesn't exist in this ConvertKit account.
 			// Just return the Post Content, unedited.

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -500,12 +500,12 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource_V4 {
 			);
 		}
 
+		// Initialize Settings.
+		$settings = new ConvertKit_Settings();
+
 		// If no uid is present in the Form API data, this is a legacy form that's served by directly fetching the HTML
 		// from forms.kit.com.
 		if ( ! isset( $this->resources[ $id ]['uid'] ) ) {
-			// Initialize Settings.
-			$settings = new ConvertKit_Settings();
-
 			// Bail if no Access Token is specified in the Plugin Settings.
 			if ( ! $settings->has_access_token() ) {
 				return new WP_Error(
@@ -584,6 +584,11 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource_V4 {
 			'data-uid' => $this->resources[ $id ]['uid'],
 			'src'      => $this->resources[ $id ]['embed_js'],
 		);
+
+		// If debugging is enabled, add the post ID to the script.
+		if ( $settings->debug_enabled() ) {
+			$script['data-post-id'] = $post_id;
+		}
 
 		/**
 		 * Filter the form <script> key/value pairs immediately before the script is output.

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -548,7 +548,7 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource_V4 {
 
 					// If debugging is enabled, add the post ID to the script.
 					if ( $settings->debug_enabled() ) {
-						$script['data-post-id'] = $post_id;
+						$script['data-kit-source-post-id'] = $post_id;
 					}
 
 					// Add the script to the scripts array.
@@ -587,7 +587,7 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource_V4 {
 
 		// If debugging is enabled, add the post ID to the script.
 		if ( $settings->debug_enabled() ) {
-			$script['data-post-id'] = $post_id;
+			$script['data-kit-source-post-id'] = $post_id;
 		}
 
 		/**

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -474,10 +474,11 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource_V4 {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @param   int $id     Form ID.
+	 * @param   int $id         Form ID.
+	 * @param   int $post_id    Post ID that requested the Form.
 	 * @return  WP_Error|string
 	 */
-	public function get_html( $id ) {
+	public function get_html( $id, $post_id = 0 ) {
 
 		// Cast ID to integer.
 		$id = absint( $id );
@@ -536,13 +537,22 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource_V4 {
 		if ( $this->resources[ $id ]['format'] !== 'inline' ) {
 			add_filter(
 				'convertkit_output_scripts_footer',
-				function ( $scripts ) use ( $id ) {
+				function ( $scripts ) use ( $id, $post_id, $settings ) {
 
-					$scripts[] = array(
+					// Build script.
+					$script = array(
 						'async'    => true,
 						'data-uid' => $this->resources[ $id ]['uid'],
 						'src'      => $this->resources[ $id ]['embed_js'],
 					);
+
+					// If debugging is enabled, add the post ID to the script.
+					if ( $settings->debug_enabled() ) {
+						$script['data-post-id'] = $post_id;
+					}
+
+					// Add the script to the scripts array.
+					$scripts[] = $script;
 
 					return $scripts;
 


### PR DESCRIPTION
## Summary

Adds a `data-kit-source-post-id` attribute to Form `<script>` tags when the Plugin's Debug setting is enabled, to help identify which Page or Post ID was used to embed a Form.

This was useful when [debugging this issue](https://linear.app/kit/issue/WP-54/wordpress-med-plugin-embedding-modal-forms-to-homepage-when-setting-is), where a home page had two modal form scripts outputting, and it wasn't clear which Posts were responsible for this, given the home page in question output some 30+ different Posts. 

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)