### PR TITLE
JS: Emit `convertkit_subscriber_id_removed_from_url` event

### DIFF
--- a/resources/frontend/js/convertkit.js
+++ b/resources/frontend/js/convertkit.js
@@ -115,6 +115,14 @@ function convertKitRemoveSubscriberIDFromURL( url ) {
 	// Update history.
 	window.history.replaceState( null, title, url_object.pathname + params + url_object.hash );
 
+	// Emit custom event with the removed subscriber ID.
+	convertKitEmitCustomEvent(
+		'convertkit_subscriber_id_removed_from_url',
+		{
+			id: ck_subscriber_id
+		}
+	);
+
 }
 
 /**

--- a/resources/frontend/js/convertkit.js
+++ b/resources/frontend/js/convertkit.js
@@ -117,7 +117,7 @@ function convertKitRemoveSubscriberIDFromURL( url ) {
 
 	// Emit custom event with the removed subscriber ID.
 	convertKitEmitCustomEvent(
-		'convertkit_subscriber_id_removed_from_url',
+		'kit_subscriber_id_removed_from_url',
 		{
 			id: ck_subscriber_id
 		}


### PR DESCRIPTION
## Summary

The Plugin has always removed the `ck_subscriber_id` query param from the URL, storing it in the `ck_subscriber_id` cookie. This approach prevents users from unintentionally sharing URLs containing their `ck_subscriber_id`, for example on social media, where that ID could potentially grant access to gated content on a WordPress site: https://github.com/Kit/convertkit-wordpress/pull/169

Some developers need to access this in JS.  Currently, they may:
- inspect the `ck_subscriber_id` cookie for a value,
- inspect the JS `convertkit` object, which will include a subscriber_id when a valid `ck_subscriber_id` was included in the URL,
- in PHP, leverage the `get_subscriber_id()` method of the `ConvertKit_Subscriber` class

This PR adds a `convertkit_subscriber_id_removed_from_url` event to the next Plugin update, which would further allow developers to fetch the ID using e.g.

```
document.addEventListener('convertkit_subscriber_id_removed_from_url', function(event) {
    console.log( event.detail.id );
});
```

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)