### PR TITLE
Fix: Classic Widget: Fatal Error

### DIFF
--- a/includes/widgets/class-ck-widget-form.php
+++ b/includes/widgets/class-ck-widget-form.php
@@ -78,14 +78,17 @@ class CK_Widget_Form extends WP_Widget {
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'form' ) ); ?>"><?php esc_html_e( 'Form', 'convertkit' ); ?></label>
 			<?php
-			$forms->output_select_field_all(
-				esc_attr( $this->get_field_name( 'form' ) ),
-				esc_attr( $this->get_field_id( 'form' ) ),
-				array(
-					'widefat',
-				),
-				esc_attr( $instance['form'] )
-			);
+			// Check if output_select_field_all() method exists before calling it.
+			if ( method_exists( $forms, 'output_select_field_all' ) ) {
+				$forms->output_select_field_all(
+					esc_attr( $this->get_field_name( 'form' ) ),
+					esc_attr( $this->get_field_id( 'form' ) ),
+					array(
+						'widefat',
+					),
+					esc_attr( $instance['form'] )
+				);
+			}
 			?>
 		</p>
 		<?php

--- a/includes/widgets/class-ck-widget-form.php
+++ b/includes/widgets/class-ck-widget-form.php
@@ -78,17 +78,14 @@ class CK_Widget_Form extends WP_Widget {
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'form' ) ); ?>"><?php esc_html_e( 'Form', 'convertkit' ); ?></label>
 			<?php
-			// Check if output_select_field_all() method exists before calling it.
-			if ( method_exists( $forms, 'output_select_field_all' ) ) {
-				$forms->output_select_field_all(
-					esc_attr( $this->get_field_name( 'form' ) ),
-					esc_attr( $this->get_field_id( 'form' ) ),
-					array(
-						'widefat',
-					),
-					esc_attr( $instance['form'] )
-				);
-			}
+			echo $forms->get_select_field_all( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				esc_attr( $this->get_field_name( 'form' ) ),
+				esc_attr( $this->get_field_id( 'form' ) ),
+				array(
+					'widefat',
+				),
+				esc_attr( $instance['form'] )
+			);
 			?>
 		</p>
 		<?php


### PR DESCRIPTION
## Summary

[Creator reports an issue](https://linear.app/kit/issue/WP-51/wp-medium-fatal-error-message-appearing-for-the-kit-plugin), where they receive "fatal error" emails from WordPress, relating to the classic form widget since updating the Plugin to 2.8.5:

<img width="1273" height="581" alt="Screenshot 2025-07-20 164140" src="https://github.com/user-attachments/assets/13d640b2-265b-448a-bb34-25fdbec0db3b" />

The issue is not replicated locally or in automated tests with 2.8.5 or higher, and the `output_select_field_all` method added in 2.8.5 exists, being used elsewhere in the Plugin without producing an error.

Rolling the Plugin back to 2.8.4 on the creator's site resolved, which is essentially what this PR does with the code change.

Given WordPress now uses the block editor for widgets by default, legacy widget support is maintained for legacy themes and setups. Unless there are more reports relating to the classic form widget, I don't feel further investigation is a priority

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)