### PR TITLE
Forms: Add Align Block Option

### DIFF
--- a/includes/blocks/class-convertkit-block-form.php
+++ b/includes/blocks/class-convertkit-block-form.php
@@ -187,6 +187,9 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 			),
 
 			// get_supports() style, color and typography attributes.
+			'align'                => array(
+				'type' => 'string',
+			),
 			'style'                => array(
 				'type' => 'object',
 			),
@@ -213,6 +216,7 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 	public function get_supports() {
 
 		return array(
+			'align'     => true,
 			'className' => true,
 			'color'     => array(
 				'link'       => false,

--- a/includes/blocks/form/block.json
+++ b/includes/blocks/form/block.json
@@ -23,6 +23,7 @@
         }
     },
     "supports": {
+        "align": true,
         "className": true,
         "color": {
             "link": false,

--- a/resources/backend/js/gutenberg-block-form.js
+++ b/resources/backend/js/gutenberg-block-form.js
@@ -67,7 +67,7 @@ function convertKitGutenbergFormBlockRenderPreview( block, props ) {
 					html: html,
 					title: block.name,
 					styles: [
-					'body{font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif; text-align:center;}',
+					'body{font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif; text-align:center;} form{margin: 0 auto;}',
 					],
 				}
 			)

--- a/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormCest.php
+++ b/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormCest.php
@@ -1319,6 +1319,56 @@ class PageBlockFormCest
 	}
 
 	/**
+	 * Test the Form block's alignment parameter works.
+	 *
+	 * @since   2.8.8
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormBlockWithAlignmentParameter(EndToEndTester $I)
+	{
+		// Setup Plugin and enable debug log.
+		$I->setupKitPlugin($I);
+		$I->setupKitPluginResources($I);
+
+		// It's tricky to interact with Gutenberg's margin and padding pickers, so we programmatically create the Page
+		// instead to then confirm the settings apply on the output.
+		// We don't need to test the margin and padding pickers themselves, as they are Gutenberg supplied components, and our
+		// other End To End tests confirm that the block can be added in Gutenberg etc.
+		$pageID = $I->havePostInDatabase(
+			[
+				'post_type'    => 'page',
+				'post_name'    => 'kit-page-form-block-alignment-param',
+				'post_content' => '<!-- wp:convertkit/form {"form":"' . $_ENV['CONVERTKIT_API_FORM_ID'] . '","align":"right"} /-->',
+				'meta_input'   => [
+					// Configure Kit Plugin to not display a default Form.
+					'_wp_convertkit_post_meta' => [
+						'form'         => '0',
+						'landing_page' => '',
+						'tag'          => '',
+					],
+				],
+			]
+		);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible('body.page-template-default');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that one Kit Form is output in the DOM.
+		// This confirms that there is only one script on the page for this form, which renders the form.
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
+
+		// Confirm that the chosen alignment is applied as a CSS class.
+		$I->seeInSource('<div class="convertkit-form alignright wp-block-convertkit-form"');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.


### PR DESCRIPTION
## Summary

Adds the block editor's [native alignment option](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#align) to Forms:

<img width="878" height="797" alt="Screenshot 2025-08-05 at 19 00 09" src="https://github.com/user-attachments/assets/d740389e-aded-4e64-b593-f7a947d01713" />
<img width="862" height="835" alt="Screenshot 2025-08-05 at 19 00 14" src="https://github.com/user-attachments/assets/b0d2af9c-62ff-4fcf-b700-fc2b872f5b87" />
<img width="925" height="797" alt="Screenshot 2025-08-05 at 19 00 21" src="https://github.com/user-attachments/assets/509b39ac-58a3-41cb-b035-3a447717295d" />

## Testing

- `testFormBlockWithAlignmentParameter`: Test that the alignment class is included in the block's output when an alignment option is chosen

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)