### PR TITLE
Tests: Return Subscriber in `apiCheckSubscriberExists` helper

### DIFF
--- a/includes/blocks/class-convertkit-block-form-builder-field-custom.php
+++ b/includes/blocks/class-convertkit-block-form-builder-field-custom.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Kit Form Builder Text Field Block class.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Kit Form Builder Text Field Block for Gutenberg.
+ *
+ * @package ConvertKit
+ * @author  ConvertKit
+ */
+class ConvertKit_Block_Form_Builder_Field_Custom extends ConvertKit_Block_Form_Builder_Field {
+
+	/**
+	 * Returns this block's programmatic name, excluding the convertkit- prefix.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @return  string
+	 */
+	public function get_name() {
+
+		/**
+		 * This will register as:
+		 * - a Gutenberg block, with the name convertkit/form-builder-field-custom.
+		 */
+		return 'form-builder-field-custom';
+
+	}
+
+	/**
+	 * Returns this block's Title, Icon, Categories, Keywords and properties.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @return  array
+	 */
+	public function get_overview() {
+
+		return array(
+			'title'                   => __( 'Kit Form Builder: Custom Field', 'convertkit' ),
+			'description'             => __( 'Adds a text field to the Kit Form Builder, whose value is stored in a Kit custom field.', 'convertkit' ),
+			'icon'                    => 'resources/backend/images/block-icon-form.svg',
+			'category'                => 'convertkit',
+			'keywords'                => array(
+				__( 'ConvertKit', 'convertkit' ),
+				__( 'Kit', 'convertkit' ),
+				__( 'Custom', 'convertkit' ),
+				__( 'Field', 'convertkit' ),
+			),
+
+			// Function to call when rendering.
+			'render_callback'         => array( $this, 'render' ),
+
+			// Gutenberg: Block Icon in Editor.
+			'gutenberg_icon'          => convertkit_get_file_contents( CONVERTKIT_PLUGIN_PATH . '/resources/backend/images/block-icon-form.svg' ),
+
+			// Gutenberg: Example image showing how this block looks when choosing it in Gutenberg.
+			'gutenberg_example_image' => CONVERTKIT_PLUGIN_URL . 'resources/backend/images/block-example-form-builder-field.png',
+
+			'has_access_token'        => true,
+			'has_resources'           => true,
+		);
+
+	}
+
+	/**
+	 * Returns this block's Attributes
+	 *
+	 * @since   3.0.0
+	 *
+	 * @return  array
+	 */
+	public function get_attributes() {
+
+		return array_merge(
+			parent::get_attributes(),
+			array(
+				'custom_field' => array(
+					'type'    => 'string',
+					'default' => $this->get_default_value( 'custom_field' ),
+				),
+			)
+		);
+
+	}
+
+	/**
+	 * Returns this block's Fields
+	 *
+	 * @since   3.0.0
+	 *
+	 * @return  bool|array
+	 */
+	public function get_fields() {
+
+		// Bail if the request is not for the WordPress Administration or frontend editor.
+		if ( ! WP_ConvertKit()->is_admin_or_frontend_editor() ) {
+			return false;
+		}
+
+		// Get Kit Custom Fields.
+		$custom_fields = new ConvertKit_Resource_Custom_Fields( 'block_form_builder' );
+		$values        = array();
+		if ( $custom_fields->exist() ) {
+			foreach ( $custom_fields->get() as $custom_field ) {
+				$values[ $custom_field['key'] ] = sanitize_text_field( $custom_field['label'] );
+			}
+		}
+
+		// Get fields from parent class.
+		return array_merge(
+			parent::get_fields(),
+			array(
+				'custom_field' => array(
+					'label'       => __( 'Custom Field', 'convertkit' ),
+					'type'        => 'select',
+					'description' => __( 'The Kit custom field to store the text field\'s entered value.', 'convertkit' ),
+					'values'      => $values,
+				),
+			)
+		);
+
+	}
+
+	/**
+	 * Returns this block's UI panels / sections.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @return  bool|array
+	 */
+	public function get_panels() {
+
+		// Bail if the request is not for the WordPress Administration or frontend editor.
+		if ( ! WP_ConvertKit()->is_admin_or_frontend_editor() ) {
+			return false;
+		}
+
+		// Get Panels from parent class.
+		$panels = parent::get_panels();
+
+		// Add attributes to the panel.
+		$panels['general']['fields'][] = 'custom_field';
+
+		return $panels;
+
+	}
+
+	/**
+	 * Returns this block's Default Values
+	 *
+	 * @since   3.0.0
+	 *
+	 * @return  array
+	 */
+	public function get_default_values() {
+
+		return array_merge(
+			array(
+				'custom_field' => '',
+			),
+			parent::get_default_values()
+		);
+
+	}
+
+	/**
+	 * Returns the block's output, based on the supplied configuration attributes.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param   array $atts   Block Attributes.
+	 * @return  string          Output
+	 */
+	public function render( $atts ) {
+
+		$this->field_name = 'custom_fields][' . $atts['custom_field'];
+		$this->field_id   = 'custom_fields_' . $atts['custom_field'];
+		return parent::render( $atts );
+
+	}
+
+}

--- a/includes/blocks/class-convertkit-block-form-builder-field-email.php
+++ b/includes/blocks/class-convertkit-block-form-builder-field-email.php
@@ -24,6 +24,15 @@ class ConvertKit_Block_Form_Builder_Field_Email extends ConvertKit_Block_Form_Bu
 	public $field_name = 'email';
 
 	/**
+	 * The field ID.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @var     string
+	 */
+	public $field_id = 'email';
+
+	/**
 	 * Whether the field is required.
 	 *
 	 * @since   3.0.0

--- a/includes/blocks/class-convertkit-block-form-builder-field-name.php
+++ b/includes/blocks/class-convertkit-block-form-builder-field-name.php
@@ -24,6 +24,15 @@ class ConvertKit_Block_Form_Builder_Field_Name extends ConvertKit_Block_Form_Bui
 	public $field_name = 'first_name';
 
 	/**
+	 * The field ID.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @var     string
+	 */
+	public $field_id = 'first_name';
+
+	/**
 	 * Returns this block's programmatic name, excluding the convertkit- prefix.
 	 *
 	 * @since   3.0.0

--- a/includes/blocks/class-convertkit-block-form-builder-field.php
+++ b/includes/blocks/class-convertkit-block-form-builder-field.php
@@ -27,6 +27,15 @@ class ConvertKit_Block_Form_Builder_Field extends ConvertKit_Block {
 	public $field_name;
 
 	/**
+	 * The field ID.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @var     string
+	 */
+	public $field_id;
+
+	/**
 	 * The type of field to render.
 	 *
 	 * @since   3.0.0
@@ -311,10 +320,10 @@ class ConvertKit_Block_Form_Builder_Field extends ConvertKit_Block {
 			'<div class="%s" style="%s"><label for="%s">%s</label><input type="%s" id="%s" name="convertkit[%s]" %s /></div>',
 			implode( ' ', map_deep( $css_classes, 'sanitize_html_class' ) ),
 			implode( ';', map_deep( $css_styles, 'esc_attr' ) ),
-			esc_attr( sanitize_title( $this->field_name ) ),
+			esc_attr( sanitize_title( $this->field_id ) ),
 			esc_html( $atts['label'] ),
 			esc_attr( $this->field_type ),
-			esc_attr( sanitize_title( $this->field_name ) ),
+			esc_attr( sanitize_title( $this->field_id ) ),
 			esc_attr( $this->field_name ),
 			$this->field_required ? ' required' : ( $atts['required'] ? ' required' : '' )
 		);

--- a/includes/blocks/class-convertkit-block-form-builder.php
+++ b/includes/blocks/class-convertkit-block-form-builder.php
@@ -98,11 +98,18 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 		// Sanitize form data.
 		$form_data = map_deep( wp_unslash( $_REQUEST['convertkit'] ), 'sanitize_text_field' );
 
+		// Build custom fields, if any were specified.
+		$custom_fields = array();
+		if ( array_key_exists( 'custom_fields', $form_data ) ) {
+			$custom_fields = $form_data['custom_fields'];
+		}
+
 		// Create subscriber.
 		$result = $api->create_subscriber(
 			sanitize_email( $form_data['email'] ),
 			array_key_exists( 'first_name', $form_data ) ? $form_data['first_name'] : '',
-			'active'
+			'active',
+			$custom_fields
 		);
 
 		// Bail if an error occured.
@@ -113,6 +120,11 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 		// Store the subscriber ID in a cookie.
 		$subscriber = new ConvertKit_Subscriber();
 		$subscriber->set( $result['subscriber']['id'] );
+
+		// If a tag was specified, add the subscriber to the tag.
+		if ( array_key_exists( 'tag_id', $form_data ) && $form_data['tag_id'] > 0 ) {
+			$api->tag_subscriber( absint( $form_data['tag_id'] ), $result['subscriber']['id'] );
+		}
 
 		// Get the redirect URL, based on whether the form is configured to redirect
 		// or not.
@@ -250,6 +262,10 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 				'type'    => 'string',
 				'default' => $this->get_default_value( 'text_if_subscribed' ),
 			),
+			'tag_id'                     => array(
+				'type'    => 'string',
+				'default' => $this->get_default_value( 'tag_id' ),
+			),
 
 			// get_supports() style, color and typography attributes.
 			'align'                      => array(
@@ -320,6 +336,15 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 			return false;
 		}
 
+		// Get Kit Tags.
+		$tags   = new ConvertKit_Resource_Tags( 'block_form_builder' );
+		$values = array();
+		if ( $tags->exist() ) {
+			foreach ( $tags->get() as $tag ) {
+				$values[ $tag['id'] ] = sanitize_text_field( $tag['name'] );
+			}
+		}
+
 		return array(
 			'redirect'                   => array(
 				'label'       => __( 'Redirect', 'convertkit' ),
@@ -335,6 +360,12 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 				'label'       => __( 'Text', 'convertkit' ),
 				'type'        => 'text',
 				'description' => __( 'The text to display if the visitor is already subscribed.', 'convertkit' ),
+			),
+			'tag_id'                     => array(
+				'label'       => __( 'Tag', 'convertkit' ),
+				'type'        => 'select',
+				'description' => __( 'The Kit tag to add the subscriber to.', 'convertkit' ),
+				'values'      => $values,
 			),
 		);
 
@@ -358,6 +389,7 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 			'general' => array(
 				'label'  => __( 'General', 'convertkit' ),
 				'fields' => array(
+					'tag_id',
 					'redirect',
 					'display_form_if_subscribed',
 					'text_if_subscribed',
@@ -377,6 +409,7 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 	public function get_default_values() {
 
 		return array(
+			'tag_id'                     => '',
 			'redirect'                   => '',
 			'display_form_if_subscribed' => true,
 			'text_if_subscribed'         => 'Thanks for subscribing!',
@@ -519,6 +552,7 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 		$fields = array(
 			'convertkit[post_id]'  => absint( $post_id ),
 			'convertkit[redirect]' => esc_url( $atts['redirect'] ),
+			'convertkit[tag_id]'   => absint( $atts['tag_id'] ),
 			'_wpnonce'             => wp_create_nonce( 'convertkit_block_form_builder' ),
 		);
 		foreach ( $fields as $name => $value ) {

--- a/includes/blocks/form-builder-field-custom/block.json
+++ b/includes/blocks/form-builder-field-custom/block.json
@@ -1,0 +1,57 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 1,
+    "name": "convertkit/form-builder-field-custom",
+    "title": "Kit Form Builder: Custom Field",
+    "category": "kit",
+    "description": "Adds a text field to the Kit Form Builder, whose value is stored in a Kit custom field.",
+    "keywords": [
+        "convertkit",
+        "kit",
+        "custom",
+        "field"
+    ],
+    "textdomain": "convertkit",
+    "parent": [ "convertkit/form-builder" ],
+    "attributes": {
+        "label": {
+            "type": "string"
+        },
+        "custom_field": {
+            "type": "string"
+        },
+        "fontSize": {
+            "type": "string"
+        },
+        "style": {
+            "type": "object"
+        },
+        "backgroundColor": {
+            "type": "string"
+        },
+        "textColor": {
+            "type": "string"
+        },
+        "is_gutenberg_example": {
+            "type": "boolean",
+            "default": false
+        }
+    },
+    "supports": {
+        "align": true,
+        "className": true,
+        "color": {
+            "background": true,
+            "text": true
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true
+        }
+    },
+    "editorScript": "convertkit-gutenberg"
+}

--- a/includes/class-convertkit-resource-custom-fields.php
+++ b/includes/class-convertkit-resource-custom-fields.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * ConvertKit Custom Fields Resource class.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Reads ConvertKit Custom Fields from the options table, and refreshes
+ * ConvertKit Custom Fields data stored locally from the API.
+ *
+ * @since   3.0.0
+ */
+class ConvertKit_Resource_Custom_Fields extends ConvertKit_Resource_V4 {
+
+	/**
+	 * Holds the Settings Key that stores site wide ConvertKit settings
+	 *
+	 * @var     string
+	 */
+	public $settings_name = 'convertkit_custom_fields';
+
+	/**
+	 * The type of resource
+	 *
+	 * @var     string
+	 */
+	public $type = 'custom_fields';
+
+	/**
+	 * Constructor.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param   bool|string $context    Context.
+	 */
+	public function __construct( $context = false ) {
+
+		// Initialize the API if the Access Token has been defined in the Plugin Settings.
+		$settings = new ConvertKit_Settings();
+		if ( $settings->has_access_and_refresh_token() ) {
+			$this->api = new ConvertKit_API_V4(
+				CONVERTKIT_OAUTH_CLIENT_ID,
+				CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
+				$settings->get_access_token(),
+				$settings->get_refresh_token(),
+				$settings->debug_enabled(),
+				$context
+			);
+		}
+
+		// Call parent initialization function.
+		parent::init();
+
+	}
+
+}

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -179,28 +179,29 @@ class WP_ConvertKit {
 	 */
 	private function initialize_global() {
 
-		$this->classes['ajax']                                       = new ConvertKit_AJAX();
-		$this->classes['blocks_convertkit_broadcasts']               = new ConvertKit_Block_Broadcasts();
-		$this->classes['blocks_convertkit_content']                  = new ConvertKit_Block_Content();
-		$this->classes['blocks_convertkit_formtrigger']              = new ConvertKit_Block_Form_Trigger();
-		$this->classes['blocks_convertkit_form']                     = new ConvertKit_Block_Form();
-		$this->classes['blocks_convertkit_form_builder']             = new ConvertKit_Block_Form_Builder();
-		$this->classes['blocks_convertkit_form_builder_field_email'] = new ConvertKit_Block_Form_Builder_Field_Email();
-		$this->classes['blocks_convertkit_form_builder_field_name']  = new ConvertKit_Block_Form_Builder_Field_Name();
-		$this->classes['blocks_convertkit_product']                  = new ConvertKit_Block_Product();
-		$this->classes['block_formatter_form_link']                  = new ConvertKit_Block_Formatter_Form_Link();
-		$this->classes['block_formatter_product_link']               = new ConvertKit_Block_Formatter_Product_Link();
-		$this->classes['pre_publish_action_broadcast_export']        = new ConvertKit_Pre_Publish_Action_Broadcast_Export();
-		$this->classes['broadcasts_exporter']                        = new ConvertKit_Broadcasts_Exporter();
-		$this->classes['broadcasts_importer']                        = new ConvertKit_Broadcasts_Importer();
-		$this->classes['elementor']                                  = new ConvertKit_Elementor();
-		$this->classes['gutenberg']                                  = new ConvertKit_Gutenberg();
-		$this->classes['media_library']                              = new ConvertKit_Media_Library();
-		$this->classes['output_restrict_content']                    = new ConvertKit_Output_Restrict_Content();
-		$this->classes['review_request']                             = new ConvertKit_Review_Request( 'Kit', 'convertkit', CONVERTKIT_PLUGIN_PATH );
-		$this->classes['preview_output']                             = new ConvertKit_Preview_Output();
-		$this->classes['setup']                                      = new ConvertKit_Setup();
-		$this->classes['shortcodes']                                 = new ConvertKit_Shortcodes();
+		$this->classes['ajax']                                        = new ConvertKit_AJAX();
+		$this->classes['blocks_convertkit_broadcasts']                = new ConvertKit_Block_Broadcasts();
+		$this->classes['blocks_convertkit_content']                   = new ConvertKit_Block_Content();
+		$this->classes['blocks_convertkit_formtrigger']               = new ConvertKit_Block_Form_Trigger();
+		$this->classes['blocks_convertkit_form']                      = new ConvertKit_Block_Form();
+		$this->classes['blocks_convertkit_form_builder']              = new ConvertKit_Block_Form_Builder();
+		$this->classes['blocks_convertkit_form_builder_field_email']  = new ConvertKit_Block_Form_Builder_Field_Email();
+		$this->classes['blocks_convertkit_form_builder_field_name']   = new ConvertKit_Block_Form_Builder_Field_Name();
+		$this->classes['blocks_convertkit_form_builder_field_custom'] = new ConvertKit_Block_Form_Builder_Field_Custom();
+		$this->classes['blocks_convertkit_product']                   = new ConvertKit_Block_Product();
+		$this->classes['block_formatter_form_link']                   = new ConvertKit_Block_Formatter_Form_Link();
+		$this->classes['block_formatter_product_link']                = new ConvertKit_Block_Formatter_Product_Link();
+		$this->classes['pre_publish_action_broadcast_export']         = new ConvertKit_Pre_Publish_Action_Broadcast_Export();
+		$this->classes['broadcasts_exporter']                         = new ConvertKit_Broadcasts_Exporter();
+		$this->classes['broadcasts_importer']                         = new ConvertKit_Broadcasts_Importer();
+		$this->classes['elementor']                                   = new ConvertKit_Elementor();
+		$this->classes['gutenberg']                                   = new ConvertKit_Gutenberg();
+		$this->classes['media_library']                               = new ConvertKit_Media_Library();
+		$this->classes['output_restrict_content']                     = new ConvertKit_Output_Restrict_Content();
+		$this->classes['review_request']                              = new ConvertKit_Review_Request( 'Kit', 'convertkit', CONVERTKIT_PLUGIN_PATH );
+		$this->classes['preview_output']                              = new ConvertKit_Preview_Output();
+		$this->classes['setup']                                       = new ConvertKit_Setup();
+		$this->classes['shortcodes']                                  = new ConvertKit_Shortcodes();
 
 		/**
 		 * Initialize integration classes for the frontend web site.

--- a/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormBuilderCest.php
+++ b/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormBuilderCest.php
@@ -64,12 +64,14 @@ class PageBlockFormBuilderCest
 		$this->seeFormBuilderField(
 			$I,
 			fieldName: 'first_name',
+			fieldID: 'first_name',
 			label: 'First name',
 			container: 'div[data-type="convertkit/form-builder"]'
 		);
 		$this->seeFormBuilderField(
 			$I,
 			fieldName: 'email',
+			fieldID: 'email',
 			label: 'Email address',
 			container: 'div[data-type="convertkit/form-builder"]'
 		);
@@ -81,12 +83,14 @@ class PageBlockFormBuilderCest
 		$this->seeFormBuilderField(
 			$I,
 			fieldName: 'first_name',
+			fieldID: 'first_name',
 			label: 'First name',
 			container: 'div.wp-block-convertkit-form-builder'
 		);
 		$this->seeFormBuilderField(
 			$I,
 			fieldName: 'email',
+			fieldID: 'email',
 			label: 'Email address',
 			container: 'div.wp-block-convertkit-form-builder'
 		);
@@ -95,14 +99,18 @@ class PageBlockFormBuilderCest
 		$emailAddress = $I->generateEmailAddress();
 
 		// Submit form.
-		$I->fillField('input[name="convertkit[first_name]"]', 'Kit');
+		$I->fillField('input[name="convertkit[first_name]"]', 'First');
 		$I->fillField('input[name="convertkit[email]"]', $emailAddress);
 		$I->click('div.wp-block-convertkit-form-builder button[type="submit"]');
 
 		// Confirm that the email address was added to Kit.
 		$I->waitForElementVisible('body.page');
 		$I->wait(3);
-		$I->apiCheckSubscriberExists($I, $emailAddress);
+		$I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $emailAddress,
+			firstName: 'First'
+		);
 	}
 
 	/**
@@ -164,12 +172,14 @@ class PageBlockFormBuilderCest
 		$this->seeFormBuilderField(
 			$I,
 			fieldName: 'first_name',
+			fieldID: 'first_name',
 			label: 'Your name',
 			container: 'div[data-type="convertkit/form-builder"]'
 		);
 		$this->seeFormBuilderField(
 			$I,
 			fieldName: 'email',
+			fieldID: 'email',
 			label: 'Your email',
 			container: 'div[data-type="convertkit/form-builder"]'
 		);
@@ -181,12 +191,14 @@ class PageBlockFormBuilderCest
 		$this->seeFormBuilderField(
 			$I,
 			fieldName: 'first_name',
+			fieldID: 'first_name',
 			label: 'Your name',
 			container: 'div.wp-block-convertkit-form-builder'
 		);
 		$this->seeFormBuilderField(
 			$I,
 			fieldName: 'email',
+			fieldID: 'email',
 			label: 'Your email',
 			container: 'div.wp-block-convertkit-form-builder'
 		);
@@ -195,7 +207,7 @@ class PageBlockFormBuilderCest
 		$emailAddress = $I->generateEmailAddress();
 
 		// Submit form.
-		$I->fillField('input[name="convertkit[first_name]"]', 'Kit');
+		$I->fillField('input[name="convertkit[first_name]"]', 'First');
 		$I->fillField('input[name="convertkit[email]"]', $emailAddress);
 		$I->click('div.wp-block-convertkit-form-builder button[type="submit"]');
 		$I->waitForElementVisible('body.page');
@@ -206,7 +218,210 @@ class PageBlockFormBuilderCest
 		$I->see('Welcome to the newsletter!');
 
 		// Confirm that the email address was added to Kit.
-		$I->apiCheckSubscriberExists($I, $emailAddress);
+		$I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $emailAddress,
+			firstName: 'First'
+		);
+	}
+
+	/**
+	 * Test the Form Builder block works when added and a Tag is specified
+	 * to subscribe the subscriber to.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormBuilderBlockWithTaggingEnabled(EndToEndTester $I)
+	{
+		// Setup Plugin and Resources.
+		$I->setupKitPlugin($I);
+		$I->setupKitPluginResources($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Builder: Block: Tagging Enabled'
+		);
+
+		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
+
+		// Add block to Page, setting the Form setting to the value specified in the .env file.
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Form Builder',
+			blockProgrammaticName: 'convertkit-form-builder',
+			blockConfiguration: [
+				'tag_id' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
+			]
+		);
+
+		// Confirm the block template was used as the default.
+		$this->seeFormBuilderBlock($I);
+		$this->seeFormBuilderButtonBlock($I);
+		$this->seeFormBuilderField(
+			$I,
+			fieldName: 'first_name',
+			fieldID: 'first_name',
+			label: 'First name',
+			container: 'div[data-type="convertkit/form-builder"]'
+		);
+		$this->seeFormBuilderField(
+			$I,
+			fieldName: 'email',
+			fieldID: 'email',
+			label: 'Email address',
+			container: 'div[data-type="convertkit/form-builder"]'
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that the Form is output in the DOM.
+		$this->seeFormBuilderField(
+			$I,
+			fieldName: 'first_name',
+			fieldID: 'first_name',
+			label: 'First name',
+			container: 'div.wp-block-convertkit-form-builder'
+		);
+		$this->seeFormBuilderField(
+			$I,
+			fieldName: 'email',
+			fieldID: 'email',
+			label: 'Email address',
+			container: 'div.wp-block-convertkit-form-builder'
+		);
+
+		// Generate email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Submit form.
+		$I->fillField('input[name="convertkit[first_name]"]', 'First');
+		$I->fillField('input[name="convertkit[email]"]', $emailAddress);
+		$I->click('div.wp-block-convertkit-form-builder button[type="submit"]');
+		$I->waitForElementVisible('body.page');
+
+		// Confirm that the email address was added to Kit.
+		$I->waitForElementVisible('body.page');
+		$I->wait(3);
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $emailAddress,
+			firstName: 'First'
+		);
+
+		// Confirm that the subscriber has the tag.
+		$I->apiCheckSubscriberHasTag(
+			$I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
+	}
+
+	/**
+	 * Test the Form Builder block works when a custom field is added.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormBuilderBlockWithCustomField(EndToEndTester $I)
+	{
+		// Setup Plugin and Resources.
+		$I->setupKitPlugin($I);
+		$I->setupKitPluginResources($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Builder: Block: Custom Field'
+		);
+
+		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
+
+		// Add block to Page.
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Form Builder',
+			blockProgrammaticName: 'convertkit-form-builder'
+		);
+
+		// Focus on an inner block, so the Form Builder field blocks are available in the inserter.
+		$I->click('div[data-type="convertkit/form-builder-field-name"]');
+
+		// Add custom field block, mapping its data to the Last Name field in Kit.
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Form Builder: Custom Field',
+			blockProgrammaticName: 'convertkit-form-builder-field-custom',
+			blockConfiguration: [
+				'label'        => [ 'input', 'Last name' ],
+				'custom_field' => [ 'select', 'Last Name' ],
+			]
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that the Form is output in the DOM.
+		$this->seeFormBuilderField(
+			$I,
+			fieldName: 'first_name',
+			fieldID: 'first_name',
+			label: 'First name',
+			container: 'div.wp-block-convertkit-form-builder'
+		);
+		$this->seeFormBuilderField(
+			$I,
+			fieldName: 'custom_fields][last_name',
+			fieldID: 'custom_fields_last_name',
+			label: 'Last name',
+			container: 'div.wp-block-convertkit-form-builder'
+		);
+		$this->seeFormBuilderField(
+			$I,
+			fieldName: 'email',
+			fieldID: 'email',
+			label: 'Email address',
+			container: 'div.wp-block-convertkit-form-builder'
+		);
+
+		// Generate email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Submit form.
+		$I->fillField('input[name="convertkit[first_name]"]', 'First');
+		$I->fillField('input[name="convertkit[custom_fields][last_name]"]', 'Last');
+		$I->fillField('input[name="convertkit[email]"]', $emailAddress);
+		$I->click('div.wp-block-convertkit-form-builder button[type="submit"]');
+
+		// Confirm that the email address was added to Kit.
+		$I->waitForElementVisible('body.page');
+		$I->wait(3);
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $emailAddress,
+			firstName: 'First'
+		);
+
+		// Confirm that the custom field was added to the subscriber.
+		$I->assertEquals('Last', $subscriber['fields']['last_name']);
 	}
 
 	/**
@@ -253,12 +468,14 @@ class PageBlockFormBuilderCest
 		$this->seeFormBuilderField(
 			$I,
 			fieldName: 'first_name',
+			fieldID: 'first_name',
 			label: 'First name',
 			container: 'div[data-type="convertkit/form-builder"]'
 		);
 		$this->seeFormBuilderField(
 			$I,
 			fieldName: 'email',
+			fieldID: 'email',
 			label: 'Email address',
 			container: 'div[data-type="convertkit/form-builder"]'
 		);
@@ -270,12 +487,14 @@ class PageBlockFormBuilderCest
 		$this->seeFormBuilderField(
 			$I,
 			fieldName: 'first_name',
+			fieldID: 'first_name',
 			label: 'First name',
 			container: 'div.wp-block-convertkit-form-builder'
 		);
 		$this->seeFormBuilderField(
 			$I,
 			fieldName: 'email',
+			fieldID: 'email',
 			label: 'Email address',
 			container: 'div.wp-block-convertkit-form-builder'
 		);
@@ -284,7 +503,7 @@ class PageBlockFormBuilderCest
 		$emailAddress = $I->generateEmailAddress();
 
 		// Submit form.
-		$I->fillField('input[name="convertkit[first_name]"]', 'Kit');
+		$I->fillField('input[name="convertkit[first_name]"]', 'First');
 		$I->fillField('input[name="convertkit[email]"]', $emailAddress);
 		$I->click('div.wp-block-convertkit-form-builder button[type="submit"]');
 
@@ -292,7 +511,11 @@ class PageBlockFormBuilderCest
 		$I->waitForElementVisible('body.home');
 
 		// Confirm that the email address was added to Kit.
-		$I->apiCheckSubscriberExists($I, $emailAddress);
+		$I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $emailAddress,
+			firstName: 'First'
+		);
 	}
 
 	/**
@@ -380,6 +603,7 @@ class PageBlockFormBuilderCest
 		// Confirm the Form Field blocks cannot be added, as we are not within the Form Builder block.
 		$I->dontSeeGutenbergBlockAvailable($I, 'Kit Form Field Name', 'convertkit-form-builder-field-name');
 		$I->dontSeeGutenbergBlockAvailable($I, 'Kit Form Field Email', 'convertkit-form-builder-field-email');
+		$I->dontSeeGutenbergBlockAvailable($I, 'Kit Form Field Custom', 'convertkit-form-builder-field-custom');
 
 		// Add the Form Builder block.
 		$I->addGutenbergBlock(
@@ -395,6 +619,7 @@ class PageBlockFormBuilderCest
 		// Confirm the Form Field blocks can be added to the Form Builder block.
 		$I->seeGutenbergBlockAvailable($I, 'Kit Form Field Name', 'convertkit-form-builder-field-name');
 		$I->seeGutenbergBlockAvailable($I, 'Kit Form Field Email', 'convertkit-form-builder-field-email');
+		$I->seeGutenbergBlockAvailable($I, 'Kit Form Field Custom', 'convertkit-form-builder-field-custom');
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -502,15 +727,16 @@ class PageBlockFormBuilderCest
 	 *
 	 * @param   EndToEndTester $I  Tester.
 	 * @param   string         $fieldName  Field name.
+	 * @param   string         $fieldID    Field ID.
 	 * @param   string         $label      Field label.
 	 * @param   bool           $required   Whether the field should be marked `required`.
 	 * @param   string         $container  The container the field should be in.
 	 */
-	private function seeFormBuilderField(EndToEndTester $I, $fieldName, $label, $required = true, $container = 'div')
+	private function seeFormBuilderField(EndToEndTester $I, $fieldName, $fieldID, $label, $required = true, $container = 'div')
 	{
-		$I->seeElementInDOM($container . ' label[for="' . $fieldName . '"]');
-		$I->seeElementInDOM($container . ' input[name="convertkit[' . $fieldName . ']"]' . $required ? '[required]' : '');
-		$I->assertEquals($label, $I->grabTextFrom($container . ' label[for="' . $fieldName . '"]'));
+		$I->seeElementInDOM($container . ' label[for="' . $fieldID . '"]');
+		$I->seeElementInDOM($container . ' input[name="convertkit[' . $fieldName . ']"][id="' . $fieldID . '"]' . $required ? '[required]' : '');
+		$I->assertEquals($label, $I->grabTextFrom($container . ' label[for="' . $fieldID . '"]'));
 	}
 
 	/**

--- a/tests/EndToEnd/integrations/other/ContactForm7FormCest.php
+++ b/tests/EndToEnd/integrations/other/ContactForm7FormCest.php
@@ -70,12 +70,12 @@ class ContactForm7FormCest
 		$I->wait(2);
 
 		// Confirm that the email address was added to Kit.
-		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has the expected form and referrer value set.
 		$I->apiCheckSubscriberHasForm(
 			$I,
-			subscriberID: $subscriberID,
+			subscriberID: $subscriber['id'],
 			formID: $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_ID'],
 			referrer: $_ENV['WORDPRESS_URL'] . $I->grabFromCurrentUrl()
 		);
@@ -142,12 +142,12 @@ class ContactForm7FormCest
 		$I->wait(2);
 
 		// Confirm that the email address was added to Kit.
-		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the tag.
 		$I->apiCheckSubscriberHasTag(
 			$I,
-			subscriberID: $subscriberID,
+			subscriberID: $subscriber['id'],
 			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
 		);
 	}
@@ -181,12 +181,12 @@ class ContactForm7FormCest
 		$I->wait(2);
 
 		// Confirm that the email address was added to Kit.
-		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the sequence.
 		$I->apiCheckSubscriberHasSequence(
 			$I,
-			subscriberID: $subscriberID,
+			subscriberID: $subscriber['id'],
 			sequenceID: $_ENV['CONVERTKIT_API_SEQUENCE_ID']
 		);
 	}

--- a/tests/EndToEnd/integrations/other/ForminatorCest.php
+++ b/tests/EndToEnd/integrations/other/ForminatorCest.php
@@ -345,12 +345,12 @@ class ForminatorCest
 		$I->wait(2);
 
 		// Confirm that the email address was added to Kit.
-		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the sequence.
 		$I->apiCheckSubscriberHasSequence(
 			$I,
-			subscriberID: $subscriberID,
+			subscriberID: $subscriber['id'],
 			sequenceID: $_ENV['CONVERTKIT_API_SEQUENCE_ID']
 		);
 	}

--- a/tests/EndToEnd/integrations/other/ForminatorCest.php
+++ b/tests/EndToEnd/integrations/other/ForminatorCest.php
@@ -70,12 +70,12 @@ class ForminatorCest
 		$I->wait(2);
 
 		// Confirm that the email address was added to Kit.
-		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has the expected form and referrer value set.
 		$I->apiCheckSubscriberHasForm(
 			$I,
-			subscriberID: $subscriberID,
+			subscriberID: $subscriber['id'],
 			formID: $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_ID'],
 			referrer: $_ENV['WORDPRESS_URL'] . $I->grabFromCurrentUrl()
 		);
@@ -142,12 +142,12 @@ class ForminatorCest
 		$I->wait(2);
 
 		// Confirm that the email address was added to Kit.
-		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the tag.
 		$I->apiCheckSubscriberHasTag(
 			$I,
-			subscriberID: $subscriberID,
+			subscriberID: $subscriber['id'],
 			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
 		);
 	}
@@ -181,10 +181,10 @@ class ForminatorCest
 		$I->wait(2);
 
 		// Confirm that the email address was added to Kit.
-		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the sequence.
-		$I->apiCheckSubscriberHasSequence($I, $subscriberID, $_ENV['CONVERTKIT_API_SEQUENCE_ID']);
+		$I->apiCheckSubscriberHasSequence($I, $subscriber['id'], $_ENV['CONVERTKIT_API_SEQUENCE_ID']);
 	}
 
 	/**
@@ -306,12 +306,12 @@ class ForminatorCest
 		$I->wait(2);
 
 		// Confirm that the email address was added to Kit.
-		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the tag.
 		$I->apiCheckSubscriberHasTag(
 			$I,
-			subscriberID: $subscriberID,
+			subscriberID: $subscriber['id'],
 			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
 		);
 	}

--- a/tests/EndToEnd/integrations/wlm/WishListMemberCest.php
+++ b/tests/EndToEnd/integrations/wlm/WishListMemberCest.php
@@ -111,10 +111,10 @@ class WishListMemberCest
 		$this->_assignLevelToUser($I, $wlmLevelID, $userID);
 
 		// Confirm that the email address was added to Kit.
-		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check subscriber assigned to tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
 	}
 
 	/**
@@ -143,10 +143,10 @@ class WishListMemberCest
 		$this->_assignLevelToUser($I, $wlmLevelID, $userID);
 
 		// Confirm that the email address was added to Kit.
-		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the sequence.
-		$I->apiCheckSubscriberHasSequence($I, $subscriberID, $_ENV['CONVERTKIT_API_SEQUENCE_ID']);
+		$I->apiCheckSubscriberHasSequence($I, $subscriber['id'], $_ENV['CONVERTKIT_API_SEQUENCE_ID']);
 	}
 
 	/**
@@ -174,7 +174,7 @@ class WishListMemberCest
 		$this->_assignLevelToUser($I, $wlmLevelID, $userID);
 
 		// Confirm that the email address was added to Kit.
-		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+		$I->apiCheckSubscriberExists($I, $emailAddress);
 	}
 
 	/**
@@ -279,10 +279,10 @@ class WishListMemberCest
 		$this->_removeLevelFromUser($I, $wlmLevelID, $userID);
 
 		// Confirm that the email address was added to Kit.
-		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check subscriber assigned to tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
 	}
 
 	/**
@@ -317,10 +317,10 @@ class WishListMemberCest
 		$this->_removeLevelFromUser($I, $wlmLevelID, $userID);
 
 		// Confirm that the email address was added to Kit.
-		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the sequence.
-		$I->apiCheckSubscriberHasSequence($I, $subscriberID, $_ENV['CONVERTKIT_API_SEQUENCE_ID']);
+		$I->apiCheckSubscriberHasSequence($I, $subscriber['id'], $_ENV['CONVERTKIT_API_SEQUENCE_ID']);
 	}
 
 	/**
@@ -349,7 +349,7 @@ class WishListMemberCest
 		$this->_assignLevelToUser($I, $wlmLevelID, $userID);
 
 		// Confirm that the email address was added to Kit.
-		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+		$I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Remove level from user.
 		$this->_removeLevelFromUser($I, $wlmLevelID, $userID);

--- a/tests/Support/Helper/KitAPI.php
+++ b/tests/Support/Helper/KitAPI.php
@@ -42,10 +42,12 @@ class KitAPI extends \Codeception\Module
 	/**
 	 * Check the given email address exists as a subscriber.
 	 *
-	 * @param   EndToEndTester $I             EndToEndTester.
+	 * @param   EndToEndTester $I              EndToEndTester.
 	 * @param   string         $emailAddress   Email Address.
+	 * @param   string         $firstName      First Name (false = don't check name matches).
+	 * @return  array                          Subscriber.
 	 */
-	public function apiCheckSubscriberExists($I, $emailAddress)
+	public function apiCheckSubscriberExists($I, $emailAddress, $firstName = false)
 	{
 		// Run request.
 		$results = $this->apiRequest(
@@ -64,8 +66,13 @@ class KitAPI extends \Codeception\Module
 		$I->assertGreaterThan(0, $results['pagination']['total_count']);
 		$I->assertEquals($emailAddress, $results['subscribers'][0]['email_address']);
 
+		// If defined, check that the name matches for the subscriber.
+		if ($firstName) {
+			$I->assertEquals($firstName, $results['subscribers'][0]['first_name']);
+		}
+
 		// Return subscriber ID.
-		return $results['subscribers'][0]['id'];
+		return $results['subscribers'][0];
 	}
 
 	/**

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -65,6 +65,7 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-output-restric
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-post.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-preview-output.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-resource-creator-network-recommendations.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-resource-custom-fields.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-resource-forms.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-resource-landing-pages.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-resource-posts.php';
@@ -89,6 +90,7 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/blocks/class-convertkit-block-f
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/blocks/class-convertkit-block-form-builder-field.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/blocks/class-convertkit-block-form-builder-field-email.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/blocks/class-convertkit-block-form-builder-field-name.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/blocks/class-convertkit-block-form-builder-field-custom.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/blocks/class-convertkit-block-product.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/block-formatters/class-convertkit-block-formatter.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/block-formatters/class-convertkit-block-formatter-form-link.php';


### PR DESCRIPTION
## Summary

Returns the subscriber when using `apiCheckSubscriberExists()`, following how this is done for the other Plugins test libraries, such as WooCommerce.

This is used in #871 to test that a subscriber's first name custom field values were correctly set.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)