### PR TITLE
Block Editor: Form Builder: Tag Option

### DIFF
--- a/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormBuilderCest.php
+++ b/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormBuilderCest.php
@@ -271,14 +271,14 @@ class PageBlockFormBuilderCest
 			$I,
 			fieldName: 'first_name',
 			fieldID: 'first_name',
-			label: 'Your name',
+			label: 'First name',
 			container: 'div[data-type="convertkit/form-builder"]'
 		);
 		$this->seeFormBuilderField(
 			$I,
 			fieldName: 'email',
 			fieldID: 'email',
-			label: 'Your email',
+			label: 'Email address',
 			container: 'div[data-type="convertkit/form-builder"]'
 		);
 
@@ -290,14 +290,14 @@ class PageBlockFormBuilderCest
 			$I,
 			fieldName: 'first_name',
 			fieldID: 'first_name',
-			label: 'Your name',
+			label: 'First name',
 			container: 'div.wp-block-convertkit-form-builder'
 		);
 		$this->seeFormBuilderField(
 			$I,
 			fieldName: 'email',
 			fieldID: 'email',
-			label: 'Your email',
+			label: 'Email address',
 			container: 'div.wp-block-convertkit-form-builder'
 		);
 
@@ -310,13 +310,10 @@ class PageBlockFormBuilderCest
 		$I->click('div.wp-block-convertkit-form-builder button[type="submit"]');
 		$I->waitForElementVisible('body.page');
 
-		// Check that the form no longer displays and the message displays.
-		$I->dontSeeElementInDOM('input[name="convertkit[first_name]"]');
-		$I->dontSeeElementInDOM('input[name="convertkit[email]"]');
-		$I->see('Welcome to the newsletter!');
-
 		// Confirm that the email address was added to Kit.
-		$I->apiCheckSubscriberExists(
+		$I->waitForElementVisible('body.page');
+		$I->wait(3);
+		$subscriber = $I->apiCheckSubscriberExists(
 			$I,
 			emailAddress: $emailAddress,
 			firstName: 'First'


### PR DESCRIPTION
## Summary

Adds an optional setting to assign subscribers to a tag when they subscribe using the Form Builder's subscription form:

<img width="1066" height="677" alt="Screenshot 2025-08-11 at 21 33 16" src="https://github.com/user-attachments/assets/d558ed98-2144-482b-9a47-caa57a0d37f3" />

## Testing

- `testFormBuilderBlockWithTaggingEnabled`: Test that the subscriber is tagged with the selected tag when configured on the Form Builder

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)