### PR TITLE
Block Editor: Form Builder: Add reCAPTCHA support

### DIFF
--- a/includes/blocks/class-convertkit-block-form-builder.php
+++ b/includes/blocks/class-convertkit-block-form-builder.php
@@ -84,7 +84,7 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 		if ( ! $settings->has_access_and_refresh_token() ) {
 			return;
 		}
-		
+
 		// Check reCAPTCHA.
 		$recaptcha          = new ConvertKit_Recaptcha();
 		$recaptcha_response = $recaptcha->verify_recaptcha(
@@ -94,11 +94,8 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 
 		// Bail if reCAPTCHA failed.
 		if ( is_wp_error( $recaptcha_response ) ) {
-			var_dump( $recaptcha_response );
 			return;
 		}
-
-		die('Passed reCAPTCHA');
 
 		// Initialize the API.
 		$api = new ConvertKit_API_V4(
@@ -528,8 +525,8 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 
 		// Add reCAPTCHA attributes to button.
 		return str_replace(
-			'class="',
-			'data-sitekey="' . esc_attr( $settings->recaptcha_site_key() ) . '" data-callback="convertKitRecaptchaFormSubmit" data-action="convertkit_form_builder" class="g-recaptcha ',
+			'<button type="submit" class="',
+			'<button type="submit" data-sitekey="' . esc_attr( $settings->recaptcha_site_key() ) . '" data-callback="convertKitRecaptchaFormSubmit" data-action="convertkit_form_builder" class="g-recaptcha ',
 			$block_content
 		);
 


### PR DESCRIPTION
## Summary

Enables Google's reCAPTCHA on the Form Builder, if the site and secret key is defined at `Kit > Settings > reCAPTCHA`

## Testing

`testFormBuilderWithRecaptchaEnabled`: Test the Form Builder block works when reCAPTCHA is enabled.
`testFormBuilderWithRecaptchaEnabledAndHighMinimumScore`: Test the Form Builder block works when reCAPTCHA is enabled, and the minimum score is set to 0.99.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)