### PR TITLE
Settings: Improve wording on Disable Scripts + CSS

### DIFF
--- a/admin/section/class-convertkit-admin-section-general.php
+++ b/admin/section/class-convertkit-admin-section-general.php
@@ -914,7 +914,7 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 			'no_scripts',
 			'on',
 			$this->settings->scripts_disabled(),
-			esc_html__( 'Prevent plugin from loading JavaScript files. This will disable the custom content and tagging features of the plugin. Does not apply to landing pages. Use with caution!', 'convertkit' )
+			esc_html__( 'Prevent plugin JavaScript files loading on the frontend site. This will disable the custom content and tagging features of the plugin. Does not apply to embedding forms or landing pages. Use with caution!', 'convertkit' )
 		);
 
 	}
@@ -939,6 +939,7 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 					esc_url( convertkit_get_form_editor_url() ),
 					esc_html__( 'Kit form editor', 'convertkit' )
 				),
+				esc_html__( 'For creators who require form designs to follow their WordPress theme, use the Kit Form Builder block in the block editor.', 'convertkit' ),
 				sprintf(
 					'%s <a href="https://wordpress.org/plugins/contact-form-7/" target="_blank">Contact Form 7</a>, <a href="https://wordpress.org/plugins/convertkit-gravity-forms/" target="_blank">Gravity Forms</a> %s <a href="https://wordpress.org/plugins/integrate-convertkit-wpforms/" target="_blank">WPForms</a> %s',
 					esc_html__( 'For developers who require custom form designs through use of CSS, consider using the', 'convertkit' ),

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -772,7 +772,14 @@ class ConvertKit_Output {
 		}
 
 		// Get ConvertKit Settings and Post's Settings.
-		$settings        = new ConvertKit_Settings();
+		$settings = new ConvertKit_Settings();
+
+		// Bail if the no scripts setting is enabled.
+		if ( $settings->scripts_disabled() ) {
+			return;
+		}
+
+		// Get ConvertKit Post's Settings.
 		$convertkit_post = new ConvertKit_Post( $post->ID );
 
 		// Register scripts that we might use.
@@ -793,11 +800,6 @@ class ConvertKit_Output {
 				'subscriber_id' => $this->subscriber_id,
 			)
 		);
-
-		// Bail if the no scripts setting is enabled.
-		if ( $settings->scripts_disabled() ) {
-			return;
-		}
 
 		// Enqueue.
 		wp_enqueue_script( 'convertkit-js' );


### PR DESCRIPTION
## Summary

The creator in [this ticket](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/conversation/215470301131730?view=List) was understandably confused when their Modal Form JS still loaded when they had enabled the 'Disable scripts' setting in the Plugin.

The Plugin always loads JS for Kit Forms and Landing Pages, to ensure forms works.

This PR resolves by:
- making the setting's description clearer,
- adding a suggestion to use the Form Builder block if creators are looking to disable styles to attempt to get a form that follows their WordPress theme,
- checks earlier to see if JS is disabled when setting up the Plugin's `convertkit.js` script 

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)