### PR TITLE
Form Builder: Custom Field: Add support for field type

### DIFF
--- a/includes/blocks/class-convertkit-block-form-builder-field-custom.php
+++ b/includes/blocks/class-convertkit-block-form-builder-field-custom.php
@@ -79,6 +79,10 @@ class ConvertKit_Block_Form_Builder_Field_Custom extends ConvertKit_Block_Form_B
 		return array_merge(
 			parent::get_attributes(),
 			array(
+				'type'         => array(
+					'type'    => 'string',
+					'default' => 'text',
+				),
 				'custom_field' => array(
 					'type'    => 'string',
 					'default' => $this->get_default_value( 'custom_field' ),
@@ -115,10 +119,21 @@ class ConvertKit_Block_Form_Builder_Field_Custom extends ConvertKit_Block_Form_B
 		return array_merge(
 			parent::get_fields(),
 			array(
+				'type'         => array(
+					'label'       => __( 'Type', 'convertkit' ),
+					'type'        => 'select',
+					'description' => __( 'The type of field to display.', 'convertkit' ),
+					'values'      => array(
+						'text'     => __( 'Text', 'convertkit' ),
+						'textarea' => __( 'Textarea', 'convertkit' ),
+						'number'   => __( 'Number', 'convertkit' ),
+						'url'      => __( 'URL', 'convertkit' ),
+					),
+				),
 				'custom_field' => array(
 					'label'       => __( 'Custom Field', 'convertkit' ),
 					'type'        => 'select',
-					'description' => __( 'The Kit custom field to store the text field\'s entered value.', 'convertkit' ),
+					'description' => __( 'The Kit custom field to store this field\'s entered value.', 'convertkit' ),
 					'values'      => $values,
 				),
 			)
@@ -144,6 +159,7 @@ class ConvertKit_Block_Form_Builder_Field_Custom extends ConvertKit_Block_Form_B
 		$panels = parent::get_panels();
 
 		// Add attributes to the panel.
+		$panels['general']['fields'][] = 'type';
 		$panels['general']['fields'][] = 'custom_field';
 
 		return $panels;
@@ -161,6 +177,7 @@ class ConvertKit_Block_Form_Builder_Field_Custom extends ConvertKit_Block_Form_B
 
 		return array_merge(
 			array(
+				'type'         => 'text',
 				'custom_field' => '',
 			),
 			parent::get_default_values()
@@ -180,6 +197,7 @@ class ConvertKit_Block_Form_Builder_Field_Custom extends ConvertKit_Block_Form_B
 
 		$this->field_name = 'custom_fields][' . $atts['custom_field'];
 		$this->field_id   = 'custom_fields_' . $atts['custom_field'];
+		$this->field_type = $atts['type'];
 		return parent::render( $atts );
 
 	}

--- a/includes/blocks/class-convertkit-block-form-builder-field.php
+++ b/includes/blocks/class-convertkit-block-form-builder-field.php
@@ -42,7 +42,7 @@ class ConvertKit_Block_Form_Builder_Field extends ConvertKit_Block {
 	 *
 	 * @var     string
 	 */
-	private $field_type = 'text';
+	public $field_type = 'text';
 
 	/**
 	 * Whether the field is required.
@@ -315,17 +315,35 @@ class ConvertKit_Block_Form_Builder_Field extends ConvertKit_Block {
 		$css_classes = $this->get_css_classes( array( 'wp-block-convertkit-form-builder-field', 'convertkit-form-builder-field' ) );
 		$css_styles  = $this->get_css_styles( $atts );
 
+		// Build input / textarea.
+		switch ( $this->field_type ) {
+			case 'textarea':
+				$field = sprintf(
+					'<textarea id="%s" name="convertkit[%s]" %s></textarea>',
+					esc_attr( sanitize_title( $this->field_id ) ),
+					esc_attr( $this->field_name ),
+					$this->field_required ? ' required' : ( $atts['required'] ? ' required' : '' )
+				);
+				break;
+			default:
+				$field = sprintf(
+					'<input type="%s" id="%s" name="convertkit[%s]" %s />',
+					esc_attr( $this->field_type ),
+					esc_attr( sanitize_title( $this->field_id ) ),
+					esc_attr( $this->field_name ),
+					$this->field_required ? ' required' : ( $atts['required'] ? ' required' : '' )
+				);
+				break;
+		}
+
 		// Build field HTML.
 		$html = sprintf(
-			'<div class="%s" style="%s"><label for="%s">%s</label><input type="%s" id="%s" name="convertkit[%s]" %s /></div>',
+			'<div class="%s" style="%s"><label for="%s">%s</label>%s</div>',
 			implode( ' ', map_deep( $css_classes, 'sanitize_html_class' ) ),
 			implode( ';', map_deep( $css_styles, 'esc_attr' ) ),
 			esc_attr( sanitize_title( $this->field_id ) ),
 			esc_html( $atts['label'] ),
-			esc_attr( $this->field_type ),
-			esc_attr( sanitize_title( $this->field_id ) ),
-			esc_attr( $this->field_name ),
-			$this->field_required ? ' required' : ( $atts['required'] ? ' required' : '' )
+			$field
 		);
 
 		/**

--- a/resources/frontend/css/form-builder.css
+++ b/resources/frontend/css/form-builder.css
@@ -2,9 +2,11 @@
  * Define some sensible default styles for the form elements,
  * in case a theme doesn't define them.
  */
-.wp-block-convertkit-form-builder-field input {
+.wp-block-convertkit-form-builder-field input,
+.wp-block-convertkit-form-builder-field textarea {
 	width: 100%;
 	margin: 0 0 20px 0;
 	padding: 10px;
 	box-sizing: border-box;
+	font-family: inherit;
 }

--- a/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormBuilderCest.php
+++ b/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormBuilderCest.php
@@ -63,6 +63,7 @@ class PageBlockFormBuilderCest
 		$this->seeFormBuilderButtonBlock($I);
 		$this->seeFormBuilderField(
 			$I,
+			fieldType: 'text',
 			fieldName: 'first_name',
 			fieldID: 'first_name',
 			label: 'First name',
@@ -70,6 +71,7 @@ class PageBlockFormBuilderCest
 		);
 		$this->seeFormBuilderField(
 			$I,
+			fieldType: 'email',
 			fieldName: 'email',
 			fieldID: 'email',
 			label: 'Email address',
@@ -82,6 +84,7 @@ class PageBlockFormBuilderCest
 		// Confirm that the Form is output in the DOM.
 		$this->seeFormBuilderField(
 			$I,
+			fieldType: 'text',
 			fieldName: 'first_name',
 			fieldID: 'first_name',
 			label: 'First name',
@@ -89,6 +92,7 @@ class PageBlockFormBuilderCest
 		);
 		$this->seeFormBuilderField(
 			$I,
+			fieldType: 'email',
 			fieldName: 'email',
 			fieldID: 'email',
 			label: 'Email address',
@@ -171,6 +175,7 @@ class PageBlockFormBuilderCest
 		$this->seeFormBuilderButtonBlock($I);
 		$this->seeFormBuilderField(
 			$I,
+			fieldType: 'text',
 			fieldName: 'first_name',
 			fieldID: 'first_name',
 			label: 'Your name',
@@ -178,6 +183,7 @@ class PageBlockFormBuilderCest
 		);
 		$this->seeFormBuilderField(
 			$I,
+			fieldType: 'email',
 			fieldName: 'email',
 			fieldID: 'email',
 			label: 'Your email',
@@ -190,6 +196,7 @@ class PageBlockFormBuilderCest
 		// Confirm that the Form is output in the DOM.
 		$this->seeFormBuilderField(
 			$I,
+			fieldType: 'text',
 			fieldName: 'first_name',
 			fieldID: 'first_name',
 			label: 'Your name',
@@ -197,6 +204,7 @@ class PageBlockFormBuilderCest
 		);
 		$this->seeFormBuilderField(
 			$I,
+			fieldType: 'email',
 			fieldName: 'email',
 			fieldID: 'email',
 			label: 'Your email',
@@ -269,6 +277,7 @@ class PageBlockFormBuilderCest
 		$this->seeFormBuilderButtonBlock($I);
 		$this->seeFormBuilderField(
 			$I,
+			fieldType: 'text',
 			fieldName: 'first_name',
 			fieldID: 'first_name',
 			label: 'First name',
@@ -276,6 +285,7 @@ class PageBlockFormBuilderCest
 		);
 		$this->seeFormBuilderField(
 			$I,
+			fieldType: 'email',
 			fieldName: 'email',
 			fieldID: 'email',
 			label: 'Email address',
@@ -288,6 +298,7 @@ class PageBlockFormBuilderCest
 		// Confirm that the Form is output in the DOM.
 		$this->seeFormBuilderField(
 			$I,
+			fieldType: 'text',
 			fieldName: 'first_name',
 			fieldID: 'first_name',
 			label: 'First name',
@@ -295,6 +306,7 @@ class PageBlockFormBuilderCest
 		);
 		$this->seeFormBuilderField(
 			$I,
+			fieldType: 'email',
 			fieldName: 'email',
 			fieldID: 'email',
 			label: 'Email address',
@@ -371,6 +383,7 @@ class PageBlockFormBuilderCest
 		$this->seeFormBuilderButtonBlock($I);
 		$this->seeFormBuilderField(
 			$I,
+			fieldType: 'text',
 			fieldName: 'first_name',
 			fieldID: 'first_name',
 			label: 'First name',
@@ -378,6 +391,7 @@ class PageBlockFormBuilderCest
 		);
 		$this->seeFormBuilderField(
 			$I,
+			fieldType: 'email',
 			fieldName: 'email',
 			fieldID: 'email',
 			label: 'Email address',
@@ -390,6 +404,7 @@ class PageBlockFormBuilderCest
 		// Confirm that the Form is output in the DOM.
 		$this->seeFormBuilderField(
 			$I,
+			fieldType: 'text',
 			fieldName: 'first_name',
 			fieldID: 'first_name',
 			label: 'First name',
@@ -397,6 +412,7 @@ class PageBlockFormBuilderCest
 		);
 		$this->seeFormBuilderField(
 			$I,
+			fieldType: 'email',
 			fieldName: 'email',
 			fieldID: 'email',
 			label: 'Email address',
@@ -430,7 +446,7 @@ class PageBlockFormBuilderCest
 	}
 
 	/**
-	 * Test the Form Builder block works when a custom field is added.
+	 * Test the Form Builder block works when custom fields are added.
 	 *
 	 * @since   3.0.0
 	 *
@@ -464,19 +480,46 @@ class PageBlockFormBuilderCest
 			blockProgrammaticName: 'convertkit-form-builder'
 		);
 
-		// Focus on an inner block, so the Form Builder field blocks are available in the inserter.
-		$I->click('div[data-type="convertkit/form-builder-field-name"]');
+		// Define custom fields to add to the form.
+		$customFields = [
+			'last_name'    => [
+				'label' => 'Last Name',
+				'type'  => 'text',
+				'value' => 'Last',
+			],
+			'phone_number' => [
+				'label' => 'Phone Number',
+				'type'  => 'number',
+				'value' => '1234567890',
+			],
+			'notes'        => [
+				'label' => 'Notes',
+				'type'  => 'textarea',
+				'value' => 'Notes',
+			],
+			'url'          => [
+				'label' => 'URL',
+				'type'  => 'url',
+				'value' => 'https://kit.com',
+			],
+		];
 
-		// Add custom field block, mapping its data to the Last Name field in Kit.
-		$I->addGutenbergBlock(
-			$I,
-			blockName: 'Kit Form Builder: Custom Field',
-			blockProgrammaticName: 'convertkit-form-builder-field-custom',
-			blockConfiguration: [
-				'label'        => [ 'input', 'Last name' ],
-				'custom_field' => [ 'select', 'Last Name' ],
-			]
-		);
+		foreach ( $customFields as $field ) {
+			// Focus on an inner block, so the Form Builder field blocks are available in the inserter.
+			$I->click('div[data-type="convertkit/form-builder-field-name"]');
+
+			// Add custom field block, mapping its data to the Last Name field in Kit.
+			$I->addGutenbergBlock(
+				$I,
+				blockName: 'Kit Form Builder: Custom Field',
+				blockProgrammaticName: 'convertkit-form-builder-field-custom',
+				blockConfiguration: [
+					'label'        => [ 'input', $field['label'] ],
+					'type'         => [ 'select', $field['type'] ],
+					'custom_field' => [ 'select', $field['label'] ],
+				]
+			);
+		}
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -484,6 +527,7 @@ class PageBlockFormBuilderCest
 		// Confirm that the Form is output in the DOM.
 		$this->seeFormBuilderField(
 			$I,
+			fieldType: 'text',
 			fieldName: 'first_name',
 			fieldID: 'first_name',
 			label: 'First name',
@@ -491,26 +535,32 @@ class PageBlockFormBuilderCest
 		);
 		$this->seeFormBuilderField(
 			$I,
-			fieldName: 'custom_fields][last_name',
-			fieldID: 'custom_fields_last_name',
-			label: 'Last name',
-			container: 'div.wp-block-convertkit-form-builder'
-		);
-		$this->seeFormBuilderField(
-			$I,
+			fieldType: 'email',
 			fieldName: 'email',
 			fieldID: 'email',
 			label: 'Email address',
 			container: 'div.wp-block-convertkit-form-builder'
 		);
+		foreach ( $customFields as $key => $field ) {
+			$this->seeFormBuilderField(
+				$I,
+				fieldType: $field['type'],
+				fieldName: 'custom_fields][' . $key,
+				fieldID: 'custom_fields_' . $key,
+				label: $field['label'],
+				container: 'div.wp-block-convertkit-form-builder'
+			);
+		}
 
 		// Generate email address for this test.
 		$emailAddress = $I->generateEmailAddress();
 
 		// Submit form.
 		$I->fillField('input[name="convertkit[first_name]"]', 'First');
-		$I->fillField('input[name="convertkit[custom_fields][last_name]"]', 'Last');
 		$I->fillField('input[name="convertkit[email]"]', $emailAddress);
+		foreach ( $customFields as $key => $field ) {
+			$I->fillField('[name="convertkit[custom_fields][' . $key . ']"]', $field['value']);
+		}
 		$I->click('div.wp-block-convertkit-form-builder button[type="submit"]');
 
 		// Confirm that the email address was added to Kit.
@@ -522,8 +572,10 @@ class PageBlockFormBuilderCest
 			firstName: 'First'
 		);
 
-		// Confirm that the custom field was added to the subscriber.
-		$I->assertEquals('Last', $subscriber['fields']['last_name']);
+		// Confirm that the custom fields were added to the subscriber.
+		foreach ( $customFields as $key => $field ) {
+			$I->assertEquals($field['value'], $subscriber['fields'][ $key ]);
+		}
 	}
 
 	/**
@@ -569,6 +621,7 @@ class PageBlockFormBuilderCest
 		$this->seeFormBuilderButtonBlock($I);
 		$this->seeFormBuilderField(
 			$I,
+			fieldType: 'text',
 			fieldName: 'first_name',
 			fieldID: 'first_name',
 			label: 'First name',
@@ -576,6 +629,7 @@ class PageBlockFormBuilderCest
 		);
 		$this->seeFormBuilderField(
 			$I,
+			fieldType: 'email',
 			fieldName: 'email',
 			fieldID: 'email',
 			label: 'Email address',
@@ -588,6 +642,7 @@ class PageBlockFormBuilderCest
 		// Confirm that the Form is output in the DOM.
 		$this->seeFormBuilderField(
 			$I,
+			fieldType: 'text',
 			fieldName: 'first_name',
 			fieldID: 'first_name',
 			label: 'First name',
@@ -595,6 +650,7 @@ class PageBlockFormBuilderCest
 		);
 		$this->seeFormBuilderField(
 			$I,
+			fieldType: 'email',
 			fieldName: 'email',
 			fieldID: 'email',
 			label: 'Email address',
@@ -958,16 +1014,26 @@ class PageBlockFormBuilderCest
 	 * @since   3.0.0
 	 *
 	 * @param   EndToEndTester $I  Tester.
+	 * @param   string         $fieldType  Field type.
 	 * @param   string         $fieldName  Field name.
 	 * @param   string         $fieldID    Field ID.
 	 * @param   string         $label      Field label.
 	 * @param   bool           $required   Whether the field should be marked `required`.
 	 * @param   string         $container  The container the field should be in.
 	 */
-	private function seeFormBuilderField(EndToEndTester $I, $fieldName, $fieldID, $label, $required = true, $container = 'div')
+	private function seeFormBuilderField(EndToEndTester $I, $fieldType, $fieldName, $fieldID, $label, $required = true, $container = 'div')
 	{
+		// Check field exists with correct attributes.
+		switch ( $fieldType ) {
+			case 'textarea':
+				$I->seeElementInDOM($container . ' textarea[name="convertkit[' . $fieldName . ']"][id="' . $fieldID . '"]' . $required ? '[required]' : '');
+				break;
+			default:
+				$I->seeElementInDOM($container . ' input[name="convertkit[' . $fieldName . ']"][type="' . $fieldType . '"][id="' . $fieldID . '"]' . $required ? '[required]' : '');
+		}
+
+		// Check label exists with correct text.
 		$I->seeElementInDOM($container . ' label[for="' . $fieldID . '"]');
-		$I->seeElementInDOM($container . ' input[name="convertkit[' . $fieldName . ']"][id="' . $fieldID . '"]' . $required ? '[required]' : '');
 		$I->assertEquals($label, $I->grabTextFrom($container . ' label[for="' . $fieldID . '"]'));
 	}
 


### PR DESCRIPTION
## Summary

Adds support for defining the input type on a Form Builder's Custom Field block

<img width="962" height="812" alt="Screenshot 2025-08-19 at 16 10 30" src="https://github.com/user-attachments/assets/901c3d4b-efa4-48ea-9afe-34012bb1b7e9" />

Future PR's could extend this to select dropdowns, checkboxes and radio buttons.

## Testing

Updated exists tests to check each input type works correctly on the backend and frontend form.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)