### PR TITLE
Limit Non-Inline Forms per Session

### DIFF
--- a/admin/section/class-convertkit-admin-section-general.php
+++ b/admin/section/class-convertkit-admin-section-general.php
@@ -383,6 +383,18 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 			)
 		);
 
+		// Non-inline Form Limit per Session.
+		add_settings_field(
+			'non_inline_form_limit_per_session',
+			__( 'Limit per Session', 'convertkit' ),
+			array( $this, 'non_inline_form_limit_per_session_callback' ),
+			$this->settings_key,
+			$this->name . '-site-wide',
+			array(
+				'label_for' => 'non_inline_form_limit_per_session',
+			)
+		);
+
 		// reCAPTCHA.
 		add_settings_field(
 			'recaptcha_site_key',
@@ -814,6 +826,26 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 			'on',
 			$this->settings->non_inline_form_honor_none_setting(),
 			esc_html__( 'If checked, do not display the site wide form(s) above on Pages / Posts that have their Kit Form setting = None.', 'convertkit' )
+		);
+
+	}
+
+
+	/**
+	 * Renders the input for the Modal Form Limit per Session setting.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param   array $args   Setting field arguments (name,description).
+	 */
+	public function non_inline_form_limit_per_session_callback( $args ) {
+
+		// Output field.
+		$this->output_checkbox_field(
+			'non_inline_form_limit_per_session',
+			'on',
+			$this->settings->non_inline_form_limit_per_session(),
+			esc_html__( 'If checked, one non-inline form can only be displayed once per session. This applies to all non-inline forms across the Site Wide, Page, Post, Custom Post and Category settings.', 'convertkit' )
 		);
 
 	}

--- a/admin/section/class-convertkit-admin-section-general.php
+++ b/admin/section/class-convertkit-admin-section-general.php
@@ -65,7 +65,7 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 				'wrap'     => true,
 			),
 			'site-wide' => array(
-				'title'    => __( 'Site Wide', 'convertkit' ),
+				'title'    => __( 'Non-inline Forms', 'convertkit' ),
 				'callback' => array( $this, 'print_section_info_site_wide' ),
 				'wrap'     => true,
 			),
@@ -386,7 +386,7 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 		// Non-inline Form Limit per Session.
 		add_settings_field(
 			'non_inline_form_limit_per_session',
-			__( 'Limit per Session', 'convertkit' ),
+			__( 'Display Limit', 'convertkit' ),
 			array( $this, 'non_inline_form_limit_per_session_callback' ),
 			$this->settings_key,
 			$this->name . '-site-wide',
@@ -845,7 +845,7 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 			'non_inline_form_limit_per_session',
 			'on',
 			$this->settings->non_inline_form_limit_per_session(),
-			esc_html__( 'If checked, one non-inline form can only be displayed once per session. This applies to all non-inline forms across the Site Wide, Page, Post, Custom Post and Category settings.', 'convertkit' )
+			esc_html__( 'If checked, one non-inline form can only be displayed once per session. This applies to all non-inline forms defined in General Settings, Site Wide, Page / Post level Settings and Category settings.', 'convertkit' )
 		);
 
 	}

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -872,6 +872,7 @@ class ConvertKit_Output {
 						'async'    => true,
 						'data-uid' => $form['uid'],
 						'src'      => $form['embed_js'],
+						'data-kit-limit-per-session' => true,
 					);
 
 					return $scripts;
@@ -987,30 +988,18 @@ class ConvertKit_Output {
 			$this->settings = new ConvertKit_Settings();
 		}
 
-		// No limitation if the setting is disabled.
+		// Display script if the "Display Limit" setting isn't enabled.
 		if ( ! $this->settings->non_inline_form_limit_per_session() ) {
 			return false;
 		}
 
-		// No limitation if the script does not have the data-kit-limit-per-session attribute.
+		// Display script if the "Display Limit" setting should not be applied to this script.
 		if ( ! isset( $script['data-kit-limit-per-session'] ) ) {
 			return false;
 		}
 
-		// No limitation if the script does not have the data-kit-limit-per-session attribute set to true.
-		if ( $script['data-kit-limit-per-session'] !== true ) {
-			return false;
-		}
-
-		// No limitation if this is the first time the visitor has seen any non-inline form.
-		if ( ! isset( $_COOKIE['convertkit_non_inline_form_output'] ) ) {
-			// Set cookie, so the visitor is not limited by the setting on subsequent page loads, limited to this session only.
-			setcookie( 'convertkit_non_inline_form_output', 1, 0, '/' );
-			return false;
-		}
-
-		// Limitation if this is not the first script to be output.
-		return true;
+		// Display script if this is the first time the visitor has seen any non-inline form.
+		return ! isset( $_COOKIE['ck_non_inline_form_displayed'] );
 
 	}
 

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -858,9 +858,9 @@ class ConvertKit_Output {
 				function ( $scripts ) use ( $form ) {
 
 					$scripts[] = array(
-						'async'    => true,
-						'data-uid' => $form['uid'],
-						'src'      => $form['embed_js'],
+						'async'                      => true,
+						'data-uid'                   => $form['uid'],
+						'src'                        => $form['embed_js'],
 						'data-kit-limit-per-session' => true,
 					);
 
@@ -988,7 +988,7 @@ class ConvertKit_Output {
 		}
 
 		// Display script if this is the first time the visitor has seen any non-inline form.
-		return ! isset( $_COOKIE['ck_non_inline_form_displayed'] );
+		return isset( $_COOKIE['ck_non_inline_form_displayed'] );
 
 	}
 

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -926,6 +926,11 @@ class ConvertKit_Output {
 			 */
 			$script = apply_filters( 'convertkit_output_script_footer', $script );
 
+			// Skip script if it is limited by the Non-inline Form Limit per Session setting.
+			if ( $this->is_script_output_limited_by_session( $script ) ) {
+				continue;
+			}
+
 			// Build output.
 			$output = '<script';
 			foreach ( $script as $attribute => $value ) {
@@ -964,6 +969,48 @@ class ConvertKit_Output {
 		foreach ( $output_scripts as $output_script ) {
 			echo $output_script . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
+
+	}
+
+	/**
+	 * Checks if a script is limited by the Non-inline Form Limit per Session setting.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param   array $script   Script.
+	 * @return  bool
+	 */
+	private function is_script_output_limited_by_session( $script ) {
+
+		// Get Settings, if they have not yet been loaded.
+		if ( ! $this->settings ) {
+			$this->settings = new ConvertKit_Settings();
+		}
+
+		// No limitation if the setting is disabled.
+		if ( ! $this->settings->non_inline_form_limit_per_session() ) {
+			return false;
+		}
+
+		// No limitation if the script does not have the data-kit-limit-per-session attribute.
+		if ( ! isset( $script['data-kit-limit-per-session'] ) ) {
+			return false;
+		}
+
+		// No limitation if the script does not have the data-kit-limit-per-session attribute set to true.
+		if ( $script['data-kit-limit-per-session'] !== true ) {
+			return false;
+		}
+
+		// No limitation if this is the first time the visitor has seen any non-inline form.
+		if ( ! isset( $_COOKIE['convertkit_non_inline_form_output'] ) ) {
+			// Set cookie, so the visitor is not limited by the setting on subsequent page loads, limited to this session only.
+			setcookie( 'convertkit_non_inline_form_output', 1, 0, '/' );
+			return false;
+		}
+
+		// Limitation if this is not the first script to be output.
+		return true;
 
 	}
 

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -541,9 +541,10 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource_V4 {
 
 					// Build script.
 					$script = array(
-						'async'    => true,
-						'data-uid' => $this->resources[ $id ]['uid'],
-						'src'      => $this->resources[ $id ]['embed_js'],
+						'async'                      => true,
+						'data-uid'                   => $this->resources[ $id ]['uid'],
+						'src'                        => $this->resources[ $id ]['embed_js'],
+						'data-kit-limit-per-session' => $settings->non_inline_form_limit_per_session(),
 					);
 
 					// If debugging is enabled, add the post ID to the script.

--- a/includes/class-convertkit-settings.php
+++ b/includes/class-convertkit-settings.php
@@ -410,6 +410,19 @@ class ConvertKit_Settings {
 	}
 
 	/**
+	 * Returns whether the Non-inline Form Limit per Session setting has been set in the Plugin settings.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @return  bool
+	 */
+	public function non_inline_form_limit_per_session() {
+
+		return ( $this->settings['non_inline_form_limit_per_session'] === 'on' ? true : false );
+
+	}
+
+	/**
 	 * Returns the reCAPTCHA Site Key Plugin setting.
 	 *
 	 * @since   3.0.0
@@ -550,6 +563,7 @@ class ConvertKit_Settings {
 			// Site Wide.
 			'non_inline_form'                    => array(), // array.
 			'non_inline_form_honor_none_setting' => '', // blank|on.
+			'non_inline_form_limit_per_session'  => '', // blank|on.
 
 			// reCAPTCHA.
 			'recaptcha_site_key'                 => '', // string.

--- a/resources/frontend/js/convertkit.js
+++ b/resources/frontend/js/convertkit.js
@@ -230,5 +230,13 @@ document.addEventListener(
 			}
 		);
 
+		// Set a cookie if any scripts with data-kit-limit-per-session attribute exist.
+		if ( document.querySelectorAll( 'script[data-kit-limit-per-session]' ).length > 0 ) {
+			document.cookie = 'ck_non_inline_form_displayed=1; path=/';
+			if ( convertkit.debug ) {
+				console.log( 'Set `ck_non_inline_form_displayed` cookie for non-inline form limit' );
+			}
+		}
+
 	}
 );

--- a/tests/EndToEnd/forms/general/NonInlineFormCest.php
+++ b/tests/EndToEnd/forms/general/NonInlineFormCest.php
@@ -683,6 +683,13 @@ class NonInlineFormCest
 		$I->dontSeeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_ID'] . '"]');
 	}
 
+	/**
+	 * Test that the non-inline form limit per session setting works.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
 	public function testNonInlineFormLimitPerSession(EndToEndTester $I)
 	{
 		// Setup Plugin with a non-inline Default Form for Site Wide,
@@ -690,13 +697,13 @@ class NonInlineFormCest
 		$I->setupKitPlugin(
 			$I,
 			[
-				'non_inline_form' => array(
+				'non_inline_form'                   => array(
 					$_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_ID'],
 				),
 				'non_inline_form_limit_per_session' => 'on',
 			]
 		);
-		
+
 		// Create a Page in the database that uses a different non-inline form.
 		$I->havePostInDatabase(
 			[
@@ -721,18 +728,17 @@ class NonInlineFormCest
 
 		// View Page.
 		$I->amOnPage('/kit-non-inline-form-limit-per-session');
-		die();
 
 		// Confirm that no Kit Form is output in the DOM, and the cookie is set, because a non-inline form was output in the previous request.
 		$I->dontSeeElementInDOM('form[data-sv-form]');
-		$I->seeCookie('convertkit_non_inline_form_output');
+		$I->seeCookie('ck_non_inline_form_displayed');
 
 		// View the home page.
 		$I->amOnPage('/');
 
 		// Confirm that no Kit Form is output in the DOM, and the cookie is set, because a non-inline form was output in the previous request.
 		$I->dontSeeElementInDOM('form[data-sv-form]');
-		$I->seeCookie('convertkit_non_inline_form_output');
+		$I->seeCookie('ck_non_inline_form_displayed');
 	}
 
 	/**

--- a/tests/EndToEnd/forms/general/NonInlineFormCest.php
+++ b/tests/EndToEnd/forms/general/NonInlineFormCest.php
@@ -683,6 +683,58 @@ class NonInlineFormCest
 		$I->dontSeeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_ID'] . '"]');
 	}
 
+	public function testNonInlineFormLimitPerSession(EndToEndTester $I)
+	{
+		// Setup Plugin with a non-inline Default Form for Site Wide,
+		// and set to limit the display of non-inline forms per session.
+		$I->setupKitPlugin(
+			$I,
+			[
+				'non_inline_form' => array(
+					$_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_ID'],
+				),
+				'non_inline_form_limit_per_session' => 'on',
+			]
+		);
+		
+		// Create a Page in the database that uses a different non-inline form.
+		$I->havePostInDatabase(
+			[
+				'post_title'  => 'Kit: Non Inline Form: Limit Per Session',
+				'post_name'   => 'kit-non-inline-form-limit-per-session',
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'meta'        => [
+					'_wp_convertkit_post_meta' => [
+						'form' => $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'],
+					],
+				],
+			]
+		);
+
+		// View the home page.
+		$I->amOnPage('/');
+
+		// Confirm that one Kit Form is output in the DOM.
+		// This confirms that there is only one script on the page for this form, which renders the form.
+		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_ID'] . '"]', 1);
+
+		// View Page.
+		$I->amOnPage('/kit-non-inline-form-limit-per-session');
+		die();
+
+		// Confirm that no Kit Form is output in the DOM, and the cookie is set, because a non-inline form was output in the previous request.
+		$I->dontSeeElementInDOM('form[data-sv-form]');
+		$I->seeCookie('convertkit_non_inline_form_output');
+
+		// View the home page.
+		$I->amOnPage('/');
+
+		// Confirm that no Kit Form is output in the DOM, and the cookie is set, because a non-inline form was output in the previous request.
+		$I->dontSeeElementInDOM('form[data-sv-form]');
+		$I->seeCookie('convertkit_non_inline_form_output');
+	}
+
 	/**
 	 * Test that the defined default non-inline form displays site wide
 	 * when stored as a string in the Plugin settings from older

--- a/tests/EndToEnd/general/plugin-screens/PluginSettingsGeneralCest.php
+++ b/tests/EndToEnd/general/plugin-screens/PluginSettingsGeneralCest.php
@@ -530,6 +530,57 @@ class PluginSettingsGeneralCest
 
 	/**
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
+	 * when the Non-inline Form settings are saved and cleared.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testNonInlineFormSettings(EndToEndTester $I)
+	{
+		// Setup Plugin.
+		$I->setupKitPlugin($I);
+		
+		// Go to the Plugin's Settings Screen.
+		$I->loadKitSettingsGeneralScreen($I);
+
+		// Define fields.
+		$I->fillSelect2MultipleField(
+			$I,
+			container: '#select2-_wp_convertkit_settings_non_inline_form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME']
+		);
+		$I->fillSelect2MultipleField(
+			$I,
+			container: '#select2-_wp_convertkit_settings_non_inline_form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME']
+		);
+		$I->checkOption('#non_inline_form_honor_none_setting');
+		$I->checkOption('#non_inline_form_limit_per_session');
+
+		// Click the Save Changes button.
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->waitForElementVisible('.notice-success');
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check the field settings saved.
+		$I->seeInFormFields(
+			'form',
+			[
+				'_wp_convertkit_settings[non_inline_form][]' => [
+					$_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'],
+					$_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'],
+				],
+			]
+		);
+		$I->seeCheckboxIsChecked('#non_inline_form_honor_none_setting');
+		$I->seeCheckboxIsChecked('#non_inline_form_limit_per_session');
+	}
+
+	/**
+	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
 	 * when the reCAPTCHA settings are saved and cleared.
 	 *
 	 * @since   3.0.0

--- a/tests/EndToEnd/general/plugin-screens/PluginSettingsGeneralCest.php
+++ b/tests/EndToEnd/general/plugin-screens/PluginSettingsGeneralCest.php
@@ -540,7 +540,7 @@ class PluginSettingsGeneralCest
 	{
 		// Setup Plugin.
 		$I->setupKitPlugin($I);
-		
+
 		// Go to the Plugin's Settings Screen.
 		$I->loadKitSettingsGeneralScreen($I);
 


### PR DESCRIPTION
## Summary

Adds a setting to limit the number of non-inline forms output to one per visitor session, as [requested here](https://n7studios-workspace.slack.com/archives/C02KFR6N1GF/p1755699619865449).

<img width="1012" height="498" alt="Screenshot 2025-08-25 at 16 19 19" src="https://github.com/user-attachments/assets/cf1e018b-506a-476c-82a8-6ee253891d08" />

## Testing

- `testNonInlineFormSettings`: Test that no PHP errors or notices are displayed on the Plugin's Setting screen when the Non-inline Form settings are saved and cleared.
- `testNonInlineFormLimitPerSession`: Test that the non-inline form limit per session setting works.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)