### PR TITLE
Rename `Multi_Value_Table` class to `ConvertKit_WP_List_Table`

### DIFF
--- a/admin/class-convertkit-wp-list-table.php
+++ b/admin/class-convertkit-wp-list-table.php
@@ -23,6 +23,13 @@ if ( ! class_exists( 'WP_List_Table' ) ) {
 class ConvertKit_WP_List_Table extends WP_List_Table {
 
 	/**
+	 * Holds the supported bulk actions.
+	 *
+	 * @var     array
+	 */
+	private $bulk_actions = array();
+
+	/**
 	 * Holds the table columns.
 	 *
 	 * @var     array
@@ -92,6 +99,17 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 	}
 
 	/**
+	 * Get the bulk actions for this table
+	 *
+	 * @return array Bulk actions
+	 */
+	public function get_bulk_actions() {
+
+		return $this->bulk_actions;
+
+	}
+
+	/**
 	 * Get a list of columns
 	 *
 	 * @return array
@@ -127,6 +145,18 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 	public function add_item( $item ) {
 
 		array_push( $this->data, $item );
+
+	}
+
+	/**
+	 * Add a bulk action to the table
+	 *
+	 * @param string $key  Machine-readable action name.
+	 * @param string $name Title shown to the user.
+	 */
+	public function add_bulk_action( $key, $name ) {
+
+		$this->bulk_actions[ $key ] = $name;
 
 	}
 

--- a/admin/class-convertkit-wp-list-table.php
+++ b/admin/class-convertkit-wp-list-table.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ConvertKit General Settings class
+ * ConvertKit WP_List_Table class.
  *
  * @package ConvertKit
  * @author ConvertKit
@@ -14,16 +14,13 @@ if ( ! class_exists( 'WP_List_Table' ) ) {
 }
 
 /**
- * Class Multi_Value_Field_Table
+ * Displays rows of data (such as settings) in a WP_List_Table.
+ * Mainly used for Contact Form 7, Forminator and WishList Member settings screens.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
  */
-class Multi_Value_Field_Table extends WP_List_Table {
-
-	/**
-	 * Holds the supported bulk actions.
-	 *
-	 * @var     array
-	 */
-	private $bulk_actions = array();
+class ConvertKit_WP_List_Table extends WP_List_Table {
 
 	/**
 	 * Holds the table columns.
@@ -95,17 +92,6 @@ class Multi_Value_Field_Table extends WP_List_Table {
 	}
 
 	/**
-	 * Get the bulk actions for this table
-	 *
-	 * @return array Bulk actions
-	 */
-	public function get_bulk_actions() {
-
-		return $this->bulk_actions;
-
-	}
-
-	/**
 	 * Get a list of columns
 	 *
 	 * @return array
@@ -141,18 +127,6 @@ class Multi_Value_Field_Table extends WP_List_Table {
 	public function add_item( $item ) {
 
 		array_push( $this->data, $item );
-
-	}
-
-	/**
-	 * Add a bulk action to the table
-	 *
-	 * @param string $key  Machine-readable action name.
-	 * @param string $name Title shown to the user.
-	 */
-	public function add_bulk_action( $key, $name ) {
-
-		$this->bulk_actions[ $key ] = $name;
 
 	}
 
@@ -221,46 +195,4 @@ class Multi_Value_Field_Table extends WP_List_Table {
 
 	}
 
-	/**
-	 * Display the table without the nonce at the top.
-	 *
-	 * @since 3.1.0
-	 * @access public
-	 */
-	public function display_no_nonce() {
-
-		$singular = $this->_args['singular'];
-
-		$this->display_tablenav( 'bottom' );
-
-		$this->screen->render_screen_reader_content( 'heading_list' );
-		?>
-		<table class="wp-list-table <?php echo esc_attr( implode( ' ', $this->get_table_classes() ) ); ?>">
-			<thead>
-			<tr>
-				<?php $this->print_column_headers(); ?>
-			</tr>
-			</thead>
-
-			<tbody id="the-list"
-			<?php
-			if ( $singular ) {
-				echo " data-wp-lists='list:" . esc_attr( $singular ) . "'";
-			}
-			?>
-			>
-			<?php $this->display_rows_or_placeholder(); ?>
-			</tbody>
-
-			<tfoot>
-			<tr>
-				<?php $this->print_column_headers( false ); ?>
-			</tr>
-			</tfoot>
-
-		</table>
-		<?php
-		$this->display_tablenav( 'bottom' );
-
-	}
 }

--- a/admin/section/class-convertkit-admin-section-form-entries.php
+++ b/admin/section/class-convertkit-admin-section-form-entries.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * ConvertKit Form Entries Admin Settings class.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Registers Form Entries Settings that can be viewed, deleted and exported at Settings > Kit > Form Entries.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+class ConvertKit_Admin_Section_Form_Entries extends ConvertKit_Admin_Section_Base {
+
+	/**
+	 * Constructor
+	 *
+	 * @since   3.0.0
+	 */
+	public function __construct() {
+
+		// Define the programmatic name, Title and Tab Text.
+		$this->name     = 'form-entries';
+		$this->title    = __( 'Form Entries', 'convertkit' );
+		$this->tab_text = __( 'Form Entries', 'convertkit' );
+
+		// Define settings sections.
+		$this->settings_sections = array(
+			'general' => array(
+				'title'    => $this->title,
+				'callback' => array( $this, 'print_section_info' ),
+				'wrap'     => false,
+			),
+		);
+
+		parent::__construct();
+
+	}
+
+	/**
+	 * Register fields for this section
+	 *
+	 * @since   3.0.0
+	 */
+	public function register_fields() {
+
+		// No fields are registered.
+		// This function is deliberately blank.
+	}
+
+	/**
+	 * Prints help info for this section.
+	 *
+	 * @since   3.0.0
+	 */
+	public function print_section_info() {
+
+		?>
+		<p>
+			<?php
+			esc_html_e( 'Displays a list of form entries from Form Builder blocks that have "store form submissions" enabled. Entries submitted using embedded Kit Forms or Landing Pages are not included.', 'convertkit' );
+			?>
+		</p>
+		<?php
+
+	}
+
+	/**
+	 * Returns the URL for the ConvertKit documentation for this setting section.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @return  string  Documentation URL.
+	 */
+	public function documentation_url() {
+
+		return 'https://help.kit.com/en/articles/2502591-the-convertkit-wordpress-plugin';
+
+	}
+
+	/**
+	 * Outputs the section as a WP_List_Table of Form Entries.
+	 *
+	 * @since   3.0.0
+	 */
+	public function render() {
+
+		$form_entries = new ConvertKit_Form_Entries();
+
+		// Render opening container.
+		$this->render_container_start();
+
+		?>
+		<h2><?php esc_html_e( 'Form Entries', 'convertkit' ); ?></h2>
+		<?php
+		$this->print_section_info();
+
+		// Setup WP_List_Table.
+		$table = new ConvertKit_WP_List_Table();
+
+		// Add columns to table.
+		$table->add_column( 'post_id', __( 'Post ID', 'convertkit' ), false );
+		$table->add_column( 'first_name', __( 'First Name', 'convertkit' ), false );
+		$table->add_column( 'email', __( 'Email', 'convertkit' ), false );
+		$table->add_column( 'created_at', __( 'Created', 'convertkit' ), false );
+		$table->add_column( 'updated_at', __( 'Updated', 'convertkit' ), false );
+		$table->add_column( 'api_result', __( 'Result', 'convertkit' ), false );
+		$table->add_column( 'api_error', __( 'Error', 'convertkit' ), false );
+
+		// Add form entries to table.
+		$entries = $form_entries->search();
+		$table->add_items( $entries );
+
+		// Set total entries.
+		$table->set_total_items( $form_entries->total() );
+
+		// Prepare and display WP_List_Table.
+		$table->prepare_items();
+		$table->display();
+
+		// Render closing container.
+		$this->render_container_end();
+
+	}
+
+}
+
+// Register Admin Settings section.
+add_filter(
+	'convertkit_admin_settings_register_sections',
+	/**
+	 * Register Form Entries as a section at Settings > Kit.
+	 *
+	 * @param   array   $sections   Settings Sections.
+	 * @return  array
+	 */
+	function ( $sections ) {
+
+		// Register this class as a section at Settings > Kit.
+		$sections['form-entries'] = new ConvertKit_Admin_Section_Form_Entries();
+		return $sections;
+
+	}
+);

--- a/includes/blocks/class-convertkit-block-form-builder.php
+++ b/includes/blocks/class-convertkit-block-form-builder.php
@@ -77,14 +77,6 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 			return;
 		}
 
-		// Initialize classes that will be used.
-		$settings = new ConvertKit_Settings();
-
-		// If the Plugin Access Token has not been configured, we can't get this subscriber's ID by email.
-		if ( ! $settings->has_access_and_refresh_token() ) {
-			return;
-		}
-
 		// Check reCAPTCHA.
 		$recaptcha          = new ConvertKit_Recaptcha();
 		$recaptcha_response = $recaptcha->verify_recaptcha(
@@ -94,6 +86,43 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 
 		// Bail if reCAPTCHA failed.
 		if ( is_wp_error( $recaptcha_response ) ) {
+			return;
+		}
+
+		// Sanitize form data.
+		$form_data = map_deep( wp_unslash( $_REQUEST['convertkit'] ), 'sanitize_text_field' );
+
+		// Build custom fields, if any were specified.
+		$custom_fields = array();
+		if ( array_key_exists( 'custom_fields', $form_data ) ) {
+			$custom_fields = $form_data['custom_fields'];
+		}
+
+		// Get Tag and Sequence IDs, if any were specified.
+		$tag_id      = array_key_exists( 'tag_id', $form_data ) ? $form_data['tag_id'] : false;
+		$sequence_id = array_key_exists( 'sequence_id', $form_data ) ? $form_data['sequence_id'] : false;
+
+		// Initialize classes that will be used.
+		$settings = new ConvertKit_Settings();
+		$entries  = new ConvertKit_Form_Entries();
+
+		// If the Plugin Access Token has not been configured, we can't add a subscriber.
+		if ( ! $settings->has_access_and_refresh_token() ) {
+			// Store entry and return.
+			if ( $form_data['store_entries'] ) {
+				$entries->upsert(
+					array(
+						'post_id'       => $form_data['post_id'],
+						'email'         => $form_data['email'],
+						'first_name'    => $form_data['first_name'],
+						'custom_fields' => $custom_fields,
+						'tag_id'        => $tag_id,
+						'sequence_id'   => $sequence_id,
+						'api_result'    => 'error',
+						'api_error'     => __( 'Plugin Access Token not configured', 'convertkit' ),
+					)
+				);
+			}
 			return;
 		}
 
@@ -107,15 +136,6 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 			'block_form_builder'
 		);
 
-		// Sanitize form data.
-		$form_data = map_deep( wp_unslash( $_REQUEST['convertkit'] ), 'sanitize_text_field' );
-
-		// Build custom fields, if any were specified.
-		$custom_fields = array();
-		if ( array_key_exists( 'custom_fields', $form_data ) ) {
-			$custom_fields = $form_data['custom_fields'];
-		}
-
 		// Create subscriber.
 		$result = $api->create_subscriber(
 			sanitize_email( $form_data['email'] ),
@@ -126,7 +146,37 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 
 		// Bail if an error occured.
 		if ( is_wp_error( $result ) ) {
+			// Store entry and return.
+			if ( $form_data['store_entries'] ) {
+				$entries->upsert(
+					array(
+						'post_id'       => $form_data['post_id'],
+						'email'         => $form_data['email'],
+						'first_name'    => $form_data['first_name'],
+						'custom_fields' => $custom_fields,
+						'tag_id'        => $tag_id,
+						'sequence_id'   => $sequence_id,
+						'api_result'    => 'error',
+						'api_error'     => $result->get_error_message(),
+					)
+				);
+			}
 			return;
+		}
+
+		// Store entry.
+		if ( $form_data['store_entries'] ) {
+			$entries->upsert(
+				array(
+					'post_id'       => $form_data['post_id'],
+					'email'         => $form_data['email'],
+					'first_name'    => $form_data['first_name'],
+					'custom_fields' => $custom_fields,
+					'tag_id'        => $tag_id,
+					'sequence_id'   => $sequence_id,
+					'api_result'    => 'success',
+				)
+			);
 		}
 
 		// Store the subscriber ID in a cookie.
@@ -134,13 +184,43 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 		$subscriber->set( $result['subscriber']['id'] );
 
 		// If a tag was specified, add the subscriber to the tag.
-		if ( array_key_exists( 'tag_id', $form_data ) && $form_data['tag_id'] > 0 ) {
-			$api->tag_subscriber( absint( $form_data['tag_id'] ), $result['subscriber']['id'] );
+		if ( $tag_id ) {
+			$result = $api->tag_subscriber( $tag_id, $result['subscriber']['id'] );
+
+			if ( $form_data['store_entries'] ) {
+				$entries->upsert(
+					array(
+						'post_id'       => $form_data['post_id'],
+						'email'         => $form_data['email'],
+						'first_name'    => $form_data['first_name'],
+						'custom_fields' => $custom_fields,
+						'tag_id'        => $tag_id,
+						'sequence_id'   => $sequence_id,
+						'api_result'    => is_wp_error( $result ) ? 'error' : 'success',
+						'api_error'     => is_wp_error( $result ) ? $result->get_error_message() : '',
+					)
+				);
+			}
 		}
 
 		// If a sequence was specified, add the subscriber to the sequence.
-		if ( array_key_exists( 'sequence_id', $form_data ) && $form_data['sequence_id'] > 0 ) {
-			$api->add_subscriber_to_sequence( absint( $form_data['sequence_id'] ), $result['subscriber']['id'] );
+		if ( $sequence_id ) {
+			$result = $api->add_subscriber_to_sequence( $sequence_id, $result['subscriber']['id'] );
+
+			if ( $form_data['store_entries'] ) {
+				$entries->upsert(
+					array(
+						'post_id'       => $form_data['post_id'],
+						'email'         => $form_data['email'],
+						'first_name'    => $form_data['first_name'],
+						'custom_fields' => $custom_fields,
+						'tag_id'        => $tag_id,
+						'sequence_id'   => $sequence_id,
+						'api_result'    => is_wp_error( $result ) ? 'error' : 'success',
+						'api_error'     => is_wp_error( $result ) ? $result->get_error_message() : '',
+					)
+				);
+			}
 		}
 
 		// Get the redirect URL, based on whether the form is configured to redirect
@@ -271,6 +351,10 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 				'type'    => 'string',
 				'default' => $this->get_default_value( 'redirect' ),
 			),
+			'store_entries'              => array(
+				'type'    => 'boolean',
+				'default' => $this->get_default_value( 'store_entries' ),
+			),
 			'display_form_if_subscribed' => array(
 				'type'    => 'boolean',
 				'default' => $this->get_default_value( 'display_form_if_subscribed' ),
@@ -381,6 +465,11 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 				'type'        => 'url',
 				'description' => __( 'The URL to redirect to after the visitor subscribes. If not specified, the visitor will remain on the current page.', 'convertkit' ),
 			),
+			'store_entries'              => array(
+				'label'       => __( 'Store form submissions', 'convertkit' ),
+				'type'        => 'toggle',
+				'description' => __( 'If enabled, stores copies of form submissions in the WordPress database. Submissions are always sent to Kit.', 'convertkit' ),
+			),
 			'display_form_if_subscribed' => array(
 				'label'       => __( 'Display form', 'convertkit' ),
 				'type'        => 'toggle',
@@ -428,6 +517,7 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 					'tag_id',
 					'sequence_id',
 					'redirect',
+					'store_entries',
 					'display_form_if_subscribed',
 					'text_if_subscribed',
 				),
@@ -449,6 +539,7 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 			'tag_id'                     => '',
 			'sequence_id'                => '',
 			'redirect'                   => '',
+			'store_entries'              => true,
 			'display_form_if_subscribed' => true,
 			'text_if_subscribed'         => 'Thanks for subscribing!',
 
@@ -606,11 +697,12 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 
 		// Add hidden fields.
 		$fields = array(
-			'convertkit[post_id]'     => absint( $post_id ),
-			'convertkit[redirect]'    => esc_url( $atts['redirect'] ),
-			'convertkit[tag_id]'      => absint( $atts['tag_id'] ),
-			'convertkit[sequence_id]' => absint( $atts['sequence_id'] ),
-			'_wpnonce'                => wp_create_nonce( 'convertkit_block_form_builder' ),
+			'convertkit[post_id]'       => absint( $post_id ),
+			'convertkit[store_entries]' => $atts['store_entries'] ? '1' : '0',
+			'convertkit[redirect]'      => esc_url( $atts['redirect'] ),
+			'convertkit[tag_id]'        => absint( $atts['tag_id'] ),
+			'convertkit[sequence_id]'   => absint( $atts['sequence_id'] ),
+			'_wpnonce'                  => wp_create_nonce( 'convertkit_block_form_builder' ),
 		);
 		foreach ( $fields as $name => $value ) {
 			$hidden = $html->createElement( 'input' );

--- a/includes/class-convertkit-form-entries.php
+++ b/includes/class-convertkit-form-entries.php
@@ -1,0 +1,349 @@
+<?php
+/**
+ * Kit Admin Form Builder Entries class.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Stores entries submitted via Form Builder blocks that have
+ * the 'Store Entries' option enabled.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+class ConvertKit_Form_Entries {
+
+	/**
+	 * Holds the DB table name
+	 *
+	 * @since   3.0.0
+	 *
+	 * @var     string
+	 */
+	private $table = 'kit_form_entries';
+
+	/**
+	 * Create database table.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @global  $wpdb   WordPress DB Object
+	 */
+	public function create_database_table() {
+
+		global $wpdb;
+
+		// Create database table.
+		$query  = $wpdb->prepare(
+			"CREATE TABLE IF NOT EXISTS %i (
+				`id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+				`post_id` int(11) NOT NULL,
+                `first_name` varchar(191) NOT NULL DEFAULT '',
+                `email` varchar(191) NOT NULL DEFAULT '',
+                `custom_fields` text,
+				`tag_id` int(11) NOT NULL,
+				`sequence_id` int(11) NOT NULL,
+                `created_at` datetime NOT NULL,
+				`updated_at` datetime NOT NULL,
+				`api_result` varchar(191) NOT NULL DEFAULT 'success',
+				`api_error` text,
+				PRIMARY KEY (`id`),
+				KEY `post_id` (`post_id`),
+				KEY `first_name` (`first_name`),
+                KEY `email` (`email`),
+				KEY `tag_id` (`tag_id`),
+				KEY `sequence_id` (`sequence_id`),
+                KEY `api_result` (`api_result`)
+			)",
+			$wpdb->prefix . $this->table
+		);
+		$query .= ' ' . $wpdb->get_charset_collate() . ' AUTO_INCREMENT=1';
+		$wpdb->query( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+	}
+
+	/**
+	 * Adds an entry
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param   array $entry      Entry.
+	 *    int             $post_id          Post ID.
+	 *    string          $first_name       First Name.
+	 *    string          $email            Email.
+	 *    array           $custom_fields    Custom Fields.
+	 *    int             $tag_id           Tag ID.
+	 *    int             $sequence_id      Sequence ID.
+	 *    string          $api_result       Result (success,error).
+	 *    string          $api_error        API Response (when $api_result is 'error').
+	 * @return  int|bool|WP_Error
+	 */
+	public function add( $entry ) {
+
+		global $wpdb;
+
+		// If no email is provided, return an error.
+		if ( ! array_key_exists( 'email', $entry ) ) {
+			return new \WP_Error( 'convertkit_form_entries_no_email', __( 'No email address provided', 'convertkit' ) );
+		}
+
+		// JSON encode custom fields, if supplied as an array.
+		if ( array_key_exists( 'custom_fields', $entry ) && is_array( $entry['custom_fields'] ) ) {
+			$entry['custom_fields'] = wp_json_encode( $entry['custom_fields'] );
+		}
+
+		// Add created_at and updated_at timestamps.
+		$entry['created_at'] = gmdate( 'Y-m-d H:i:s' );
+		$entry['updated_at'] = gmdate( 'Y-m-d H:i:s' );
+
+		$wpdb->insert(
+			$wpdb->prefix . $this->table,
+			$entry
+		);
+
+		// Return the entry ID.
+		return $wpdb->insert_id;
+
+	}
+
+	/**
+	 * Updates an entry
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param   int   $id           Entry ID.
+	 * @param   array $entry      Entry.
+	 *    int             $post_id          Post ID.
+	 *    string          $first_name       First Name.
+	 *    string          $email            Email.
+	 *    array           $custom_fields    Custom Fields.
+	 *    int             $tag_id           Tag ID.
+	 *    int             $sequence_id      Sequence ID.
+	 *    string          $api_result       Result (success,error).
+	 *    string          $api_error        API Response (when $api_result is 'error').
+	 * @return  int|bool|WP_Error
+	 */
+	public function update( $id, $entry ) {
+
+		global $wpdb;
+
+		// If no email is provided, return an error.
+		if ( ! array_key_exists( 'email', $entry ) ) {
+			return new \WP_Error( 'convertkit_form_entries_no_email', __( 'No email address provided', 'convertkit' ) );
+		}
+
+		// JSON encode custom fields, if supplied as an array.
+		if ( array_key_exists( 'custom_fields', $entry ) && is_array( $entry['custom_fields'] ) ) {
+			$entry['custom_fields'] = wp_json_encode( $entry['custom_fields'] );
+		}
+
+		// Add updated_at timestamp.
+		$entry['updated_at'] = gmdate( 'Y-m-d H:i:s' );
+
+		$wpdb->update(
+			$wpdb->prefix . $this->table,
+			$entry,
+			array( 'id' => $id )
+		);
+
+		// Return the entry ID.
+		return $wpdb->insert_id;
+
+	}
+
+	/**
+	 * Upserts an entry
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param   array $entry      Entry.
+	 *    int             $post_id          Post ID.
+	 *    string          $first_name       First Name.
+	 *    string          $email            Email.
+	 *    array           $custom_fields    Custom Fields.
+	 *    datetime        $created_at       Created At.
+	 *    datetime        $api_request_sent Request Sent to API.
+	 *    string          $api_result       Result (success,test_mode,pending,error).
+	 *    string          $api_response     API Response.
+	 * @return  int|bool|WP_Error
+	 */
+	public function upsert( $entry ) {
+
+		global $wpdb;
+
+		// If no email is provided, return an error.
+		if ( ! array_key_exists( 'email', $entry ) ) {
+			return new \WP_Error( 'convertkit_form_entries_no_email', __( 'No email address provided', 'convertkit' ) );
+		}
+
+		// Check if an entry already exists for the given Post ID and Email.
+		$id = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT id FROM %i WHERE post_id = %d AND email = %s',
+				$wpdb->prefix . $this->table,
+				$entry['post_id'],
+				$entry['email']
+			)
+		);
+
+		// If an entry already exists, update it.
+		if ( $id ) {
+			return $this->update( $id, $entry );
+		}
+
+		// Insert new entry.
+		return $this->add( $entry );
+
+	}
+
+	/**
+	 * Searches entries by the given key/value pairs
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param   bool|string $search     Search Query.
+	 * @param   string      $order_by   Order Results By.
+	 * @param   string      $order      Order (asc|desc).
+	 * @param   int         $page       Pagination Offset (default: 1).
+	 * @param   int         $per_page   Number of Results to Return (default: 25).
+	 * @return  array
+	 */
+	public function search( $search = false, $order_by = 'created_at', $order = 'desc', $page = 1, $per_page = 25 ) {
+
+		global $wpdb;
+
+		// Prepare query.
+		$query = $wpdb->prepare(
+			'SELECT * FROM %i',
+			$wpdb->prefix . $this->table
+		);
+
+		// Add search clause.
+		if ( $search ) {
+			$query .= $wpdb->prepare(
+				' WHERE first_name LIKE %s OR email LIKE %s',
+				'%' . $search . '%',
+				'%' . $search . '%'
+			);
+		}
+
+		// Order.
+		$query .= $wpdb->prepare(
+			' ORDER BY %i.%i',
+			$wpdb->prefix . $this->table,
+			$order_by
+		);
+		$query .= ' ' . ( strtolower( $order ) === 'asc' ? 'ASC' : 'DESC' );
+
+		// Limit.
+		if ( $page > 0 && $per_page > 0 ) {
+			$query .= $wpdb->prepare( ' LIMIT %d, %d', ( ( $page - 1 ) * $per_page ), $per_page );
+		}
+
+		// Run and return query results.
+		return $wpdb->get_results( $query, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+	}
+
+	/**
+	 * Gets the number of entry records found for the given query parameters
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param   bool|string $search     Search Query.
+	 * @return  int
+	 */
+	public function total( $search = false ) {
+
+		global $wpdb;
+
+		// Prepare query.
+		$query = $wpdb->prepare(
+			'SELECT COUNT(%i.id) FROM %i',
+			$wpdb->prefix . $this->table,
+			$wpdb->prefix . $this->table
+		);
+
+		// Add search clause.
+		if ( $search ) {
+			$query .= $wpdb->prepare(
+				' WHERE first_name LIKE %s OR email LIKE %s',
+				'%' . $search . '%',
+				'%' . $search . '%'
+			);
+		}
+
+		// Run and return total records found.
+		return (int) $wpdb->get_var( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+	}
+
+	/**
+	 * Deletes a single entry for the given ID
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param   array $id     Entry ID.
+	 * @return  bool
+	 */
+	public function delete_by_id( $id ) {
+
+		global $wpdb;
+
+		return $wpdb->delete(
+			$wpdb->prefix . $this->table,
+			array(
+				'id' => absint( $id ),
+			)
+		);
+
+	}
+
+	/**
+	 * Deletes multiple entries for the given Entry IDs
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param   array $ids    Entry IDs.
+	 * @return  bool            Success
+	 */
+	public function delete_by_ids( $ids ) {
+
+		global $wpdb;
+
+		return $wpdb->query(
+			$wpdb->prepare(
+				sprintf(
+					'DELETE FROM %s WHERE id IN (%s)',
+					$wpdb->prefix . $this->table, // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+					implode( ',', array_fill( 0, count( $ids ), '%d' ) )
+				),
+				$ids
+			)
+		);
+
+	}
+
+	/**
+	 * Deletes all entries
+	 *
+	 * @since   3.0.0
+	 *
+	 * @return  bool
+	 */
+	public function delete_all() {
+
+		global $wpdb;
+
+		return $wpdb->query(
+			$wpdb->prepare(
+				'TRUNCATE TABLE %i',
+				$wpdb->prefix . $this->table
+			)
+		);
+
+	}
+
+}

--- a/includes/class-convertkit-setup.php
+++ b/includes/class-convertkit-setup.php
@@ -25,6 +25,10 @@ class ConvertKit_Setup {
 		// Call any functions to e.g. schedule WordPress Cron events now.
 		$this->schedule_cron_events();
 
+		// Install entries database table.
+		$entries = new ConvertKit_Form_Entries();
+		$entries->create_database_table();
+
 	}
 
 	/**
@@ -58,9 +62,14 @@ class ConvertKit_Setup {
 
 		/**
 		 * 3.0.0: Migrate reCAPTCHA settings from Restrict Content to General settings.
+		 * Install entries database table.
 		 */
 		if ( version_compare( $current_version, '3.0.0', '<' ) ) {
 			$this->migrate_recaptcha_settings();
+
+			// Install entries database table.
+			$entries = new ConvertKit_Form_Entries();
+			$entries->create_database_table();
 		}
 
 		/**

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-section.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-section.php
@@ -134,7 +134,7 @@ class ConvertKit_ContactForm7_Admin_Section extends ConvertKit_Admin_Section_Bas
 		$creator_network_recommendations_enabled = $creator_network_recommendations->enabled();
 
 		// Setup WP_List_Table.
-		$table = new Multi_Value_Field_Table();
+		$table = new ConvertKit_WP_List_Table();
 		$table->add_column( 'title', __( 'Contact Form 7 Form', 'convertkit' ), true );
 		$table->add_column( 'form', __( 'Kit', 'convertkit' ), false );
 		$table->add_column( 'email', __( 'Contact Form 7 Email Field', 'convertkit' ), false );

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-section.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-section.php
@@ -141,7 +141,8 @@ class ConvertKit_ContactForm7_Admin_Section extends ConvertKit_Admin_Section_Bas
 		$table->add_column( 'name', __( 'Contact Form 7 Name Field', 'convertkit' ), false );
 		$table->add_column( 'creator_network_recommendations', __( 'Enable Creator Network Recommendations', 'convertkit' ), false );
 
-		// Iterate through Contact Form 7 Forms, adding a table row for each Contact Form 7 Form.
+		// Iterate through Contact Form 7 Forms, building table array.
+		$table_rows = array();
 		foreach ( $cf7_forms as $cf7_form ) {
 			// Build row.
 			$table_row = array(
@@ -176,8 +177,15 @@ class ConvertKit_ContactForm7_Admin_Section extends ConvertKit_Admin_Section_Bas
 			}
 
 			// Add row to table of settings.
-			$table->add_item( $table_row );
+			$table_rows[] = $table_row;
 		}
+
+		// Sort table rows.
+		$table_rows = $table->reorder( $table_rows );
+
+		// Set items.
+		$table->add_items( $table_rows );
+		$table->set_total_items( count( $table_rows ) );
 
 		// Prepare and display WP_List_Table.
 		$table->prepare_items();

--- a/includes/integrations/forminator/class-convertkit-forminator-admin-section.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-admin-section.php
@@ -121,7 +121,7 @@ class ConvertKit_Forminator_Admin_Section extends ConvertKit_Admin_Section_Base 
 		$creator_network_recommendations_enabled = $creator_network_recommendations->enabled();
 
 		// Setup WP_List_Table.
-		$table = new Multi_Value_Field_Table();
+		$table = new ConvertKit_WP_List_Table();
 		$table->add_column( 'title', __( 'Forminator Form', 'convertkit' ), true );
 		$table->add_column( 'form', __( 'Kit', 'convertkit' ), false );
 		$table->add_column( 'creator_network_recommendations', __( 'Enable Creator Network Recommendations', 'convertkit' ), false );

--- a/includes/integrations/forminator/class-convertkit-forminator-admin-section.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-admin-section.php
@@ -126,7 +126,8 @@ class ConvertKit_Forminator_Admin_Section extends ConvertKit_Admin_Section_Base 
 		$table->add_column( 'form', __( 'Kit', 'convertkit' ), false );
 		$table->add_column( 'creator_network_recommendations', __( 'Enable Creator Network Recommendations', 'convertkit' ), false );
 
-		// Iterate through Forminator Forms, adding a table row for each Forminator Form.
+		// Iterate through Forminator Forms, building table array.
+		$table_rows = array();
 		foreach ( $forminator_forms as $forminator_form ) {
 			// Build row.
 			$table_row = array(
@@ -159,8 +160,15 @@ class ConvertKit_Forminator_Admin_Section extends ConvertKit_Admin_Section_Base 
 			}
 
 			// Add row to table of settings.
-			$table->add_item( $table_row );
+			$table_rows[] = $table_row;
 		}
+
+		// Sort table rows.
+		$table_rows = $table->reorder( $table_rows );
+
+		// Set items.
+		$table->add_items( $table_rows );
+		$table->set_total_items( count( $table_rows ) );
 
 		// Prepare and display WP_List_Table.
 		$table->prepare_items();

--- a/includes/integrations/wishlist/class-convertkit-wishlist-admin-section.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist-admin-section.php
@@ -114,7 +114,7 @@ class ConvertKit_Wishlist_Admin_Section extends ConvertKit_Admin_Section_Base {
 		}
 
 		// Setup WP_List_Table.
-		$table = new Multi_Value_Field_Table();
+		$table = new ConvertKit_WP_List_Table();
 		$table->add_column( 'title', __( 'WishList Membership Level', 'convertkit' ), true );
 		$table->add_column( 'add', __( 'Assign to member', 'convertkit' ), false );
 		$table->add_column( 'remove', __( 'Remove from member', 'convertkit' ), false );

--- a/includes/integrations/wishlist/class-convertkit-wishlist-admin-section.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist-admin-section.php
@@ -119,31 +119,37 @@ class ConvertKit_Wishlist_Admin_Section extends ConvertKit_Admin_Section_Base {
 		$table->add_column( 'add', __( 'Assign to member', 'convertkit' ), false );
 		$table->add_column( 'remove', __( 'Remove from member', 'convertkit' ), false );
 
-		// Iterate through WishList Member Levels, adding a table row for each Level.
+		// Iterate through WishList Member Levels, building table array.
+		$table_rows = array();
 		foreach ( $wlm_levels as $wlm_level ) {
-			$table->add_item(
-				array(
-					'title'  => $wlm_level['name'],
-					'add'    => convertkit_get_subscription_dropdown_field(
-						'_wp_convertkit_integration_wishlistmember_settings[' . $wlm_level['id'] . '_add]',
-						(string) $this->settings->get_convertkit_add_setting_by_wishlist_member_level_id( $wlm_level['id'] ),
-						'_wp_convertkit_integration_wishlistmember_settings_' . $wlm_level['id'] . '_add',
-						'widefat',
-						'wlm'
-					),
-					'remove' => convertkit_get_subscription_dropdown_field(
-						'_wp_convertkit_integration_wishlistmember_settings[' . $wlm_level['id'] . '_remove]',
-						(string) $this->settings->get_convertkit_remove_setting_by_wishlist_member_level_id( $wlm_level['id'] ),
-						'_wp_convertkit_integration_wishlistmember_settings_' . $wlm_level['id'] . '_remove',
-						'widefat',
-						'wlm',
-						array(
-							'unsubscribe' => __( 'Unsubscribe', 'convertkit' ),
-						)
-					),
-				)
+			$table_rows[] = array(
+				'title'  => $wlm_level['name'],
+				'add'    => convertkit_get_subscription_dropdown_field(
+					'_wp_convertkit_integration_wishlistmember_settings[' . $wlm_level['id'] . '_add]',
+					(string) $this->settings->get_convertkit_add_setting_by_wishlist_member_level_id( $wlm_level['id'] ),
+					'_wp_convertkit_integration_wishlistmember_settings_' . $wlm_level['id'] . '_add',
+					'widefat',
+					'wlm'
+				),
+				'remove' => convertkit_get_subscription_dropdown_field(
+					'_wp_convertkit_integration_wishlistmember_settings[' . $wlm_level['id'] . '_remove]',
+					(string) $this->settings->get_convertkit_remove_setting_by_wishlist_member_level_id( $wlm_level['id'] ),
+					'_wp_convertkit_integration_wishlistmember_settings_' . $wlm_level['id'] . '_remove',
+					'widefat',
+					'wlm',
+					array(
+						'unsubscribe' => __( 'Unsubscribe', 'convertkit' ),
+					)
+				),
 			);
 		}
+
+		// Sort table rows.
+		$table_rows = $table->reorder( $table_rows );
+
+		// Set items.
+		$table->add_items( $table_rows );
+		$table->set_total_items( count( $table_rows ) );
 
 		// Prepare and display WP_List_Table.
 		$table->prepare_items();

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -24,11 +24,9 @@
 		They are not intended as advice about which sniffs to exclude.
 		-->
 
-		<!--
-		<exclude name="WordPress.WhiteSpace.ControlStructureSpacing"/>
-		-->
 		<exclude name="WordPress.PHP.YodaConditions" />
 		<exclude name="WordPress.DB.SlowDBQuery.slow_db_query_meta_query" />
+		<exclude name="WordPress.DB.DirectDatabaseQuery" />
 		<exclude name="PSR2.Methods.FunctionClosingBrace.SpacingBeforeClose" />
 		<exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody" />
 	</rule>

--- a/tests/EndToEnd/general/other/UpgradePathsCest.php
+++ b/tests/EndToEnd/general/other/UpgradePathsCest.php
@@ -194,6 +194,28 @@ class UpgradePathsCest
 	}
 
 	/**
+	 * Tests that the form entries table is created when upgrading to 3.0.0 or later.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testCreateFormEntriesTable(EndToEndTester $I)
+	{
+		// Setup Kit Plugin.
+		$I->setupKitPlugin($I);
+
+		// Define an installation version older than 3.0.0.
+		$I->haveOptionInDatabase('convertkit_version', '2.8.7');
+
+		// Activate the Plugin, as if we just upgraded to 3.0.0 or higher.
+		$I->activateKitPlugin($I, false);
+
+		// Confirm the form entries table is created.
+		$I->seeTableInDatabase('wp_kit_form_entries');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/Integration/FormEntriesTest.php
+++ b/tests/Integration/FormEntriesTest.php
@@ -1,0 +1,528 @@
+<?php
+
+namespace Tests;
+
+use lucatume\WPBrowser\TestCase\WPTestCase;
+
+/**
+ * Tests for the ConvertKit_Form_Entries functions.
+ *
+ * @since   3.0.0
+ */
+class FormEntriesTest extends WPTestCase
+{
+	/**
+	 * The testing implementation.
+	 *
+	 * @var \WpunitTester.
+	 */
+	protected $tester;
+
+	/**
+	 * The table name.
+	 *
+	 * @var string
+	 */
+	private $table_name = 'wp_kit_form_entries';
+
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since   3.0.0
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		// Activate Plugin.
+		activate_plugins('convertkit/wp-convertkit.php');
+
+		// Initialize the class we want to test.
+		$this->entries = new \ConvertKit_Form_Entries();
+
+		// Confirm initialization didn't result in an error.
+		$this->assertNotInstanceOf(\WP_Error::class, $this->entries);
+	}
+
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since   3.0.0
+	 */
+	public function tearDown(): void
+	{
+		// Destroy the class we tested.
+		unset($this->entries);
+
+		// Deactivate Plugin.
+		deactivate_plugins('convertkit/wp-convertkit.php');
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test adding an entry with the minimum required data.
+	 *
+	 * @since   3.0.0
+	 */
+	public function testAddEntry()
+	{
+		$data = [
+			'post_id'    => 1,
+			'email'      => 'test@example.com',
+			'first_name' => 'Test',
+		];
+		$id   = $this->entries->add($data);
+
+		// Assert no error and that the entry is in the database.
+		$this->assertNotInstanceOf(\WP_Error::class, $id);
+		$this->assertNotFalse($id );
+		$this->seeInDatabase($this->table_name, $data);
+	}
+
+	/**
+	 * Test adding an entry with custom fields, tag ID and sequence ID.
+	 *
+	 * @since   3.0.0
+	 */
+	public function testAddEntryWithAdditionalData()
+	{
+		$data = [
+			'post_id'       => 1,
+			'email'         => 'test@example.com',
+			'first_name'    => 'Test',
+			'custom_fields' => [
+				'custom_field_1' => 'Custom Field 1',
+				'custom_field_2' => 'Custom Field 2',
+			],
+			'tag_id'        => 1,
+			'sequence_id'   => 1,
+		];
+		$id   = $this->entries->add($data);
+
+		// Assert no error and that the entry is in the database.
+		$this->assertNotInstanceOf(\WP_Error::class, $id);
+		$this->assertNotFalse($id);
+		$this->seeInDatabase($this->table_name, $data);
+	}
+
+	/**
+	 * Test adding an entry with no email address returns a WP_Error.
+	 *
+	 * @since   3.0.0
+	 */
+	public function testAddEntryWithNoEmail()
+	{
+		$data = [
+			'post_id'    => 1,
+			'first_name' => 'Test',
+		];
+		$id   = $this->entries->add($data);
+
+		// Assert an error and that the entry is not in the database.
+		$this->assertInstanceOf(\WP_Error::class, $id);
+		$this->dontSeeInDatabase($this->table_name, $data);
+	}
+
+	/**
+	 * Test updating an entry.
+	 *
+	 * @since   3.0.0
+	 */
+	public function testUpdateEntry()
+	{
+		// Add an entry.
+		$data = [
+			'post_id'    => 1,
+			'email'      => 'test@example.com',
+			'first_name' => 'Test',
+		];
+		$id   = $this->entries->add($data);
+
+		// Assert no error and that the entry is in the database.
+		$this->assertNotInstanceOf(\WP_Error::class, $id);
+		$this->assertNotFalse($id);
+		$this->seeInDatabase($this->table_name, $data);
+
+		// Update the entry.
+		$updatedData = array_merge(
+			$data,
+			[
+				'first_name'  => 'Updated',
+				'tag_id'      => 2,
+				'sequence_id' => 2,
+			]
+		);
+		$updatedId   = $this->entries->update($id, $updatedData);
+
+		// Assert no error, the updated entry is in the database, and the original entry is not.
+		$this->assertNotInstanceOf(\WP_Error::class, $updatedId);
+		$this->assertNotFalse($updatedId);
+		$this->assertEquals($id, $updatedId);
+		$this->seeInDatabase($this->table_name, $updatedData);
+		$this->dontSeeInDatabase($this->table_name, $data);
+	}
+
+	/**
+	 * Test upserting an entry.
+	 *
+	 * @since   3.0.0
+	 */
+	public function testUpsertEntry()
+	{
+		// Add an entry.
+		$data = [
+			'post_id'    => 1,
+			'email'      => 'test@example.com',
+			'first_name' => 'Test',
+		];
+		$id   = $this->entries->upsert( $data );
+
+		// Assert no error and that the entry is in the database.
+		$this->assertNotInstanceOf(\WP_Error::class, $id);
+		$this->assertNotFalse($id);
+		$this->seeInDatabase($this->table_name, $data);
+
+		// Update the entry.
+		$updatedData = array_merge(
+			$data,
+			[
+				'first_name'  => 'Updated',
+				'tag_id'      => 2,
+				'sequence_id' => 2,
+			]
+		);
+		$updatedId   = $this->entries->upsert($updatedData);
+
+		// Assert no error, the updated entry is in the database, and the original entry is not.
+		$this->assertNotInstanceOf(\WP_Error::class, $updatedId);
+		$this->assertNotFalse($updatedId);
+		$this->assertEquals($id, $updatedId);
+		$this->seeInDatabase($this->table_name, $updatedData);
+		$this->dontSeeInDatabase($this->table_name, $data);
+	}
+
+	/**
+	 * Test upserting an entry with no email address returns a WP_Error.
+	 *
+	 * @since   3.0.0
+	 */
+	public function testUpsertEntryWithNoEmail()
+	{
+		$data = [
+			'post_id'    => 1,
+			'first_name' => 'Test',
+		];
+		$id   = $this->entries->upsert($data);
+
+		// Assert an error and that the entry is not in the database.
+		$this->assertInstanceOf(\WP_Error::class, $id);
+		$this->dontSeeInDatabase($this->table_name, $data);
+	}
+
+	/**
+	 * Test deleting an entry.
+	 *
+	 * @since   3.0.0
+	 */
+	public function testDeleteEntry()
+	{
+		// Add entry.
+		$data = [
+			'post_id' => 1,
+			'email'   => 'test@example.com',
+		];
+		$id   = $this->entries->add($data);
+
+		// Assert no error and that the entry is in the database.
+		$this->assertNotInstanceOf(\WP_Error::class, $id);
+		$this->assertNotFalse($id );
+		$this->seeInDatabase($this->table_name, $data);
+
+		// Delete the entry.
+		$this->entries->delete_by_id($id);
+
+		// Assert the entry is not in the database.
+		$this->dontSeeInDatabase($this->table_name, $data);
+	}
+
+	/**
+	 * Test deleting multiple entries.
+	 *
+	 * @since   3.0.0
+	 */
+	public function testDeleteEntries()
+	{
+		// Seed database table.
+		$ids = $this->seedDatabaseTable();
+
+		// Delete entries.
+		$this->entries->delete_by_ids($ids);
+
+		// Assert database table is empty.
+		$this->assertDatabaseTableIsEmpty($this->table_name);
+	}
+
+	/**
+	 * Test deleting all entries.
+	 *
+	 * @since   3.0.0
+	 */
+	public function testDeleteAllEntries()
+	{
+		// Seed database table.
+		$this->seedDatabaseTable();
+
+		// Delete all entries.
+		$this->entries->delete_all();
+
+		// Assert database table is empty.
+		$this->assertDatabaseTableIsEmpty($this->table_name);
+	}
+
+	/**
+	 * Test searching for entries.
+	 *
+	 * @since   3.0.0
+	 */
+	public function testSearchNoParameters()
+	{
+		// Seed database table.
+		$this->seedDatabaseTable();
+
+		// Run search with no parameters.
+		$results = $this->entries->search();
+
+		// Assert the correct number of results are returned.
+		$this->assertEquals(10, count($results));
+	}
+
+	/**
+	 * Test searching for entries with order by and order parameters.
+	 *
+	 * @since   3.0.0
+	 */
+	public function testSearchOrderByAndOrder()
+	{
+		// Seed database table.
+		$this->seedDatabaseTable();
+
+		// Run search ordered by post ID ascending.
+		$results = $this->entries->search(
+			order_by: 'post_id',
+			order: 'asc',
+		);
+		$this->assertEquals( 0, $results[0]['post_id'] );
+		$this->assertEquals( 1, $results[1]['post_id'] );
+
+		// Run search ordered by post ID descending.
+		$results = $this->entries->search(
+			order_by: 'post_id',
+			order: 'desc',
+		);
+		$this->assertEquals( 9, $results[0]['post_id'] );
+		$this->assertEquals( 8, $results[1]['post_id'] );
+
+		// Run search ordered by email ascending.
+		$results = $this->entries->search(
+			order_by: 'email',
+			order: 'asc',
+		);
+		$this->assertEquals( 'test0@example.com', $results[0]['email'] );
+		$this->assertEquals( 'test1@example.com', $results[1]['email'] );
+
+		// Run search ordered by email descending.
+		$results = $this->entries->search(
+			order_by: 'email',
+			order: 'desc',
+		);
+		$this->assertEquals( 'test9@example.com', $results[0]['email'] );
+		$this->assertEquals( 'test8@example.com', $results[1]['email'] );
+
+		// Run search ordered by first name ascending.
+		$results = $this->entries->search(
+			order_by: 'first_name',
+			order: 'asc',
+		);
+		$this->assertEquals( 'Test 0', $results[0]['first_name'] );
+		$this->assertEquals( 'Test 1', $results[1]['first_name'] );
+
+		// Run search ordered by first name descending.
+		$results = $this->entries->search(
+			order_by: 'first_name',
+			order: 'desc',
+		);
+		$this->assertEquals( 'Test 9', $results[0]['first_name'] );
+		$this->assertEquals( 'Test 8', $results[1]['first_name'] );
+	}
+
+	/**
+	 * Test searching for entries with search parameters.
+	 *
+	 * @since   3.0.0
+	 */
+	public function testSearchWithSearchParameter()
+	{
+		// Seed database table.
+		$this->seedDatabaseTable();
+
+		// Run specific search for first name.
+		$results = $this->entries->search(
+			search: 'Test 0',
+		);
+
+		// Assert the correct number of results are returned.
+		$this->assertEquals( 1, count( $results ) );
+		$this->assertEquals( 'Test 0', $results[0]['first_name'] );
+
+		// Run specific search for email.
+		$results = $this->entries->search(
+			search: 'test0@example.com',
+		);
+
+		// Assert the correct number of results are returned.
+		$this->assertEquals( 1, count( $results ) );
+		$this->assertEquals( 'test0@example.com', $results[0]['email'] );
+
+		// Run generic search.
+		$results = $this->entries->search(
+			search: 'test0',
+		);
+
+		// Assert the correct number of results are returned.
+		$this->assertEquals( 1, count( $results ) );
+		$this->assertEquals( 'test0@example.com', $results[0]['email'] );
+
+		// Run generic search on email, ordered by post ID descending.
+		$results = $this->entries->search(
+			search: 'example.com',
+			order_by: 'post_id',
+			order: 'desc',
+		);
+
+		// Assert the correct number of results are returned.
+		$this->assertEquals( 10, count( $results ) );
+		$this->assertEquals( 9, $results[0]['post_id'] );
+		$this->assertEquals( 8, $results[1]['post_id'] );
+	}
+
+	/**
+	 * Add entries to the database table.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @return array
+	 */
+	protected function seedDatabaseTable()
+	{
+		// Delete all entries.
+		$this->entries->delete_all();
+
+		// Add entries.
+		$ids = [];
+		for ( $i = 0; $i < 10; $i++ ) {
+			$data  = [
+				'post_id'    => $i,
+				'first_name' => 'Test ' . $i,
+				'email'      => 'test' . $i . '@example.com',
+			];
+			$id    = $this->entries->add($data);
+			$ids[] = $id;
+			// Assert no error and that the entry is in the database.
+			$this->assertNotInstanceOf(\WP_Error::class, $id);
+			$this->assertNotFalse($id);
+			$this->seeInDatabase($this->table_name, $data);
+		}
+
+		return $ids;
+	}
+
+	/**
+	 * Assert that a row exists in the database table matching the given conditions.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param string $table         Table name.
+	 * @param array  $conditions    Column => value pairs to match.
+	 */
+	protected function seeInDatabase(string $table, array $conditions): void
+	{
+		global $wpdb;
+
+		// Fetch row and run assertion.
+		$this->assertNotNull(
+			$wpdb->get_row($this->buildQuery($table, $conditions)), // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			"No row found in table '$table' matching conditions: " . wp_json_encode($conditions)
+		);
+	}
+
+	/**
+	 * Assert that no row exists in the database table matching the given conditions.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param string $table         Table name.
+	 * @param array  $conditions    Column => value pairs to match.
+	 */
+	protected function dontSeeInDatabase(string $table, array $conditions): void
+	{
+		global $wpdb;
+
+		// Fetch row and run assertion.
+		$this->assertNull(
+			$wpdb->get_row($this->buildQuery($table, $conditions)), // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			"Row found in table '$table' matching conditions: " . wp_json_encode($conditions)
+		);
+	}
+
+	/**
+	 * Assert that the database table is empty.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param string $table Table name.
+	 */
+	protected function assertDatabaseTableIsEmpty(string $table): void
+	{
+		global $wpdb;
+		$this->assertEquals( 0, $wpdb->get_var( "SELECT COUNT(*) FROM $table" ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+
+	/**
+	 * Build a SQL query for the given table and conditions.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param string $table         Table name.
+	 * @param array  $conditions    Column => value pairs to match.
+	 * @return string
+	 */
+	protected function buildQuery(string $table, array $conditions): string
+	{
+		global $wpdb;
+
+		// Fail if no conditions are provided.
+		if (empty($conditions)) {
+			$this->fail('You must provide at least one condition.');
+		}
+
+		// Build WHERE clauses.
+		$where_clauses = [];
+		$values        = [];
+		foreach ($conditions as $column => $value) {
+			// Detect integer vs string for proper placeholder.
+			$placeholder     = is_int($value) ? '%d' : '%s';
+			$where_clauses[] = "$column = $placeholder";
+
+			// If the value is an array, check for the JSON encoded value, as this is how
+			// the Form Entries class stores array valus such as custom fields.
+			$values[] = is_array($value) ? wp_json_encode($value) : $value;
+		}
+
+		// Build SQL.
+		$where_sql = implode(' AND ', $where_clauses);
+		$sql       = "SELECT * FROM $table WHERE $where_sql LIMIT 1";
+
+		return $wpdb->prepare($sql, ...$values); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+	}
+}

--- a/tests/Support/Helper/KitPlugin.php
+++ b/tests/Support/Helper/KitPlugin.php
@@ -568,6 +568,21 @@ class KitPlugin extends \Codeception\Module
 	}
 
 	/**
+	 * Helper method to load the Plugin's Settings > Form Entries screen.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param   EndToEndTester $I     EndToEndTester.
+	 */
+	public function loadKitSettingsFormEntriesScreen($I)
+	{
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=form-entries');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+	}
+
+	/**
 	 * Helper method to clear the Plugin's debug log.
 	 *
 	 * @since   1.9.6

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -114,7 +114,7 @@ require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-settings.ph
 require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-tinymce.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-user.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-setup-wizard.php';
-require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-multi-value-field-table.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-wp-list-table.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-base.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-broadcasts.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-general.php';

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -57,6 +57,7 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-broadcasts-exp
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-broadcasts-importer.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-cache-plugins.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-cron.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-form-entries.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-gutenberg.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-media-library.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-output.php';
@@ -117,6 +118,7 @@ require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-setup-wizar
 require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-wp-list-table.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-base.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-broadcasts.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-form-entries.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-general.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-oauth.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-restrict-content.php';


### PR DESCRIPTION
## Summary

Renames the `Multi_Value_Table` class to `ConvertKit_WP_List_Table`, and removes some unused methods.

This class has been named this way since the Plugin's creation, and doesn't follow the naming convention of the Plugin's other classes starting with `ConvertKit_*`.

Further work on this class will follow when using it to display form submissions via the [Form Entries block](https://github.com/Kit/convertkit-wordpress/pull/886).

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)