### PR TITLE
Form Builder: View Entries

### DIFF
--- a/admin/class-convertkit-wp-list-table.php
+++ b/admin/class-convertkit-wp-list-table.php
@@ -152,10 +152,10 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 
 	/**
 	 * Add multiple items to the table
-	 * 
+	 *
 	 * @since   3.0.0
 	 *
-	 * @param 	array 	$items 	Table rows.
+	 * @param   array $items  Table rows.
 	 */
 	public function add_items( $items ) {
 
@@ -166,10 +166,10 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 	/**
 	 * Set the total number of items available, which may
 	 * be greater than the number of items displayed.
-	 * 
+	 *
 	 * @since   3.0.0
 	 *
-	 * @param 	int 	$total_items 	Total number of items.
+	 * @param   int $total_items    Total number of items.
 	 */
 	public function set_total_items( $total_items ) {
 
@@ -180,7 +180,7 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 	/**
 	 * Get the total number of items available, which may
 	 * be greater than the number of items displayed.
-	 * 
+	 *
 	 * @since   3.0.0
 	 *
 	 * @return int Total number of items.
@@ -205,7 +205,7 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 
 	/**
 	 * Define table columns and pagination for this WP_List_Table.
-	 * 
+	 *
 	 * @since   3.0.0
 	 */
 	public function prepare_items() {
@@ -219,9 +219,9 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 	/**
 	 * Reorder the data according to the sort parameters
 	 *
-	 * @param array  $data   			Row data, unsorted.
-	 * @param string $order_by_default 	Default order by.
-	 * @param string $order_default 	Default order direction.
+	 * @param array  $data              Row data, unsorted.
+	 * @param string $order_by_default  Default order by.
+	 * @param string $order_default     Default order direction.
 	 *
 	 * @return array Row data, sorted
 	 */
@@ -232,7 +232,7 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 			function ( $a, $b ) use ( $order_by_default, $order_default ) {
 				// Get order by and order.
 				$orderby = $this->get_order_by( $order_by_default );
-				$order = $this->get_order( $order_default );
+				$order   = $this->get_order( $order_default );
 
 				$result = strcmp( $a[ $orderby ], $b[ $orderby ] ); // Determine sort order.
 				return ( 'asc' === $order ) ? $result : -$result; // Send final sort direction to usort.
@@ -284,13 +284,14 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 	 *
 	 * @since   3.0.0
 	 *
+	 * @param   string $default_order_by  Default order by.
 	 * @return  string
 	 */
-	public function get_order_by( $default = 'title' ) {
+	public function get_order_by( $default_order_by = 'title' ) {
 
 		// Don't nonce check because order by may not include a nonce if no search performed.
 		if ( ! filter_has_var( INPUT_GET, 'orderby' ) ) {
-			return $default;
+			return $default_order_by;
 		}
 
 		return sanitize_sql_orderby( filter_input( INPUT_GET, 'orderby', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
@@ -302,13 +303,14 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 	 *
 	 * @since   3.0.0
 	 *
+	 * @param   string $default_order  Default order.
 	 * @return  string
 	 */
-	public function get_order( $default = 'DESC' ) {
+	public function get_order( $default_order = 'DESC' ) {
 
 		// Don't nonce check because order may not include a nonce if no search performed.
 		if ( ! filter_has_var( INPUT_GET, 'order' ) ) {
-			return $default;
+			return $default_order;
 		}
 
 		return filter_input( INPUT_GET, 'order', FILTER_SANITIZE_FULL_SPECIAL_CHARS );

--- a/admin/class-convertkit-wp-list-table.php
+++ b/admin/class-convertkit-wp-list-table.php
@@ -134,7 +134,7 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 		$this->columns[ $key ] = $title;
 
 		if ( $sortable ) {
-			$this->sortable_columns[ $key ] = true;
+			$this->sortable_columns[ $key ] = array( $key, false );
 		}
 
 	}

--- a/admin/class-convertkit-wp-list-table.php
+++ b/admin/class-convertkit-wp-list-table.php
@@ -150,18 +150,41 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 
 	}
 
+	/**
+	 * Add multiple items to the table
+	 * 
+	 * @since   3.0.0
+	 *
+	 * @param 	array 	$items 	Table rows.
+	 */
 	public function add_items( $items ) {
 
 		$this->items = $items;
 
 	}
 
+	/**
+	 * Set the total number of items available, which may
+	 * be greater than the number of items displayed.
+	 * 
+	 * @since   3.0.0
+	 *
+	 * @param 	int 	$total_items 	Total number of items.
+	 */
 	public function set_total_items( $total_items ) {
 
 		$this->total_items = $total_items;
 
 	}
 
+	/**
+	 * Get the total number of items available, which may
+	 * be greater than the number of items displayed.
+	 * 
+	 * @since   3.0.0
+	 *
+	 * @return int Total number of items.
+	 */
 	public function get_total_items() {
 
 		return $this->total_items ?? count( $this->items );
@@ -181,28 +204,15 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 	}
 
 	/**
-	 * Prepares the items (rows) to be rendered
+	 * Define table columns and pagination for this WP_List_Table.
+	 * 
+	 * @since   3.0.0
 	 */
 	public function prepare_items() {
 
-		
-
-		/*
-
-
-
-		var_dump( $this->items );
-
-		// Define pagination.
-		$per_page = 25;
-		$this->set_pagination_args(
-			array(
-				'total_items' => $this->total_items,
-				'total_pages' => ceil( $this->total_items / $per_page ),
-				'per_page'    => $per_page,
-			)
-		);
-		*/
+		// Set column headers.
+		// If this isn't done, the table will not display.
+		$this->_column_headers = array( $this->columns, array(), $this->sortable_columns );
 
 	}
 
@@ -302,24 +312,6 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 		}
 
 		return filter_input( INPUT_GET, 'order', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
-
-	}
-
-	/**
-	 * Get the Pagination Page requested by the user
-	 *
-	 * @since   3.0.0
-	 *
-	 * @return  string
-	 */
-	public function get_page() {
-
-		// Don't nonce check because pagination may not include a nonce if no search performed.
-		if ( ! filter_has_var( INPUT_GET, 'paged' ) ) {
-			return 1;
-		}
-
-		return absint( filter_input( INPUT_GET, 'paged', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 	}
 

--- a/admin/class-convertkit-wp-list-table.php
+++ b/admin/class-convertkit-wp-list-table.php
@@ -185,16 +185,9 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 	 */
 	public function prepare_items() {
 
-		$this->items = [
-			[
-				'id' => 1,
-				'title' => 'Item 1',
-			],
-			[
-				'id' => 2,
-				'title' => 'Item 2',
-			],
-		];
+		
+
+		/*
 
 
 
@@ -209,6 +202,7 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 				'per_page'    => $per_page,
 			)
 		);
+		*/
 
 	}
 

--- a/admin/class-convertkit-wp-list-table.php
+++ b/admin/class-convertkit-wp-list-table.php
@@ -187,7 +187,11 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 	 */
 	public function get_total_items() {
 
-		return $this->total_items ?? count( $this->items );
+		if ( $this->total_items ) {
+			return $this->total_items;
+		}
+
+		return count( $this->items );
 
 	}
 

--- a/admin/class-convertkit-wp-list-table.php
+++ b/admin/class-convertkit-wp-list-table.php
@@ -44,11 +44,13 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 	private $sortable_columns = array();
 
 	/**
-	 * Holds the table rows and their data.
+	 * Holds the total number of items in the table.
 	 *
-	 * @var     array
+	 * @since   3.0.0
+	 *
+	 * @var     int
 	 */
-	private $data = array();
+	private $total_items = 0;
 
 	/**
 	 * Constructor.
@@ -132,7 +134,7 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 		$this->columns[ $key ] = $title;
 
 		if ( $sortable ) {
-			$this->sortable_columns[ $key ] = array( $key, false );
+			$this->sortable_columns[ $key ] = true;
 		}
 
 	}
@@ -144,7 +146,25 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 	 */
 	public function add_item( $item ) {
 
-		array_push( $this->data, $item );
+		array_push( $this->items, $item );
+
+	}
+
+	public function add_items( $items ) {
+
+		$this->items = $items;
+
+	}
+
+	public function set_total_items( $total_items ) {
+
+		$this->total_items = $total_items;
+
+	}
+
+	public function get_total_items() {
+
+		return $this->total_items ?? count( $this->items );
 
 	}
 
@@ -165,28 +185,28 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 	 */
 	public function prepare_items() {
 
-		$total_items = count( $this->data );
-		$per_page    = 25;
+		$this->items = [
+			[
+				'id' => 1,
+				'title' => 'Item 1',
+			],
+			[
+				'id' => 2,
+				'title' => 'Item 2',
+			],
+		];
 
-		$columns  = $this->columns;
-		$hidden   = array();
-		$sortable = $this->sortable_columns;
 
-		$this->_column_headers = array( $columns, $hidden, $sortable );
 
-		$current_page = $this->get_pagenum();
+		var_dump( $this->items );
 
-		$sorted_data = $this->reorder( $this->data );
-
-		$data = array_slice( $sorted_data, ( ( $current_page - 1 ) * $per_page ), $per_page );
-
-		$this->items = $data;
-
+		// Define pagination.
+		$per_page = 25;
 		$this->set_pagination_args(
 			array(
-				'total_items' => $total_items,
+				'total_items' => $this->total_items,
+				'total_pages' => ceil( $this->total_items / $per_page ),
 				'per_page'    => $per_page,
-				'total_pages' => (int) ceil( $total_items / $per_page ),
 			)
 		);
 
@@ -195,26 +215,21 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 	/**
 	 * Reorder the data according to the sort parameters
 	 *
-	 * @param array $data   Row data, unsorted.
+	 * @param array  $data   			Row data, unsorted.
+	 * @param string $order_by_default 	Default order by.
+	 * @param string $order_default 	Default order direction.
+	 *
 	 * @return array Row data, sorted
 	 */
-	public function reorder( $data ) {
+	public function reorder( $data, $order_by_default = 'title', $order_default = 'asc' ) {
 
 		usort(
 			$data,
-			function ( $a, $b ) {
+			function ( $a, $b ) use ( $order_by_default, $order_default ) {
+				// Get order by and order.
+				$orderby = $this->get_order_by( $order_by_default );
+				$order = $this->get_order( $order_default );
 
-				if ( ! filter_has_var( INPUT_GET, 'orderby' ) || empty( filter_input( INPUT_GET, 'orderby', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) ) {
-					$orderby = 'title';
-				} else {
-					$orderby = sanitize_sql_orderby( filter_input( INPUT_GET, 'orderby', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
-				}
-
-				if ( ! filter_has_var( INPUT_GET, 'order' ) || empty( filter_input( INPUT_GET, 'order', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) ) {
-					$order = 'asc';
-				} else {
-					$order = filter_input( INPUT_GET, 'order', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
-				}
 				$result = strcmp( $a[ $orderby ], $b[ $orderby ] ); // Determine sort order.
 				return ( 'asc' === $order ) ? $result : -$result; // Send final sort direction to usort.
 
@@ -222,6 +237,95 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 		);
 
 		return $data;
+
+	}
+
+	/**
+	 * Returns whether a search has been performed on the table.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @return  bool    Search has been performed.
+	 */
+	public function is_search() {
+
+		return filter_has_var( INPUT_GET, 's' );
+
+	}
+
+	/**
+	 * Get the Search requested by the user
+	 *
+	 * @since   3.0.0
+	 *
+	 * @return  string
+	 */
+	public function get_search() {
+
+		// Bail if nonce is not valid.
+		if ( ! isset( $_REQUEST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( wp_unslash( $_REQUEST['_wpnonce'] ) ), 'bulk-wp-to-social-log' ) ) {
+			return '';
+		}
+
+		if ( ! array_key_exists( 's', $_REQUEST ) ) {
+			return '';
+		}
+
+		return urldecode( sanitize_text_field( wp_unslash( $_REQUEST['s'] ) ) );
+
+	}
+
+	/**
+	 * Get the Order By requested by the user
+	 *
+	 * @since   3.0.0
+	 *
+	 * @return  string
+	 */
+	public function get_order_by( $default = 'title' ) {
+
+		// Don't nonce check because order by may not include a nonce if no search performed.
+		if ( ! filter_has_var( INPUT_GET, 'orderby' ) ) {
+			return $default;
+		}
+
+		return sanitize_sql_orderby( filter_input( INPUT_GET, 'orderby', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+
+	}
+
+	/**
+	 * Get the Order requested by the user
+	 *
+	 * @since   3.0.0
+	 *
+	 * @return  string
+	 */
+	public function get_order( $default = 'DESC' ) {
+
+		// Don't nonce check because order may not include a nonce if no search performed.
+		if ( ! filter_has_var( INPUT_GET, 'order' ) ) {
+			return $default;
+		}
+
+		return filter_input( INPUT_GET, 'order', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+
+	}
+
+	/**
+	 * Get the Pagination Page requested by the user
+	 *
+	 * @since   3.0.0
+	 *
+	 * @return  string
+	 */
+	public function get_page() {
+
+		// Don't nonce check because pagination may not include a nonce if no search performed.
+		if ( ! filter_has_var( INPUT_GET, 'paged' ) ) {
+			return 1;
+		}
+
+		return absint( filter_input( INPUT_GET, 'paged', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 	}
 

--- a/admin/section/class-convertkit-admin-section-form-entries.php
+++ b/admin/section/class-convertkit-admin-section-form-entries.php
@@ -110,11 +110,7 @@ class ConvertKit_Admin_Section_Form_Entries extends ConvertKit_Admin_Section_Bas
 		$table->add_column( 'api_error', __( 'Error', 'convertkit' ), false );
 
 		// Add form entries to table.
-		$entries = $form_entries->search(
-			$table->get_order_by( 'created_at' ),
-			$table->get_order( 'DESC' ),
-			$table->get_pagenum()
-		);
+		$entries = $form_entries->search();
 		$table->add_items( $entries );
 
 		// Set total entries.

--- a/admin/section/class-convertkit-admin-section-form-entries.php
+++ b/admin/section/class-convertkit-admin-section-form-entries.php
@@ -60,7 +60,7 @@ class ConvertKit_Admin_Section_Form_Entries extends ConvertKit_Admin_Section_Bas
 		?>
 		<p>
 			<?php
-			esc_html_e( 'Displays a list of form entries from Form Builder blocks that have "store entries" enabled. Entries submitted using embedded Kit Forms or Landing Pages are not included.', 'convertkit' );
+			esc_html_e( 'Displays a list of form entries from Form Builder blocks that have "store form submissions" enabled. Entries submitted using embedded Kit Forms or Landing Pages are not included.', 'convertkit' );
 			?>
 		</p>
 		<?php
@@ -81,10 +81,9 @@ class ConvertKit_Admin_Section_Form_Entries extends ConvertKit_Admin_Section_Bas
 	}
 
 	/**
-	 * Outputs the section as a WP_List_Table of Contact Form 7 Forms, with options to choose
-	 * a ConvertKit Form mapping for each.
+	 * Outputs the section as a WP_List_Table of Form Entries.
 	 *
-	 * @since   1.9.6
+	 * @since   3.0.0
 	 */
 	public function render() {
 
@@ -102,7 +101,7 @@ class ConvertKit_Admin_Section_Form_Entries extends ConvertKit_Admin_Section_Bas
 		$table = new ConvertKit_WP_List_Table();
 
 		// Add columns to table.
-		$table->add_column( 'post_id', __( 'Post ID', 'convertkit' ), true );
+		$table->add_column( 'post_id', __( 'Post ID', 'convertkit' ), false );
 		$table->add_column( 'first_name', __( 'First Name', 'convertkit' ), false );
 		$table->add_column( 'email', __( 'Email', 'convertkit' ), false );
 		$table->add_column( 'created_at', __( 'Created', 'convertkit' ), false );
@@ -114,8 +113,7 @@ class ConvertKit_Admin_Section_Form_Entries extends ConvertKit_Admin_Section_Bas
 		$entries = $form_entries->search(
 			$table->get_order_by( 'created_at' ),
 			$table->get_order( 'DESC' ),
-			$table->get_page(),
-			1
+			$table->get_pagenum()
 		);
 		$table->add_items( $entries );
 
@@ -143,10 +141,6 @@ add_filter(
 	 * @return  array
 	 */
 	function ( $sections ) {
-
-		if ( ! class_exists( 'WP_List_Table' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
-		}
 
 		// Register this class as a section at Settings > Kit.
 		$sections['form-entries'] = new ConvertKit_Admin_Section_Form_Entries();

--- a/admin/section/class-convertkit-admin-section-form-entries.php
+++ b/admin/section/class-convertkit-admin-section-form-entries.php
@@ -15,15 +15,6 @@
 class ConvertKit_Form_Entries_Admin_Section extends ConvertKit_Admin_Section_Base {
 
 	/**
-	 * Holds the WP_List_Table instance.
-	 *
-     * @since   3.0.0
-     *
-	 * @var     ConvertKit_WP_List_Table
-	 */
-	public $table;
-
-	/**
 	 * Constructor
      * 
      * @since   3.0.0
@@ -43,9 +34,6 @@ class ConvertKit_Form_Entries_Admin_Section extends ConvertKit_Admin_Section_Bas
 				'wrap'     => false,
 			),
 		);
-
-		// Setup WP_List_Table.
-		$this->table = new ConvertKit_WP_List_Table();
 
 		parent::__construct();
 
@@ -110,31 +98,34 @@ class ConvertKit_Form_Entries_Admin_Section extends ConvertKit_Admin_Section_Bas
 		<?php
 		$this->print_section_info();
 
+		// Setup WP_List_Table.
+		$table = new ConvertKit_WP_List_Table();
+
 		// Add columns to table.
-		$this->table->add_column( 'post_id', __( 'Post ID', 'convertkit' ), true );
-		$this->table->add_column( 'first_name', __( 'First Name', 'convertkit' ), false );
-		$this->table->add_column( 'email', __( 'Email', 'convertkit' ), false );
-		$this->table->add_column( 'created_at', __( 'Created', 'convertkit' ), false );
-        $this->table->add_column( 'updated_at', __( 'Updated', 'convertkit' ), false );
-		$this->table->add_column( 'api_result', __( 'Result', 'convertkit' ), false );
-        $this->table->add_column( 'api_error', __( 'Error', 'convertkit' ), false );
+		$table->add_column( 'post_id', __( 'Post ID', 'convertkit' ), true );
+		$table->add_column( 'first_name', __( 'First Name', 'convertkit' ), false );
+		$table->add_column( 'email', __( 'Email', 'convertkit' ), false );
+		$table->add_column( 'created_at', __( 'Created', 'convertkit' ), false );
+        $table->add_column( 'updated_at', __( 'Updated', 'convertkit' ), false );
+		$table->add_column( 'api_result', __( 'Result', 'convertkit' ), false );
+        $table->add_column( 'api_error', __( 'Error', 'convertkit' ), false );
 
 		// Add form entries to table.
 		$entries = $form_entries->search(
-			$this->table->get_order_by( 'created_at' ),
-			$this->table->get_order( 'DESC' ),
-			$this->table->get_page(),
+			$table->get_order_by( 'created_at' ),
+			$table->get_order( 'DESC' ),
+			$table->get_page(),
 			1
 		);
-		$this->table->add_items( $entries );
+		$table->add_items( $entries );
 
 		// Set total entries.
-		$this->table->set_total_items( $form_entries->total() );
+		$table->set_total_items( $form_entries->total() );
 		
 		// Prepare and display WP_List_Table.
-		$this->table->prepare_items();
-		$this->table->search_box( __( 'Search', 'convertkit' ), 'convertkit-form-entries' );
-		$this->table->display();
+		$table->prepare_items();
+		$table->search_box( __( 'Search', 'convertkit' ), 'convertkit-form-entries' );
+		$table->display();
 
 		// Render closing container.
 		$this->render_container_end();

--- a/admin/section/class-convertkit-admin-section-form-entries.php
+++ b/admin/section/class-convertkit-admin-section-form-entries.php
@@ -98,6 +98,8 @@ class ConvertKit_Form_Entries_Admin_Section extends ConvertKit_Admin_Section_Bas
 	 */
 	public function render() {
 
+		$form_entries = new ConvertKit_Form_Entries();
+
 		// Render opening container.
 		$this->render_container_start();
 
@@ -106,29 +108,27 @@ class ConvertKit_Form_Entries_Admin_Section extends ConvertKit_Admin_Section_Bas
 		<?php
 		$this->print_section_info();
 
-		// Add search filters to the table.
-		$this->table->add_search_filter(
-			'api_result',
-			__( 'Result', 'convertkit' ),
-			array(
-				'success' => __( 'Success', 'convertkit' ),
-				'error' => __( 'Error', 'convertkit' ),
-			)
-		);
-
-		// Add bulk actions to the table.
-		$this->table->add_bulk_action( 'send', __( 'Send to Kit', 'convertkit' ) );
-		$this->table->add_bulk_action( 'delete', __( 'Delete', 'convertkit' ) );
-
 		// Add columns to table.
 		$this->table->add_column( 'post_id', __( 'Post ID', 'convertkit' ), true );
 		$this->table->add_column( 'first_name', __( 'First Name', 'convertkit' ), false );
 		$this->table->add_column( 'email', __( 'Email', 'convertkit' ), false );
 		$this->table->add_column( 'created_at', __( 'Created', 'convertkit' ), false );
         $this->table->add_column( 'updated_at', __( 'Updated', 'convertkit' ), false );
-		$this->table->add_column( 'api_request_sent', __( 'Sent to Kit', 'convertkit' ), false );
 		$this->table->add_column( 'api_result', __( 'Result', 'convertkit' ), false );
+        $this->table->add_column( 'api_error', __( 'Error', 'convertkit' ), false );
 
+		// Add form entries to table.
+		$entries = $form_entries->search(
+			$this->table->get_order_by(),
+			$this->table->get_order(),
+			$this->table->get_page(),
+			1
+		);
+		$this->table->add_items( $entries );
+
+		// Set total entries.
+		$this->table->set_total_items( $form_entries->total() );
+		
 		// Prepare and display WP_List_Table.
 		$this->table->prepare_items();
 		$this->table->search_box( __( 'Search', 'convertkit' ), 'convertkit-form-entries' );

--- a/admin/section/class-convertkit-admin-section-form-entries.php
+++ b/admin/section/class-convertkit-admin-section-form-entries.php
@@ -12,12 +12,12 @@
  * @package ConvertKit
  * @author ConvertKit
  */
-class ConvertKit_Form_Entries_Admin_Section extends ConvertKit_Admin_Section_Base {
+class ConvertKit_Admin_Section_Form_Entries extends ConvertKit_Admin_Section_Base {
 
 	/**
 	 * Constructor
-     * 
-     * @since   3.0.0
+	 *
+	 * @since   3.0.0
 	 */
 	public function __construct() {
 
@@ -41,8 +41,8 @@ class ConvertKit_Form_Entries_Admin_Section extends ConvertKit_Admin_Section_Bas
 
 	/**
 	 * Register fields for this section
-     * 
-     * @since   3.0.0
+	 *
+	 * @since   3.0.0
 	 */
 	public function register_fields() {
 
@@ -52,8 +52,8 @@ class ConvertKit_Form_Entries_Admin_Section extends ConvertKit_Admin_Section_Bas
 
 	/**
 	 * Prints help info for this section.
-     * 
-     * @since   3.0.0
+	 *
+	 * @since   3.0.0
 	 */
 	public function print_section_info() {
 
@@ -106,9 +106,9 @@ class ConvertKit_Form_Entries_Admin_Section extends ConvertKit_Admin_Section_Bas
 		$table->add_column( 'first_name', __( 'First Name', 'convertkit' ), false );
 		$table->add_column( 'email', __( 'Email', 'convertkit' ), false );
 		$table->add_column( 'created_at', __( 'Created', 'convertkit' ), false );
-        $table->add_column( 'updated_at', __( 'Updated', 'convertkit' ), false );
+		$table->add_column( 'updated_at', __( 'Updated', 'convertkit' ), false );
 		$table->add_column( 'api_result', __( 'Result', 'convertkit' ), false );
-        $table->add_column( 'api_error', __( 'Error', 'convertkit' ), false );
+		$table->add_column( 'api_error', __( 'Error', 'convertkit' ), false );
 
 		// Add form entries to table.
 		$entries = $form_entries->search(
@@ -121,10 +121,9 @@ class ConvertKit_Form_Entries_Admin_Section extends ConvertKit_Admin_Section_Bas
 
 		// Set total entries.
 		$table->set_total_items( $form_entries->total() );
-		
+
 		// Prepare and display WP_List_Table.
 		$table->prepare_items();
-		$table->search_box( __( 'Search', 'convertkit' ), 'convertkit-form-entries' );
 		$table->display();
 
 		// Render closing container.
@@ -150,7 +149,7 @@ add_filter(
 		}
 
 		// Register this class as a section at Settings > Kit.
-		$sections['form-entries'] = new ConvertKit_Form_Entries_Admin_Section();
+		$sections['form-entries'] = new ConvertKit_Admin_Section_Form_Entries();
 		return $sections;
 
 	}

--- a/admin/section/class-convertkit-admin-section-form-entries.php
+++ b/admin/section/class-convertkit-admin-section-form-entries.php
@@ -47,6 +47,8 @@ class ConvertKit_Form_Entries_Admin_Section extends ConvertKit_Admin_Section_Bas
 		// Setup WP_List_Table.
 		$this->table = new ConvertKit_WP_List_Table();
 
+		parent::__construct();
+
 	}
 
 	/**
@@ -119,8 +121,8 @@ class ConvertKit_Form_Entries_Admin_Section extends ConvertKit_Admin_Section_Bas
 
 		// Add form entries to table.
 		$entries = $form_entries->search(
-			$this->table->get_order_by(),
-			$this->table->get_order(),
+			$this->table->get_order_by( 'created_at' ),
+			$this->table->get_order( 'DESC' ),
 			$this->table->get_page(),
 			1
 		);

--- a/includes/class-convertkit-form-entries.php
+++ b/includes/class-convertkit-form-entries.php
@@ -274,7 +274,7 @@ class ConvertKit_Form_Entries {
 		}
 
 		// Run and return total records found.
-		return $wpdb->get_var( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		return (int) $wpdb->get_var( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
 	}
 

--- a/includes/class-convertkit-form-entries.php
+++ b/includes/class-convertkit-form-entries.php
@@ -203,19 +203,16 @@ class ConvertKit_Form_Entries {
 	 *
 	 * @since   3.0.0
 	 *
-	 * @param   string     $order_by   Order Results By.
-	 * @param   string     $order      Order (asc|desc).
-	 * @param   int        $page       Pagination Offset (default: 1).
-	 * @param   int        $per_page   Number of Results to Return (default: 25).
-	 * @param   bool|array $params     Query Parameters (false = all records).
+	 * @param   bool|string $search     Search Query.
+	 * @param   string      $order_by   Order Results By.
+	 * @param   string      $order      Order (asc|desc).
+	 * @param   int         $page       Pagination Offset (default: 1).
+	 * @param   int         $per_page   Number of Results to Return (default: 25).
 	 * @return  array
 	 */
-	public function search( $order_by, $order, $page = 1, $per_page = 25, $params = false ) {
+	public function search( $search = false, $order_by = 'created_at', $order = 'desc', $page = 1, $per_page = 25 ) {
 
 		global $wpdb;
-
-		// Build where clauses.
-		$where = $this->build_where_clause( $params );
 
 		// Prepare query.
 		$query = $wpdb->prepare(
@@ -223,9 +220,13 @@ class ConvertKit_Form_Entries {
 			$wpdb->prefix . $this->table
 		);
 
-		// Add where clauses.
-		if ( $where !== false ) {
-			$query .= ' WHERE ' . $where;
+		// Add search clause.
+		if ( $search ) {
+			$query .= $wpdb->prepare(
+				' WHERE first_name LIKE %s OR email LIKE %s',
+				'%' . $search . '%',
+				'%' . $search . '%'
+			);
 		}
 
 		// Order.
@@ -251,15 +252,12 @@ class ConvertKit_Form_Entries {
 	 *
 	 * @since   3.0.0
 	 *
-	 * @param   mixed $params     Query Parameters (false = all records).
+	 * @param   bool|string $search     Search Query.
 	 * @return  int
 	 */
-	public function total( $params = false ) {
+	public function total( $search = false ) {
 
 		global $wpdb;
-
-		// Build where clauses.
-		$where = $this->build_where_clause( $params );
 
 		// Prepare query.
 		$query = $wpdb->prepare(
@@ -268,60 +266,17 @@ class ConvertKit_Form_Entries {
 			$wpdb->prefix . $this->table
 		);
 
-		// Add where clauses.
-		if ( $where !== false ) {
-			$query .= ' WHERE ' . $where;
+		// Add search clause.
+		if ( $search ) {
+			$query .= $wpdb->prepare(
+				' WHERE first_name LIKE %s OR email LIKE %s',
+				'%' . $search . '%',
+				'%' . $search . '%'
+			);
 		}
 
 		// Run and return total records found.
 		return (int) $wpdb->get_var( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-
-	}
-
-	/**
-	 * Builds a WHERE SQL clause based on the given column key/values
-	 *
-	 * @since   3.0.0
-	 *
-	 * @param   bool|array $params     Query Parameters.
-	 * @return  bool|string
-	 */
-	private function build_where_clause( $params ) {
-
-		global $wpdb;
-
-		// Bail if no params.
-		if ( ! $params ) {
-			return false;
-		}
-
-		// Build where clauses.
-		$where = array();
-		foreach ( $params as $key => $value ) {
-			// Skip blank params.
-			if ( empty( $value ) ) {
-				continue;
-			}
-
-			// Build condition based on the key.
-			switch ( $key ) {
-				default:
-					$where[] = $wpdb->prepare(
-						'%i = %s',
-						$key,
-						$value
-					);
-					break;
-			}
-		}
-
-		// If no where clauses, return false.
-		if ( ! count( $where ) ) {
-			return false;
-		}
-
-		// Return where clause.
-		return implode( ' AND ', $where );
 
 	}
 

--- a/includes/class-convertkit-form-entries.php
+++ b/includes/class-convertkit-form-entries.php
@@ -203,14 +203,14 @@ class ConvertKit_Form_Entries {
 	 *
 	 * @since   3.0.0
 	 *
-	 * @param   string $order_by   Order Results By.
-	 * @param   string $order      Order (asc|desc).
-	 * @param   int    $page       Pagination Offset (default: 0).
-	 * @param   int    $per_page   Number of Results to Return (default: 20).
-	 * @param   mixed  $params     Query Parameters (false = all records).
+	 * @param   string     $order_by   Order Results By.
+	 * @param   string     $order      Order (asc|desc).
+	 * @param   int        $page       Pagination Offset (default: 1).
+	 * @param   int        $per_page   Number of Results to Return (default: 25).
+	 * @param   bool|array $params     Query Parameters (false = all records).
 	 * @return  array
 	 */
-	public function search( $order_by, $order, $page = 0, $per_page = 20, $params = false ) {
+	public function search( $order_by, $order, $page = 1, $per_page = 25, $params = false ) {
 
 		global $wpdb;
 
@@ -283,8 +283,8 @@ class ConvertKit_Form_Entries {
 	 *
 	 * @since   3.0.0
 	 *
-	 * @param   array $params     Query Parameters (false = all records).
-	 * @return  string              WHERE SQL clause
+	 * @param   bool|array $params     Query Parameters.
+	 * @return  bool|string
 	 */
 	private function build_where_clause( $params ) {
 
@@ -297,30 +297,30 @@ class ConvertKit_Form_Entries {
 
 		// Build where clauses.
 		$where = array();
-		if ( $params !== false && is_array( $params ) && count( $params ) > 0 ) {
-			foreach ( $params as $key => $value ) {
-				// Skip blank params.
-				if ( empty( $value ) ) {
-					continue;
-				}
+		foreach ( $params as $key => $value ) {
+			// Skip blank params.
+			if ( empty( $value ) ) {
+				continue;
+			}
 
-				// Build condition based on the key.
-				switch ( $key ) {
-					default:
-						$where[] = $wpdb->prepare(
-							'%i = %s',
-							$key,
-							$value
-						);
-						break;
-				}
+			// Build condition based on the key.
+			switch ( $key ) {
+				default:
+					$where[] = $wpdb->prepare(
+						'%i = %s',
+						$key,
+						$value
+					);
+					break;
 			}
 		}
 
+		// If no where clauses, return false.
 		if ( ! count( $where ) ) {
 			return false;
 		}
 
+		// Return where clause.
 		return implode( ' AND ', $where );
 
 	}

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-section.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-section.php
@@ -15,15 +15,6 @@
 class ConvertKit_ContactForm7_Admin_Section extends ConvertKit_Admin_Section_Base {
 
 	/**
-	 * Holds the WP_List_Table instance.
-	 *
-     * @since   3.0.0
-     *
-	 * @var     ConvertKit_WP_List_Table
-	 */
-	public $table;
-
-	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -47,10 +38,6 @@ class ConvertKit_ContactForm7_Admin_Section extends ConvertKit_Admin_Section_Bas
 				'wrap'     => false,
 			),
 		);
-
-		// Setup WP_List_Table.
-		// Doing this in render() is too late - columns and items don't display.
-		$this->table = new ConvertKit_WP_List_Table();
 
 		parent::__construct();
 
@@ -147,11 +134,12 @@ class ConvertKit_ContactForm7_Admin_Section extends ConvertKit_Admin_Section_Bas
 		$creator_network_recommendations_enabled = $creator_network_recommendations->enabled();
 
 		// Setup WP_List_Table.
-		$this->table->add_column( 'title', __( 'Contact Form 7 Form', 'convertkit' ), true );
-		$this->table->add_column( 'form', __( 'Kit', 'convertkit' ), false );
-		$this->table->add_column( 'email', __( 'Contact Form 7 Email Field', 'convertkit' ), false );
-		$this->table->add_column( 'name', __( 'Contact Form 7 Name Field', 'convertkit' ), false );
-		$this->table->add_column( 'creator_network_recommendations', __( 'Enable Creator Network Recommendations', 'convertkit' ), false );
+		$table = new ConvertKit_WP_List_Table();
+		$table->add_column( 'title', __( 'Contact Form 7 Form', 'convertkit' ), true );
+		$table->add_column( 'form', __( 'Kit', 'convertkit' ), false );
+		$table->add_column( 'email', __( 'Contact Form 7 Email Field', 'convertkit' ), false );
+		$table->add_column( 'name', __( 'Contact Form 7 Name Field', 'convertkit' ), false );
+		$table->add_column( 'creator_network_recommendations', __( 'Enable Creator Network Recommendations', 'convertkit' ), false );
 
 		// Iterate through Contact Form 7 Forms, building table array.
 		$table_rows = array();
@@ -193,15 +181,15 @@ class ConvertKit_ContactForm7_Admin_Section extends ConvertKit_Admin_Section_Bas
 		}
 
 		// Sort table rows.
-		$table_rows = $this->table->reorder( $table_rows );
+		$table_rows = $table->reorder( $table_rows );
 
 		// Set items.
-		$this->table->add_items( $table_rows );
-		$this->table->set_total_items( count( $table_rows ) );
+		$table->add_items( $table_rows );
+		$table->set_total_items( count( $table_rows ) );
 
 		// Prepare and display WP_List_Table.
-		$this->table->prepare_items();
-		$this->table->display();
+		$table->prepare_items();
+		$table->display();
 
 		// Register settings field.
 		settings_fields( $this->settings_key );

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-section.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-section.php
@@ -15,6 +15,15 @@
 class ConvertKit_ContactForm7_Admin_Section extends ConvertKit_Admin_Section_Base {
 
 	/**
+	 * Holds the WP_List_Table instance.
+	 *
+     * @since   3.0.0
+     *
+	 * @var     ConvertKit_WP_List_Table
+	 */
+	public $table;
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -38,6 +47,10 @@ class ConvertKit_ContactForm7_Admin_Section extends ConvertKit_Admin_Section_Bas
 				'wrap'     => false,
 			),
 		);
+
+		// Setup WP_List_Table.
+		// Doing this in render() is too late - columns and items don't display.
+		$this->table = new ConvertKit_WP_List_Table();
 
 		parent::__construct();
 
@@ -134,12 +147,11 @@ class ConvertKit_ContactForm7_Admin_Section extends ConvertKit_Admin_Section_Bas
 		$creator_network_recommendations_enabled = $creator_network_recommendations->enabled();
 
 		// Setup WP_List_Table.
-		$table = new ConvertKit_WP_List_Table();
-		$table->add_column( 'title', __( 'Contact Form 7 Form', 'convertkit' ), true );
-		$table->add_column( 'form', __( 'Kit', 'convertkit' ), false );
-		$table->add_column( 'email', __( 'Contact Form 7 Email Field', 'convertkit' ), false );
-		$table->add_column( 'name', __( 'Contact Form 7 Name Field', 'convertkit' ), false );
-		$table->add_column( 'creator_network_recommendations', __( 'Enable Creator Network Recommendations', 'convertkit' ), false );
+		$this->table->add_column( 'title', __( 'Contact Form 7 Form', 'convertkit' ), true );
+		$this->table->add_column( 'form', __( 'Kit', 'convertkit' ), false );
+		$this->table->add_column( 'email', __( 'Contact Form 7 Email Field', 'convertkit' ), false );
+		$this->table->add_column( 'name', __( 'Contact Form 7 Name Field', 'convertkit' ), false );
+		$this->table->add_column( 'creator_network_recommendations', __( 'Enable Creator Network Recommendations', 'convertkit' ), false );
 
 		// Iterate through Contact Form 7 Forms, building table array.
 		$table_rows = array();
@@ -181,15 +193,15 @@ class ConvertKit_ContactForm7_Admin_Section extends ConvertKit_Admin_Section_Bas
 		}
 
 		// Sort table rows.
-		$table_rows = $table->reorder( $table_rows, 'title', 'asc' );
+		$table_rows = $this->table->reorder( $table_rows );
 
 		// Set items.
-		$table->add_items( $table_rows );
-		$table->set_total_items( count( $table_rows ) );
+		$this->table->add_items( $table_rows );
+		$this->table->set_total_items( count( $table_rows ) );
 
 		// Prepare and display WP_List_Table.
-		$table->prepare_items();
-		$table->display();
+		$this->table->prepare_items();
+		$this->table->display();
 
 		// Register settings field.
 		settings_fields( $this->settings_key );

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-section.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-section.php
@@ -141,7 +141,8 @@ class ConvertKit_ContactForm7_Admin_Section extends ConvertKit_Admin_Section_Bas
 		$table->add_column( 'name', __( 'Contact Form 7 Name Field', 'convertkit' ), false );
 		$table->add_column( 'creator_network_recommendations', __( 'Enable Creator Network Recommendations', 'convertkit' ), false );
 
-		// Iterate through Contact Form 7 Forms, adding a table row for each Contact Form 7 Form.
+		// Iterate through Contact Form 7 Forms, building table array.
+		$table_rows = array();
 		foreach ( $cf7_forms as $cf7_form ) {
 			// Build row.
 			$table_row = array(
@@ -176,8 +177,15 @@ class ConvertKit_ContactForm7_Admin_Section extends ConvertKit_Admin_Section_Bas
 			}
 
 			// Add row to table of settings.
-			$table->add_item( $table_row );
+			$table_rows[] = $table_row;
 		}
+
+		// Sort table rows.
+		$table_rows = $table->reorder( $table_rows, 'title', 'asc' );
+
+		// Set items.
+		$table->add_items( $table_rows );
+		$table->set_total_items( count( $table_rows ) );
 
 		// Prepare and display WP_List_Table.
 		$table->prepare_items();

--- a/includes/integrations/forminator/class-convertkit-forminator-admin-section.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-admin-section.php
@@ -15,6 +15,15 @@
 class ConvertKit_Forminator_Admin_Section extends ConvertKit_Admin_Section_Base {
 
 	/**
+	 * Holds the WP_List_Table instance.
+	 *
+     * @since   3.0.0
+     *
+	 * @var     ConvertKit_WP_List_Table
+	 */
+	public $table;
+
+	/**
 	 * Constructor
 	 *
 	 * @since   2.3.0
@@ -40,6 +49,10 @@ class ConvertKit_Forminator_Admin_Section extends ConvertKit_Admin_Section_Base 
 				'wrap'     => false,
 			),
 		);
+
+		// Setup WP_List_Table.
+		// Doing this in render() is too late - columns and items don't display.
+		$this->table = new ConvertKit_WP_List_Table();
 
 		parent::__construct();
 
@@ -121,12 +134,12 @@ class ConvertKit_Forminator_Admin_Section extends ConvertKit_Admin_Section_Base 
 		$creator_network_recommendations_enabled = $creator_network_recommendations->enabled();
 
 		// Setup WP_List_Table.
-		$table = new ConvertKit_WP_List_Table();
-		$table->add_column( 'title', __( 'Forminator Form', 'convertkit' ), true );
-		$table->add_column( 'form', __( 'Kit', 'convertkit' ), false );
-		$table->add_column( 'creator_network_recommendations', __( 'Enable Creator Network Recommendations', 'convertkit' ), false );
+		$this->table->add_column( 'title', __( 'Forminator Form', 'convertkit' ), true );
+		$this->table->add_column( 'form', __( 'Kit', 'convertkit' ), false );
+		$this->table->add_column( 'creator_network_recommendations', __( 'Enable Creator Network Recommendations', 'convertkit' ), false );
 
-		// Iterate through Forminator Forms, adding a table row for each Forminator Form.
+		// Iterate through Forminator Forms, building table array.
+		$table_rows = array();
 		foreach ( $forminator_forms as $forminator_form ) {
 			// Build row.
 			$table_row = array(
@@ -159,12 +172,19 @@ class ConvertKit_Forminator_Admin_Section extends ConvertKit_Admin_Section_Base 
 			}
 
 			// Add row to table of settings.
-			$table->add_item( $table_row );
+			$table_rows[] = $table_row;
 		}
 
+		// Sort table rows.
+		$table_rows = $this->table->reorder( $table_rows );
+
+		// Set items.
+		$this->table->add_items( $table_rows );
+		$this->table->set_total_items( count( $table_rows ) );
+
 		// Prepare and display WP_List_Table.
-		$table->prepare_items();
-		$table->display();
+		$this->table->prepare_items();
+		$this->table->display();
 
 		// Register settings field.
 		settings_fields( $this->settings_key );

--- a/includes/integrations/forminator/class-convertkit-forminator-admin-section.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-admin-section.php
@@ -15,15 +15,6 @@
 class ConvertKit_Forminator_Admin_Section extends ConvertKit_Admin_Section_Base {
 
 	/**
-	 * Holds the WP_List_Table instance.
-	 *
-     * @since   3.0.0
-     *
-	 * @var     ConvertKit_WP_List_Table
-	 */
-	public $table;
-
-	/**
 	 * Constructor
 	 *
 	 * @since   2.3.0
@@ -49,10 +40,6 @@ class ConvertKit_Forminator_Admin_Section extends ConvertKit_Admin_Section_Base 
 				'wrap'     => false,
 			),
 		);
-
-		// Setup WP_List_Table.
-		// Doing this in render() is too late - columns and items don't display.
-		$this->table = new ConvertKit_WP_List_Table();
 
 		parent::__construct();
 
@@ -134,9 +121,10 @@ class ConvertKit_Forminator_Admin_Section extends ConvertKit_Admin_Section_Base 
 		$creator_network_recommendations_enabled = $creator_network_recommendations->enabled();
 
 		// Setup WP_List_Table.
-		$this->table->add_column( 'title', __( 'Forminator Form', 'convertkit' ), true );
-		$this->table->add_column( 'form', __( 'Kit', 'convertkit' ), false );
-		$this->table->add_column( 'creator_network_recommendations', __( 'Enable Creator Network Recommendations', 'convertkit' ), false );
+		$table = new ConvertKit_WP_List_Table();
+		$table->add_column( 'title', __( 'Forminator Form', 'convertkit' ), true );
+		$table->add_column( 'form', __( 'Kit', 'convertkit' ), false );
+		$table->add_column( 'creator_network_recommendations', __( 'Enable Creator Network Recommendations', 'convertkit' ), false );
 
 		// Iterate through Forminator Forms, building table array.
 		$table_rows = array();
@@ -176,15 +164,15 @@ class ConvertKit_Forminator_Admin_Section extends ConvertKit_Admin_Section_Base 
 		}
 
 		// Sort table rows.
-		$table_rows = $this->table->reorder( $table_rows );
+		$table_rows = $table->reorder( $table_rows );
 
 		// Set items.
-		$this->table->add_items( $table_rows );
-		$this->table->set_total_items( count( $table_rows ) );
+		$table->add_items( $table_rows );
+		$table->set_total_items( count( $table_rows ) );
 
 		// Prepare and display WP_List_Table.
-		$this->table->prepare_items();
-		$this->table->display();
+		$table->prepare_items();
+		$table->display();
 
 		// Register settings field.
 		settings_fields( $this->settings_key );

--- a/includes/integrations/wishlist/class-convertkit-wishlist-admin-section.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist-admin-section.php
@@ -15,15 +15,6 @@
 class ConvertKit_Wishlist_Admin_Section extends ConvertKit_Admin_Section_Base {
 
 	/**
-	 * Holds the WP_List_Table instance.
-	 *
-     * @since   3.0.0
-     *
-	 * @var     ConvertKit_WP_List_Table
-	 */
-	public $table;
-
-	/**
 	 * Constructor.
 	 *
 	 * @since   1.9.6
@@ -49,10 +40,6 @@ class ConvertKit_Wishlist_Admin_Section extends ConvertKit_Admin_Section_Base {
 				'wrap'     => false,
 			),
 		);
-
-		// Setup WP_List_Table.
-		// Doing this in render() is too late - columns and items don't display.
-		$this->table = new ConvertKit_WP_List_Table();
 
 		parent::__construct();
 
@@ -127,9 +114,10 @@ class ConvertKit_Wishlist_Admin_Section extends ConvertKit_Admin_Section_Base {
 		}
 
 		// Setup WP_List_Table.
-		$this->table->add_column( 'title', __( 'WishList Membership Level', 'convertkit' ), true );
-		$this->table->add_column( 'add', __( 'Assign to member', 'convertkit' ), false );
-		$this->table->add_column( 'remove', __( 'Remove from member', 'convertkit' ), false );
+		$table = new ConvertKit_WP_List_Table();
+		$table->add_column( 'title', __( 'WishList Membership Level', 'convertkit' ), true );
+		$table->add_column( 'add', __( 'Assign to member', 'convertkit' ), false );
+		$table->add_column( 'remove', __( 'Remove from member', 'convertkit' ), false );
 
 		// Iterate through WishList Member Levels, building table array.
 		$table_rows = array();
@@ -157,15 +145,15 @@ class ConvertKit_Wishlist_Admin_Section extends ConvertKit_Admin_Section_Base {
 		}
 
 		// Sort table rows.
-		$table_rows = $this->table->reorder( $table_rows );
+		$table_rows = $table->reorder( $table_rows );
 
 		// Set items.
-		$this->table->add_items( $table_rows );
-		$this->table->set_total_items( count( $table_rows ) );
+		$table->add_items( $table_rows );
+		$table->set_total_items( count( $table_rows ) );
 
 		// Prepare and display WP_List_Table.
-		$this->table->prepare_items();
-		$this->table->display();
+		$table->prepare_items();
+		$table->display();
 
 		// Register settings field.
 		settings_fields( $this->settings_key );

--- a/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormBuilderCest.php
+++ b/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormBuilderCest.php
@@ -1078,6 +1078,13 @@ class PageBlockFormBuilderCest
 				'api_result'    => 'success',
 			]
 		);
+
+		// Confirm that the entry is displayed in the Form Entries section.
+		$I->loadKitSettingsFormEntriesScreen($I);
+		$I->seeInSource($emailAddress);
+		$I->seeInSource('First');
+		$I->seeInSource('Last');
+		$I->seeInSource('success');
 	}
 
 	/**

--- a/tests/Integration/FormEntriesTest.php
+++ b/tests/Integration/FormEntriesTest.php
@@ -316,27 +316,42 @@ class FormEntriesTest extends WPTestCase
 		$this->assertEquals( 1, $results[1]['post_id'] );
 
 		// Run search ordered by post ID descending.
-		$results = $this->entries->search('post_id', 'desc');
+		$results = $this->entries->search(
+			order_by: 'post_id',
+			order: 'desc',
+		);
 		$this->assertEquals( 9, $results[0]['post_id'] );
 		$this->assertEquals( 8, $results[1]['post_id'] );
 
 		// Run search ordered by email ascending.
-		$results = $this->entries->search('email', 'asc');
+		$results = $this->entries->search(
+			order_by: 'email',
+			order: 'asc',
+		);
 		$this->assertEquals( 'test0@example.com', $results[0]['email'] );
 		$this->assertEquals( 'test1@example.com', $results[1]['email'] );
 
 		// Run search ordered by email descending.
-		$results = $this->entries->search('email', 'desc');
+		$results = $this->entries->search(
+			order_by: 'email',
+			order: 'desc',
+		);
 		$this->assertEquals( 'test9@example.com', $results[0]['email'] );
 		$this->assertEquals( 'test8@example.com', $results[1]['email'] );
 
 		// Run search ordered by first name ascending.
-		$results = $this->entries->search('first_name', 'asc');
+		$results = $this->entries->search(
+			order_by: 'first_name',
+			order: 'asc',
+		);
 		$this->assertEquals( 'Test 0', $results[0]['first_name'] );
 		$this->assertEquals( 'Test 1', $results[1]['first_name'] );
 
 		// Run search ordered by first name descending.
-		$results = $this->entries->search('first_name', 'desc');
+		$results = $this->entries->search(
+			order_by: 'first_name',
+			order: 'desc',
+		);
 		$this->assertEquals( 'Test 9', $results[0]['first_name'] );
 		$this->assertEquals( 'Test 8', $results[1]['first_name'] );
 	}
@@ -378,13 +393,17 @@ class FormEntriesTest extends WPTestCase
 		$this->assertEquals( 1, count( $results ) );
 		$this->assertEquals( 'test0@example.com', $results[0]['email'] );
 
-		// Run generic search on email.
+		// Run generic search on email, ordered by post ID descending.
 		$results = $this->entries->search(
 			search: 'example.com',
+			order_by: 'post_id',
+			order: 'desc',
 		);
 
 		// Assert the correct number of results are returned.
 		$this->assertEquals( 10, count( $results ) );
+		$this->assertEquals( 9, $results[0]['post_id'] );
+		$this->assertEquals( 8, $results[1]['post_id'] );
 	}
 
 	/**

--- a/tests/Integration/FormEntriesTest.php
+++ b/tests/Integration/FormEntriesTest.php
@@ -253,19 +253,8 @@ class FormEntriesTest extends WPTestCase
 	 */
 	public function testDeleteEntries()
 	{
-		// Add entries.
-		for ( $i = 0; $i < 3; $i++ ) {
-			$data = [
-				'post_id' => $i,
-				'email'   => 'test' . $i . '@example.com',
-			];
-			$id   = $this->entries->add($data);
-
-			// Assert no error and that the entry is in the database.
-			$this->assertNotInstanceOf(\WP_Error::class, $id);
-			$this->assertNotFalse($id);
-			$this->seeInDatabase($this->table_name, $data);
-		}
+		// Seed database table.
+		$this->seedDatabaseTable();
 
 		// Delete entries.
 		$this->entries->delete_by_ids([ 1, 2, 3 ]);
@@ -281,11 +270,139 @@ class FormEntriesTest extends WPTestCase
 	 */
 	public function testDeleteAllEntries()
 	{
+		// Seed database table.
+		$this->seedDatabaseTable();
+
+		// Delete all entries.
+		$this->entries->delete_all();
+
+		// Assert database table is empty.
+		$this->assertDatabaseTableIsEmpty($this->table_name);
+	}
+
+	/**
+	 * Test searching for entries.
+	 *
+	 * @since   3.0.0
+	 */
+	public function testSearchNoParameters()
+	{
+		// Seed database table.
+		$this->seedDatabaseTable();
+
+		// Run search with no parameters.
+		$results = $this->entries->search();
+
+		// Assert the correct number of results are returned.
+		$this->assertEquals(10, count($results));
+	}
+
+	/**
+	 * Test searching for entries with order by and order parameters.
+	 *
+	 * @since   3.0.0
+	 */
+	public function testSearchOrderByAndOrder()
+	{
+		// Seed database table.
+		$this->seedDatabaseTable();
+
+		// Run search ordered by post ID ascending.
+		$results = $this->entries->search(
+			order_by: 'post_id',
+			order: 'asc',
+		);
+		$this->assertEquals( 0, $results[0]['post_id'] );
+		$this->assertEquals( 1, $results[1]['post_id'] );
+
+		// Run search ordered by post ID descending.
+		$results = $this->entries->search('post_id', 'desc');
+		$this->assertEquals( 9, $results[0]['post_id'] );
+		$this->assertEquals( 8, $results[1]['post_id'] );
+
+		// Run search ordered by email ascending.
+		$results = $this->entries->search('email', 'asc');
+		$this->assertEquals( 'test0@example.com', $results[0]['email'] );
+		$this->assertEquals( 'test1@example.com', $results[1]['email'] );
+
+		// Run search ordered by email descending.
+		$results = $this->entries->search('email', 'desc');
+		$this->assertEquals( 'test9@example.com', $results[0]['email'] );
+		$this->assertEquals( 'test8@example.com', $results[1]['email'] );
+
+		// Run search ordered by first name ascending.
+		$results = $this->entries->search('first_name', 'asc');
+		$this->assertEquals( 'Test 0', $results[0]['first_name'] );
+		$this->assertEquals( 'Test 1', $results[1]['first_name'] );
+
+		// Run search ordered by first name descending.
+		$results = $this->entries->search('first_name', 'desc');
+		$this->assertEquals( 'Test 9', $results[0]['first_name'] );
+		$this->assertEquals( 'Test 8', $results[1]['first_name'] );
+	}
+
+	/**
+	 * Test searching for entries with search parameters.
+	 *
+	 * @since   3.0.0
+	 */
+	public function testSearchWithSearchParameter()
+	{
+		// Seed database table.
+		$this->seedDatabaseTable();
+
+		// Run specific search for first name.
+		$results = $this->entries->search(
+			search: 'Test 0',
+		);
+
+		// Assert the correct number of results are returned.
+		$this->assertEquals( 1, count( $results ) );
+		$this->assertEquals( 'Test 0', $results[0]['first_name'] );
+
+		// Run specific search for email.
+		$results = $this->entries->search(
+			search: 'test0@example.com',
+		);
+
+		// Assert the correct number of results are returned.
+		$this->assertEquals( 1, count( $results ) );
+		$this->assertEquals( 'test0@example.com', $results[0]['email'] );
+
+		// Run generic search.
+		$results = $this->entries->search(
+			search: 'test0',
+		);
+
+		// Assert the correct number of results are returned.
+		$this->assertEquals( 1, count( $results ) );
+		$this->assertEquals( 'test0@example.com', $results[0]['email'] );
+
+		// Run generic search on email.
+		$results = $this->entries->search(
+			search: 'example.com',
+		);
+
+		// Assert the correct number of results are returned.
+		$this->assertEquals( 10, count( $results ) );
+	}
+
+	/**
+	 * Add entries to the database table.
+	 *
+	 * @since   3.0.0
+	 */
+	protected function seedDatabaseTable()
+	{
+		// Delete all entries.
+		$this->entries->delete_all();
+
 		// Add entries.
 		for ( $i = 0; $i < 10; $i++ ) {
 			$data = [
-				'post_id' => $i,
-				'email'   => 'test' . $i . '@example.com',
+				'post_id'    => $i,
+				'first_name' => 'Test ' . $i,
+				'email'      => 'test' . $i . '@example.com',
 			];
 			$id   = $this->entries->add($data);
 
@@ -294,12 +411,6 @@ class FormEntriesTest extends WPTestCase
 			$this->assertNotFalse($id);
 			$this->seeInDatabase($this->table_name, $data);
 		}
-
-		// Delete all entries.
-		$this->entries->delete_all();
-
-		// Assert database table is empty.
-		$this->assertDatabaseTableIsEmpty($this->table_name);
 	}
 
 	/**

--- a/tests/Support/Helper/KitPlugin.php
+++ b/tests/Support/Helper/KitPlugin.php
@@ -568,6 +568,21 @@ class KitPlugin extends \Codeception\Module
 	}
 
 	/**
+	 * Helper method to load the Plugin's Settings > Form Entries screen.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param   EndToEndTester $I     EndToEndTester.
+	 */
+	public function loadKitSettingsFormEntriesScreen($I)
+	{
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=form-entries');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+	}
+
+	/**
 	 * Helper method to clear the Plugin's debug log.
 	 *
 	 * @since   1.9.6

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -118,6 +118,7 @@ require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-setup-wizar
 require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-wp-list-table.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-base.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-broadcasts.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-form-entries.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-general.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-oauth.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-admin-section-restrict-content.php';


### PR DESCRIPTION
## Summary

Adds a section to the Kit Plugin's settings where form submissions made using Form Builder blocks with "Store form submissions" can be viewed.

<img width="805" height="743" alt="Screenshot 2025-08-26 at 16 49 45" src="https://github.com/user-attachments/assets/6ac58c86-9a33-4245-8ebc-8d089667acaf" />

Future PR's to follow to enable sorting, search, pagination and re-sending subscribers to the API. 

## Testing

Tests in this PR.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)