### PR TITLE
Tests: Block Toggles: Reference by name

### DIFF
--- a/tests/EndToEnd/broadcasts/blocks-shortcodes/PageBlockBroadcastsCest.php
+++ b/tests/EndToEnd/broadcasts/blocks-shortcodes/PageBlockBroadcastsCest.php
@@ -225,7 +225,7 @@ class PageBlockBroadcastsCest
 			blockName: 'Kit Broadcasts',
 			blockProgrammaticName: 'convertkit-broadcasts',
 			blockConfiguration: [
-				'#inspector-toggle-control-0' => [ 'toggle', true ],
+				'Display as grid' => [ 'toggle', true ],
 			]
 		);
 
@@ -359,8 +359,8 @@ class PageBlockBroadcastsCest
 			blockName: 'Kit Broadcasts',
 			blockProgrammaticName: 'convertkit-broadcasts',
 			blockConfiguration: [
-				'#inspector-toggle-control-0' => [ 'toggle', true ],
-				'#inspector-toggle-control-1' => [ 'toggle', true ],
+				'Display as grid' => [ 'toggle', true ],
+				'Display images'  => [ 'toggle', true ],
 			]
 		);
 
@@ -403,7 +403,7 @@ class PageBlockBroadcastsCest
 			blockName: 'Kit Broadcasts',
 			blockProgrammaticName: 'convertkit-broadcasts',
 			blockConfiguration: [
-				'#inspector-toggle-control-2' => [ 'toggle', true ],
+				'Display descriptions' => [ 'toggle', true ],
 			]
 		);
 
@@ -445,8 +445,8 @@ class PageBlockBroadcastsCest
 			blockName: 'Kit Broadcasts',
 			blockProgrammaticName: 'convertkit-broadcasts',
 			blockConfiguration: [
-				'#inspector-toggle-control-3' => [ 'toggle', true ],
-				'read_more_label'             => [ 'input', 'Continue reading' ],
+				'Display read more links' => [ 'toggle', true ],
+				'read_more_label'         => [ 'input', 'Continue reading' ],
 			]
 		);
 
@@ -588,8 +588,8 @@ class PageBlockBroadcastsCest
 			blockName: 'Kit Broadcasts',
 			blockProgrammaticName: 'convertkit-broadcasts',
 			blockConfiguration: [
-				'limit'                       => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
-				'#inspector-toggle-control-4' => [ 'toggle', true ],
+				'limit'              => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
+				'Display pagination' => [ 'toggle', true ],
 			]
 		);
 
@@ -625,10 +625,10 @@ class PageBlockBroadcastsCest
 			blockName: 'Kit Broadcasts',
 			blockProgrammaticName: 'convertkit-broadcasts',
 			blockConfiguration: [
-				'limit'                       => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
-				'#inspector-toggle-control-4' => [ 'toggle', true ],
-				'paginate_label_prev'         => [ 'input', 'Newer' ],
-				'paginate_label_next'         => [ 'input', 'Older' ],
+				'limit'               => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
+				'Display pagination'  => [ 'toggle', true ],
+				'paginate_label_prev' => [ 'input', 'Newer' ],
+				'paginate_label_next' => [ 'input', 'Older' ],
 			]
 		);
 
@@ -664,10 +664,10 @@ class PageBlockBroadcastsCest
 			blockName: 'Kit Broadcasts',
 			blockProgrammaticName: 'convertkit-broadcasts',
 			blockConfiguration: [
-				'limit'                       => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
-				'#inspector-toggle-control-4' => [ 'toggle', true ],
-				'paginate_label_prev'         => [ 'input', '' ],
-				'paginate_label_next'         => [ 'input', '' ],
+				'limit'               => [ 'input', '2', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
+				'Display pagination'  => [ 'toggle', true ],
+				'paginate_label_prev' => [ 'input', '' ],
+				'paginate_label_next' => [ 'input', '' ],
 			]
 		);
 

--- a/tests/EndToEnd/broadcasts/blocks-shortcodes/WidgetBroadcastsCest.php
+++ b/tests/EndToEnd/broadcasts/blocks-shortcodes/WidgetBroadcastsCest.php
@@ -147,8 +147,8 @@ class WidgetBroadcastsCest
 			blockName: 'Kit Broadcasts',
 			blockProgrammaticName: 'convertkit-broadcasts',
 			blockConfiguration: [
-				'#inspector-toggle-control-4' => [ 'toggle', true, 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
-				'limit'                       => [ 'input', '2' ],
+				'Display pagination' => [ 'toggle', true, 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
+				'limit'              => [ 'input', '2' ],
 			]
 		);
 
@@ -174,10 +174,10 @@ class WidgetBroadcastsCest
 			blockName: 'Kit Broadcasts',
 			blockProgrammaticName: 'convertkit-broadcasts',
 			blockConfiguration: [
-				'#inspector-toggle-control-4' => [ 'toggle', true, 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
-				'limit'                       => [ 'input', '2' ],
-				'paginate_label_prev'         => [ 'input', 'Newer' ],
-				'paginate_label_next'         => [ 'input', 'Older' ],
+				'Display pagination'  => [ 'toggle', true, 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
+				'limit'               => [ 'input', '2' ],
+				'paginate_label_prev' => [ 'input', 'Newer' ],
+				'paginate_label_next' => [ 'input', 'Older' ],
 			]
 		);
 
@@ -207,10 +207,10 @@ class WidgetBroadcastsCest
 			blockName: 'Kit Broadcasts',
 			blockProgrammaticName: 'convertkit-broadcasts',
 			blockConfiguration: [
-				'#inspector-toggle-control-4' => [ 'toggle', true, 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
-				'limit'                       => [ 'input', '2' ],
-				'paginate_label_prev'         => [ 'input', '' ],
-				'paginate_label_next'         => [ 'input', '' ],
+				'Display pagination'  => [ 'toggle', true, 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
+				'limit'               => [ 'input', '2' ],
+				'paginate_label_prev' => [ 'input', '' ],
+				'paginate_label_next' => [ 'input', '' ],
 			]
 		);
 

--- a/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormBuilderCest.php
+++ b/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormBuilderCest.php
@@ -153,8 +153,8 @@ class PageBlockFormBuilderCest
 			blockName: 'Kit Form Builder',
 			blockProgrammaticName: 'convertkit-form-builder',
 			blockConfiguration: [
-				'#inspector-toggle-control-1' => [ 'toggle', false ],
-				'text_if_subscribed'          => [ 'text', 'Welcome to the newsletter!' ],
+				'Display form'       => [ 'toggle', false ],
+				'text_if_subscribed' => [ 'text', 'Welcome to the newsletter!' ],
 			]
 		);
 
@@ -945,10 +945,7 @@ class PageBlockFormBuilderCest
 		$I->addGutenbergBlock(
 			$I,
 			blockName: 'Kit Form Builder',
-			blockProgrammaticName: 'convertkit-form-builder',
-			blockConfiguration: [
-				'#inspector-toggle-control-0' => [ 'toggle', true ],
-			]
+			blockProgrammaticName: 'convertkit-form-builder'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -1007,9 +1004,9 @@ class PageBlockFormBuilderCest
 			blockName: 'Kit Form Builder',
 			blockProgrammaticName: 'convertkit-form-builder',
 			blockConfiguration: [
-				'#inspector-toggle-control-0' => [ 'toggle', true ],
-				'sequence_id'                 => [ 'select', $_ENV['CONVERTKIT_API_SEQUENCE_ID'] ],
-				'tag_id'                      => [ 'select', $_ENV['CONVERTKIT_API_TAG_ID'] ],
+				'Store form submissions' => [ 'toggle', true ],
+				'sequence_id'            => [ 'select', $_ENV['CONVERTKIT_API_SEQUENCE_ID'] ],
+				'tag_id'                 => [ 'select', $_ENV['CONVERTKIT_API_TAG_ID'] ],
 			]
 		);
 

--- a/tests/EndToEnd/products/PageBlockProductCest.php
+++ b/tests/EndToEnd/products/PageBlockProductCest.php
@@ -349,8 +349,8 @@ class PageBlockProductCest
 			blockName: 'Kit Product',
 			blockProgrammaticName: 'convertkit-product',
 			blockConfiguration: [
-				'product'                     => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
-				'#inspector-toggle-control-0' => [ 'toggle', true ],
+				'product'            => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+				'Load checkout step' => [ 'toggle', true ],
 			]
 		);
 
@@ -406,8 +406,8 @@ class PageBlockProductCest
 			blockName: 'Kit Product',
 			blockProgrammaticName: 'convertkit-product',
 			blockConfiguration: [
-				'product'                     => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
-				'#inspector-toggle-control-1' => [ 'toggle', true ],
+				'product'                 => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+				'Disable modal on mobile' => [ 'toggle', true ],
 			]
 		);
 

--- a/tests/Support/Helper/WPGutenberg.php
+++ b/tests/Support/Helper/WPGutenberg.php
@@ -100,6 +100,9 @@ class WPGutenberg extends \Codeception\Module
 						$I->selectOption($fieldID, $attributes[1]);
 						break;
 					case 'toggle':
+						// The block editor doesn't use the field ID, so we need to find the field by the label.
+						$field = "//label[normalize-space(text())='" . $field . "']/preceding-sibling::span/input";
+
 						// Determine if the toggle has checked the checkbox.
 						$isChecked = $I->grabAttributeFrom($field, 'checked');
 


### PR DESCRIPTION
## Summary

Unlike other block fields, the block editor doesn't use field names for toggle controls, instead using e.g. `#inspector-toggle-control-0`, `#inspector-toggle-control-1` etc:

```html
<div class="components-base-control__field af-d-f-af-cfddcdb-1sf3vf3 ej5x27r3">
<div data-wp-c16t="true" data-wp-component="HStack" class="components-flex components-h-stack af-d-f-af-cfddcdb-1f9s4va e19lxcc00">
<span class="components-form-toggle is-checked">
<input class="components-form-toggle__input" id="inspector-toggle-control-0" type="checkbox" aria-describedby="inspector-toggle-control-0__help" checked="">
<span class="components-form-toggle__track"></span>
<span class="components-form-toggle__thumb"></span>
</span>
<label data-wp-c16t="true" data-wp-component="FlexBlock" for="inspector-toggle-control-0" class="components-flex-item components-flex-block components-toggle-control__label af-d-f-af-cfddcdb-13y8vek e19lxcc00">Store form submissions</label>
</div>
</div>
```

This makes tests unreadable at times when we pass a `blockConfiguration` when adding a block.

This PR resolves by searching for the toggle control by the field label's text.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)