### PR TITLE
Form Builder: Store Entries: Require Post ID

### DIFF
--- a/includes/class-convertkit-form-entries.php
+++ b/includes/class-convertkit-form-entries.php
@@ -139,11 +139,6 @@ class ConvertKit_Form_Entries {
 			return new \WP_Error( 'convertkit_form_entries_no_email', __( 'No email address provided', 'convertkit' ) );
 		}
 
-		// If no post ID is provided, return an error.
-		if ( ! array_key_exists( 'post_id', $entry ) ) {
-			return new \WP_Error( 'convertkit_form_entries_no_post_id', __( 'No post ID provided', 'convertkit' ) );
-		}
-
 		// JSON encode custom fields, if supplied as an array.
 		if ( array_key_exists( 'custom_fields', $entry ) && is_array( $entry['custom_fields'] ) ) {
 			$entry['custom_fields'] = wp_json_encode( $entry['custom_fields'] );

--- a/includes/class-convertkit-form-entries.php
+++ b/includes/class-convertkit-form-entries.php
@@ -89,6 +89,11 @@ class ConvertKit_Form_Entries {
 			return new \WP_Error( 'convertkit_form_entries_no_email', __( 'No email address provided', 'convertkit' ) );
 		}
 
+		// If no post ID is provided, return an error.
+		if ( ! array_key_exists( 'post_id', $entry ) ) {
+			return new \WP_Error( 'convertkit_form_entries_no_post_id', __( 'No post ID provided', 'convertkit' ) );
+		}
+
 		// JSON encode custom fields, if supplied as an array.
 		if ( array_key_exists( 'custom_fields', $entry ) && is_array( $entry['custom_fields'] ) ) {
 			$entry['custom_fields'] = wp_json_encode( $entry['custom_fields'] );
@@ -134,6 +139,11 @@ class ConvertKit_Form_Entries {
 			return new \WP_Error( 'convertkit_form_entries_no_email', __( 'No email address provided', 'convertkit' ) );
 		}
 
+		// If no post ID is provided, return an error.
+		if ( ! array_key_exists( 'post_id', $entry ) ) {
+			return new \WP_Error( 'convertkit_form_entries_no_post_id', __( 'No post ID provided', 'convertkit' ) );
+		}
+
 		// JSON encode custom fields, if supplied as an array.
 		if ( array_key_exists( 'custom_fields', $entry ) && is_array( $entry['custom_fields'] ) ) {
 			$entry['custom_fields'] = wp_json_encode( $entry['custom_fields'] );
@@ -176,6 +186,11 @@ class ConvertKit_Form_Entries {
 		// If no email is provided, return an error.
 		if ( ! array_key_exists( 'email', $entry ) ) {
 			return new \WP_Error( 'convertkit_form_entries_no_email', __( 'No email address provided', 'convertkit' ) );
+		}
+
+		// If no post ID is provided, return an error.
+		if ( ! array_key_exists( 'post_id', $entry ) ) {
+			return new \WP_Error( 'convertkit_form_entries_no_post_id', __( 'No post ID provided', 'convertkit' ) );
 		}
 
 		// Check if an entry already exists for the given Post ID and Email.

--- a/tests/Integration/FormEntriesTest.php
+++ b/tests/Integration/FormEntriesTest.php
@@ -125,6 +125,24 @@ class FormEntriesTest extends WPTestCase
 	}
 
 	/**
+	 * Test adding an entry with no post ID returns a WP_Error.
+	 *
+	 * @since   3.0.0
+	 */
+	public function testAddEntryWithNoPostID()
+	{
+		$data = [
+			'email'      => 'test@example.com',
+			'first_name' => 'Test',
+		];
+		$id   = $this->entries->add($data);
+
+		// Assert an error and that the entry is not in the database.
+		$this->assertInstanceOf(\WP_Error::class, $id);
+		$this->dontSeeInDatabase($this->table_name, $data);
+	}
+
+	/**
 	 * Test updating an entry.
 	 *
 	 * @since   3.0.0

--- a/tests/Integration/FormEntriesTest.php
+++ b/tests/Integration/FormEntriesTest.php
@@ -239,6 +239,24 @@ class FormEntriesTest extends WPTestCase
 	}
 
 	/**
+	 * Test upserting an entry with no post ID returns a WP_Error.
+	 *
+	 * @since   3.0.0
+	 */
+	public function testUpsertEntryWithNoPostID()
+	{
+		$data = [
+			'email'      => 'test@example.com',
+			'first_name' => 'Test',
+		];
+		$id   = $this->entries->upsert($data);
+
+		// Assert an error and that the entry is not in the database.
+		$this->assertInstanceOf(\WP_Error::class, $id);
+		$this->dontSeeInDatabase($this->table_name, $data);
+	}
+
+	/**
 	 * Test deleting an entry.
 	 *
 	 * @since   3.0.0


### PR DESCRIPTION
## Summary

Require a `post_id` be included when storing an entry from the Form Builder block.

## Testing

- `testAddEntryWithNoPostID`: Test that a `WP_Error` is returned when no Post ID is included.
- `testUpsertEntryWithNoPostID`: Test that a `WP_Error` is returned when no Post ID is included.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)