### PR TITLE
Form Builder: Store Entries: Search Submissions

### DIFF
--- a/admin/class-convertkit-admin-settings.php
+++ b/admin/class-convertkit-admin-settings.php
@@ -149,9 +149,28 @@ class ConvertKit_Admin_Settings {
 			if ( count( $this->sections ) > 1 ) {
 				$this->display_section_nav( $active_section );
 			}
-			?>
 
-			<form method="post" action="options.php" enctype="multipart/form-data">
+			/**
+			 * Defines the settings form's method.
+			 *
+			 * @since   3.0.0
+			 *
+			 * @param   string  $form_method        The method of the form.
+			 * @param   string  $active_section     The active section.
+			 */
+			$form_method = apply_filters( 'convertkit_admin_settings_form_method', 'post', $active_section );
+
+			/**
+			 * Defines the settings form's action URL.
+			 *
+			 * @since   3.0.0
+			 *
+			 * @param   string  $form_action_url    The URL to submit the form to.
+			 * @param   string  $active_section     The active section.
+			 */
+			$form_action_url = apply_filters( 'convertkit_admin_settings_form_action_url', admin_url( 'options.php' ), $active_section );
+			?>
+			<form method="<?php echo esc_attr( $form_method ); ?>" action="<?php echo esc_url( $form_action_url ); ?>" enctype="multipart/form-data">
 				<?php
 				// Iterate through sections to find the active section to render.
 				if ( isset( $this->sections[ $active_section ] ) ) {

--- a/admin/class-convertkit-wp-list-table.php
+++ b/admin/class-convertkit-wp-list-table.php
@@ -158,7 +158,7 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 		<p class="search-box">
 			<label class="screen-reader-text" for="<?php echo esc_attr( $input_id ); ?>"><?php echo esc_attr( $text ); ?>:</label>
 			<input type="search" id="<?php echo esc_attr( $input_id ); ?>" name="s" value="<?php _admin_search_query(); ?>" placeholder="<?php esc_attr_e( 'Search', 'convertkit' ); ?>" />
-			<?php submit_button( $text, '', '', false, array( 'id' => 'search-submit' ) ); ?>
+			<?php submit_button( $text, 'secondary', 'submit', false, array( 'id' => 'search-submit' ) ); ?>
 		</p>
 		<?php
 		if ( $this->page ) {

--- a/admin/class-convertkit-wp-list-table.php
+++ b/admin/class-convertkit-wp-list-table.php
@@ -23,6 +23,24 @@ if ( ! class_exists( 'WP_List_Table' ) ) {
 class ConvertKit_WP_List_Table extends WP_List_Table {
 
 	/**
+	 * Holds the page query parameter.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @var     string
+	 */
+	private $page = false;
+
+	/**
+	 * Holds the tab query parameter.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @var     string
+	 */
+	private $tab = false;
+
+	/**
 	 * Holds the supported bulk actions.
 	 *
 	 * @var     array
@@ -65,8 +83,14 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 	 * Constructor.
 	 *
 	 * @since 1.0.0
+	 *
+	 * @param   string $page  Page query parameter.
+	 * @param   string $tab   Tab query parameter.
 	 */
-	public function __construct() {
+	public function __construct( $page = false, $tab = false ) {
+
+		$this->page = $page;
+		$this->tab  = $tab;
 
 		parent::__construct(
 			array(
@@ -117,6 +141,36 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 	public function get_bulk_actions() {
 
 		return $this->bulk_actions;
+
+	}
+
+	/**
+	 * Displays the search input field.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param   string $text        The 'submit' button label.
+	 * @param   string $input_id    ID attribute value for the search input field.
+	 */
+	public function search_box( $text, $input_id ) {
+
+		?>
+		<p class="search-box">
+			<label class="screen-reader-text" for="<?php echo esc_attr( $input_id ); ?>"><?php echo esc_attr( $text ); ?>:</label>
+			<input type="search" id="<?php echo esc_attr( $input_id ); ?>" name="s" value="<?php _admin_search_query(); ?>" placeholder="<?php esc_attr_e( 'Search', 'convertkit' ); ?>" />
+			<?php submit_button( $text, '', '', false, array( 'id' => 'search-submit' ) ); ?>
+		</p>
+		<?php
+		if ( $this->page ) {
+			?>
+			<input type="hidden" name="page" value="<?php echo esc_attr( $this->page ); ?>" />
+			<?php
+		}
+		if ( $this->tab ) {
+			?>
+			<input type="hidden" name="tab" value="<?php echo esc_attr( $this->tab ); ?>" />
+			<?php
+		}
 
 	}
 
@@ -272,6 +326,7 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 	 */
 	protected function display_tablenav( $which ) {
 
+		// Define a nonce for search submissions.
 		if ( 'top' === $which ) {
 			wp_nonce_field( 'bulk-' . $this->_args['plural'] );
 		}
@@ -342,7 +397,7 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 	public function get_search() {
 
 		// Bail if nonce is not valid.
-		if ( ! isset( $_REQUEST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( wp_unslash( $_REQUEST['_wpnonce'] ) ), 'bulk-wp-to-social-log' ) ) {
+		if ( ! isset( $_REQUEST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( wp_unslash( $_REQUEST['_wpnonce'] ) ), 'bulk-' . $this->_args['plural'] ) ) {
 			return '';
 		}
 

--- a/admin/section/class-convertkit-admin-section-form-entries.php
+++ b/admin/section/class-convertkit-admin-section-form-entries.php
@@ -136,13 +136,13 @@ class ConvertKit_Admin_Section_Form_Entries extends ConvertKit_Admin_Section_Bas
 		// Display search term.
 		if ( $table->is_search() ) {
 			?>
-			<span class="subtitle left"><?php esc_html_e( 'Search results for', 'convertkit' ); ?> &#8220;<?php echo esc_html( $table->get_search() ); ?>&#8221;</span>
+			<span class="subtitle left"><?php esc_html_e( 'Search results for', 'convertkit' ); ?> &quot;<?php echo esc_html( $table->get_search() ); ?>&quot;</span>
 			<?php
 		}
 
 		// Prepare and display WP_List_Table.
 		$table->prepare_items();
-		$table->search_box( __( 'Search', 'convertkit' ), 'convertkit' );
+		$table->search_box( __( 'Search', 'convertkit' ), 'convertkit-search' );
 		$table->display();
 
 		// Render closing container.

--- a/resources/backend/css/settings.css
+++ b/resources/backend/css/settings.css
@@ -177,3 +177,26 @@ body.settings_page__wp_convertkit_settings .wrap .postbox.convertkit-beta > p.de
 	padding-top: 30px;
 	border-top: 1px solid #e3e3e3;
 }
+
+/**
+ * Screen Options
+ */
+body.settings_page__wp_convertkit_settings #screen-meta-links {
+	position: absolute;
+	right: 0;
+}
+
+/**
+ * Search
+ */
+body.settings_page__wp_convertkit_settings .wrap .subtitle.left {
+	margin: 11px 0;
+	display: flex;
+	float: left;
+	padding-left: 0;
+	line-height: 40px;
+	font-style: italic;
+}
+body.settings_page__wp_convertkit_settings .wrap .search-box input[type=search] {
+	min-height: 40px;
+}

--- a/tests/EndToEnd/general/plugin-screens/PluginSettingsFormEntriesCest.php
+++ b/tests/EndToEnd/general/plugin-screens/PluginSettingsFormEntriesCest.php
@@ -122,6 +122,180 @@ class PluginSettingsFormEntriesCest
 	}
 
 	/**
+	 * Test the Form Entries table with an exact email search.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormEntriesTableWithExactEmailSearch(EndToEndTester $I)
+	{
+		// Setup Plugin.
+		$I->setupKitPlugin($I);
+		$I->setupKitPluginResources($I);
+
+		// Enter some entries into the Form Entries table.
+		$items = $this->insertFormEntriesToDatabase($I);
+
+		// Load the Form Entries screen.
+		$I->loadKitSettingsFormEntriesScreen($I);
+
+		// Search by email.
+		$I->fillField('#convertkit-search', 'test0@example.com');
+		$I->click('#search-submit');
+
+		// Confirm that the search term is displayed.
+		$I->waitForElementVisible('span.subtitle.left');
+		$I->assertEquals('Search results for "test0@example.com"', $I->grabTextFrom('span.subtitle.left'));
+
+		// Confirm search result displayed in the table.
+		$I->assertEquals($items[0]['email'], $I->grabTextFrom('tbody#the-list tr:first-child td.email'));
+	}
+
+	/**
+	 * Test the Form Entries table with a partial email search.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormEntriesTableWithPartialEmailSearch(EndToEndTester $I)
+	{
+		// Setup Plugin.
+		$I->setupKitPlugin($I);
+		$I->setupKitPluginResources($I);
+
+		// Enter some entries into the Form Entries table.
+		$items = $this->insertFormEntriesToDatabase($I);
+
+		// Load the Form Entries screen.
+		$I->loadKitSettingsFormEntriesScreen($I);
+
+		// Search by partial email.
+		$I->fillField('#convertkit-search', 'test0@');
+		$I->click('#search-submit');
+
+		// Confirm that the search term is displayed.
+		$I->waitForElementVisible('span.subtitle.left');
+		$I->assertEquals('Search results for "test0@"', $I->grabTextFrom('span.subtitle.left'));
+
+		// Confirm search result displayed in the table.
+		$I->assertEquals($items[0]['email'], $I->grabTextFrom('tbody#the-list tr:first-child td.email'));
+	}
+
+	/**
+	 * Test the Form Entries table with an exact name search.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormEntriesTableWithExactNameSearch(EndToEndTester $I)
+	{
+		// Setup Plugin.
+		$I->setupKitPlugin($I);
+		$I->setupKitPluginResources($I);
+
+		// Enter some entries into the Form Entries table.
+		$items = $this->insertFormEntriesToDatabase($I);
+
+		// Load the Form Entries screen.
+		$I->loadKitSettingsFormEntriesScreen($I);
+
+		// Search by name.
+		$I->fillField('#convertkit-search', 'First 0');
+		$I->click('#search-submit');
+
+		// Confirm that the search term is displayed.
+		$I->waitForElementVisible('span.subtitle.left');
+		$I->assertEquals('Search results for "First 0"', $I->grabTextFrom('span.subtitle.left'));
+
+		// Confirm search result displayed in the table.
+		$I->assertEquals($items[0]['first_name'], $I->grabTextFrom('tbody#the-list tr:first-child td.first_name'));
+	}
+
+	/**
+	 * Test the Form Entries table with a partial name search.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormEntriesTableWithPartialNameSearch(EndToEndTester $I)
+	{
+		// Setup Plugin.
+		$I->setupKitPlugin($I);
+		$I->setupKitPluginResources($I);
+
+		// Enter some entries into the Form Entries table.
+		$items = $this->insertFormEntriesToDatabase($I);
+
+		// Load the Form Entries screen.
+		$I->loadKitSettingsFormEntriesScreen($I);
+
+		// Search by name.
+		$I->fillField('#convertkit-search', 'First');
+		$I->click('#search-submit');
+
+		// Confirm that the search term is displayed.
+		$I->waitForElementVisible('span.subtitle.left');
+		$I->assertEquals('Search results for "First"', $I->grabTextFrom('span.subtitle.left'));
+
+		// Confirm search result displayed in the table.
+		$I->assertEquals($items[0]['first_name'], $I->grabTextFrom('tbody#the-list tr:first-child td.first_name'));
+	}
+
+	/**
+	 * Test the Form Entries table with search and pagination.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormEntriesTableWithSearchAndPagination(EndToEndTester $I)
+	{
+		// Setup Plugin.
+		$I->setupKitPlugin($I);
+		$I->setupKitPluginResources($I);
+
+		// Enter some entries into the Form Entries table.
+		$items = $this->insertFormEntriesToDatabase($I);
+
+		// Load the Form Entries screen.
+		$I->loadKitSettingsFormEntriesScreen($I);
+
+		// Set pagination to 2 per page.
+		$I->click('button#show-settings-link');
+		$I->waitForElementVisible('input#convertkit_form_entries_per_page');
+		$I->fillField('#convertkit_form_entries_per_page', '2');
+		$I->click('Apply');
+		$I->waitForElementNotVisible('input#convertkit_form_entries_per_page');
+
+		// Search by name.
+		$I->fillField('#convertkit-search', 'First');
+		$I->click('#search-submit');
+
+		// Confirm that the search term is displayed.
+		$I->waitForElementVisible('span.subtitle.left');
+		$I->assertEquals('Search results for "First"', $I->grabTextFrom('span.subtitle.left'));
+
+		// Confirm search result displayed in the table.
+		$I->assertEquals($items[0]['first_name'], $I->grabTextFrom('tbody#the-list tr:first-child td.first_name'));
+		$I->assertEquals($items[1]['first_name'], $I->grabTextFrom('tbody#the-list tr:nth-child(2) td.first_name'));
+
+		// Click next page.
+		$I->click('a.next-page');
+
+		// Confirm that the search term is retained.
+		$I->waitForElementVisible('span.subtitle.left');
+		$I->assertEquals('Search results for "First"', $I->grabTextFrom('span.subtitle.left'));
+
+		// Confirm search result displayed in the table.
+		$I->assertEquals($items[2]['first_name'], $I->grabTextFrom('tbody#the-list tr:first-child td.first_name'));
+		$I->assertEquals($items[3]['first_name'], $I->grabTextFrom('tbody#the-list tr:nth-child(2) td.first_name'));
+	}
+
+	/**
 	 * Helper method to insert form entries into the database.
 	 *
 	 * @since   3.0.0


### PR DESCRIPTION
## Summary

Adds search functionality to the Form Builder's entries table.

<img width="1133" height="721" alt="Screenshot 2025-09-01 at 19 19 54" src="https://github.com/user-attachments/assets/3fa18755-33db-4e1b-bf8b-1c309ccf44a1" />

<img width="1135" height="711" alt="Screenshot 2025-09-01 at 19 19 38" src="https://github.com/user-attachments/assets/bb006d57-d49d-48ff-8777-a24b128a0643" />

## Testing

- `testFormEntriesTableWithExactEmailSearch`: Test the Form Entries table with an exact email search.
- `testFormEntriesTableWithPartialEmailSearch`: Test the Form Entries table with a partial email search.
- `testFormEntriesTableWithExactNameSearch`: Test the Form Entries table with an exact name search.
- `testFormEntriesTableWithPartialNameSearch`: Test the Form Entries table with a partial name search.
- `testFormEntriesTableWithSearchAndPagination`: Test the Form Entries table with search and pagination.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)