### PR TITLE
Form Builder: Store Entries: Bulk Delete

### DIFF
--- a/admin/class-convertkit-admin-notices.php
+++ b/admin/class-convertkit-admin-notices.php
@@ -43,11 +43,6 @@ class ConvertKit_Admin_Notices {
 	 */
 	public function output() {
 
-		// Don't output if we're on a settings screen.
-		if ( convertkit_get_current_screen( 'base' ) === 'settings_page__wp_convertkit_settings' ) {
-			return;
-		}
-
 		// Don't output if we don't have the required capabilities to fix the issue.
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;

--- a/admin/class-convertkit-wp-list-table.php
+++ b/admin/class-convertkit-wp-list-table.php
@@ -94,8 +94,8 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 
 		parent::__construct(
 			array(
-				'singular' => 'item',
-				'plural'   => 'items',
+				'singular' => 'convertkit-item',
+				'plural'   => 'convertkit-items',
 				'ajax'     => false,
 			)
 		);
@@ -126,8 +126,9 @@ class ConvertKit_WP_List_Table extends WP_List_Table {
 	public function column_cb( $item ) {
 
 		return sprintf(
-			'<input type="checkbox" name="%1$s[]" value="%2$s" />',
-			$this->_args['singular'],
+			'<input type="checkbox" name="%1$s[]" id="cb-select-%2$s" value="%3$s" />',
+			$this->_args['plural'],
+			$item['id'],
 			$item['id']
 		);
 

--- a/resources/backend/css/settings.css
+++ b/resources/backend/css/settings.css
@@ -187,7 +187,7 @@ body.settings_page__wp_convertkit_settings #screen-meta-links {
 }
 
 /**
- * Search
+ * WP_List_Table Search
  */
 body.settings_page__wp_convertkit_settings .wrap .subtitle.left {
 	margin: 11px 0;
@@ -199,4 +199,15 @@ body.settings_page__wp_convertkit_settings .wrap .subtitle.left {
 }
 body.settings_page__wp_convertkit_settings .wrap .search-box input[type=search] {
 	min-height: 40px;
+}
+
+/**
+ * WP_List_Table Bulk Actions
+ */
+body.settings_page__wp_convertkit_settings .wrap .tablenav.top {
+	margin-bottom: 10px;
+}
+body.settings_page__wp_convertkit_settings .wrap .tablenav input.button.action {
+	height: 20px;
+	line-height: 20px;
 }

--- a/tests/EndToEnd/general/plugin-screens/PluginSettingsFormEntriesCest.php
+++ b/tests/EndToEnd/general/plugin-screens/PluginSettingsFormEntriesCest.php
@@ -296,6 +296,42 @@ class PluginSettingsFormEntriesCest
 	}
 
 	/**
+	 * Test the Form Entries table delete bulk action.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormEntriesTableDeleteBulkAction(EndToEndTester $I)
+	{
+		// Setup Plugin.
+		$I->setupKitPlugin($I);
+		$I->setupKitPluginResources($I);
+
+		// Enter some entries into the Form Entries table.
+		$items = $this->insertFormEntriesToDatabase($I);
+
+		// Load the Form Entries screen.
+		$I->loadKitSettingsFormEntriesScreen($I);
+
+		// Select the first two entries.
+		$I->checkOption('tbody#the-list tr:first-child th.check-column input[type="checkbox"]');
+		$I->checkOption('tbody#the-list tr:nth-child(2) th.check-column input[type="checkbox"]');
+
+		// Click Delete.
+		$I->selectOption('#bulk-action-selector-top', 'Delete');
+		$I->click('#doaction');
+
+		// Wait for notice to be displayed.
+		$I->waitForElementVisible('div.notice');
+		$I->see('Form Entries deleted.');
+
+		// Confirm that the entries are deleted.
+		$I->dontSee($items[0]['first_name']);
+		$I->dontSee($items[1]['first_name']);
+	}
+
+	/**
 	 * Helper method to insert form entries into the database.
 	 *
 	 * @since   3.0.0


### PR DESCRIPTION
## Summary

Adds a delete bulk action to the Form Builder's entries table.

<img width="1225" height="802" alt="Screenshot 2025-09-02 at 11 27 12" src="https://github.com/user-attachments/assets/1dc4aa85-fb81-40c1-a581-f594579ece0f" />

## Testing

- `testFormEntriesTableDeleteBulkAction`: Test the Form Entries table delete bulk action.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)