### PR TITLE
Update Documentation Links

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -170,7 +170,7 @@ is setup successfully.
 
 ### Connect Plugin to Kit
 
-Refer to the [Kit Help Article](https://help.kit.com/en/articles/2502591-getting-started-the-wordpress-plugin) to get started with using the WordPress Plugin.
+Refer to the [Kit Help Article](https://help.kit.com/en/articles/2502591-how-to-set-up-the-kit-plugin-on-your-wordpress-website) to get started with using the WordPress Plugin.
 
 ## Docker
 

--- a/admin/section/class-convertkit-admin-section-broadcasts.php
+++ b/admin/section/class-convertkit-admin-section-broadcasts.php
@@ -383,7 +383,7 @@ class ConvertKit_Admin_Section_Broadcasts extends ConvertKit_Admin_Section_Base 
 	 */
 	public function documentation_url() {
 
-		return 'https://help.kit.com/en/articles/2502591-the-convertkit-wordpress-plugin';
+		return 'https://help.kit.com/en/articles/9669096-publish-broadcasts-as-wordpress-posts-and-vice-versa';
 
 	}
 

--- a/admin/section/class-convertkit-admin-section-form-entries.php
+++ b/admin/section/class-convertkit-admin-section-form-entries.php
@@ -81,7 +81,7 @@ class ConvertKit_Admin_Section_Form_Entries extends ConvertKit_Admin_Section_Bas
 	 */
 	public function documentation_url() {
 
-		return 'https://help.kit.com/en/articles/2502591-the-convertkit-wordpress-plugin';
+		return 'https://help.kit.com/en/articles/2502591-how-to-set-up-the-kit-plugin-on-your-wordpress-website';
 
 	}
 

--- a/admin/section/class-convertkit-admin-section-general.php
+++ b/admin/section/class-convertkit-admin-section-general.php
@@ -542,7 +542,7 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 	 */
 	public function documentation_url() {
 
-		return 'https://help.kit.com/en/articles/2502591-the-convertkit-wordpress-plugin';
+		return 'https://help.kit.com/en/articles/2502591-how-to-set-up-the-kit-plugin-on-your-wordpress-website';
 
 	}
 

--- a/admin/section/class-convertkit-admin-section-oauth.php
+++ b/admin/section/class-convertkit-admin-section-oauth.php
@@ -152,7 +152,7 @@ class ConvertKit_Admin_Section_OAuth extends ConvertKit_Admin_Section_Base {
 	 */
 	public function documentation_url() {
 
-		return 'https://help.kit.com/en/articles/2502591-the-convertkit-wordpress-plugin';
+		return 'https://help.kit.com/en/articles/2502591-how-to-set-up-the-kit-plugin-on-your-wordpress-website';
 
 	}
 

--- a/admin/section/class-convertkit-admin-section-restrict-content.php
+++ b/admin/section/class-convertkit-admin-section-restrict-content.php
@@ -419,7 +419,7 @@ class ConvertKit_Admin_Section_Restrict_Content extends ConvertKit_Admin_Section
 	 */
 	public function documentation_url() {
 
-		return 'https://help.kit.com/en/articles/2502591-the-convertkit-wordpress-plugin';
+		return 'https://help.kit.com/en/articles/7896769-how-to-customize-your-kit-subscribers-experience-on-your-wordpress-website';
 
 	}
 

--- a/admin/section/class-convertkit-admin-section-tools.php
+++ b/admin/section/class-convertkit-admin-section-tools.php
@@ -365,7 +365,7 @@ class ConvertKit_Admin_Section_Tools extends ConvertKit_Admin_Section_Base {
 	 */
 	public function documentation_url() {
 
-		return 'https://help.kit.com/en/articles/2502591-the-convertkit-wordpress-plugin';
+		return 'https://help.kit.com/en/articles/2502591-how-to-set-up-the-kit-plugin-on-your-wordpress-website';
 
 	}
 

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-section.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-section.php
@@ -102,7 +102,7 @@ class ConvertKit_ContactForm7_Admin_Section extends ConvertKit_Admin_Section_Bas
 	 */
 	public function documentation_url() {
 
-		return 'https://help.kit.com/en/articles/2502591-the-convertkit-wordpress-plugin';
+		return 'https://help.kit.com/en/articles/2502591-how-to-set-up-the-kit-plugin-on-your-wordpress-website';
 
 	}
 

--- a/includes/integrations/forminator/class-convertkit-forminator-admin-section.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-admin-section.php
@@ -89,7 +89,7 @@ class ConvertKit_Forminator_Admin_Section extends ConvertKit_Admin_Section_Base 
 	 */
 	public function documentation_url() {
 
-		return 'https://help.kit.com/en/articles/2502591-the-convertkit-wordpress-plugin';
+		return 'https://help.kit.com/en/articles/2502591-how-to-set-up-the-kit-plugin-on-your-wordpress-website';
 
 	}
 

--- a/includes/integrations/wishlist/class-convertkit-wishlist-admin-section.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist-admin-section.php
@@ -86,7 +86,7 @@ class ConvertKit_Wishlist_Admin_Section extends ConvertKit_Admin_Section_Base {
 	 */
 	public function documentation_url() {
 
-		return 'https://help.kit.com/en/articles/2502591-the-convertkit-wordpress-plugin';
+		return 'https://help.kit.com/en/articles/2502591-how-to-set-up-the-kit-plugin-on-your-wordpress-website';
 
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -106,7 +106,7 @@ Kit is the go-to email marketing hub for creators that helps you grow and moneti
 
 ### Documentation
 
-Full Plugin documentation can be found [here](https://help.kit.com/en/articles/2502591-the-convertkit-wordpress-plugin?utm_source=wordpress&utm_term=en_US&utm_content=readme).
+Full Plugin documentation can be found [here](https://help.kit.com/en/articles/2502591-how-to-set-up-the-kit-plugin-on-your-wordpress-website?utm_source=wordpress&utm_term=en_US&utm_content=readme).
 
 == Installation ==
 
@@ -144,7 +144,7 @@ To import your past (and future) email newsletters from Kit to WordPress:
 
 = Where can I find the Plugin's Documentation? =
 
-Full Plugin documentation can be found [here](https://help.kit.com/en/articles/2502591-the-convertkit-wordpress-plugin?utm_source=wordpress&utm_content=readme).
+Full Plugin documentation can be found [here](https://help.kit.com/en/articles/2502591-how-to-set-up-the-kit-plugin-on-your-wordpress-website?utm_source=wordpress&utm_content=readme).
 
 == Screenshots ==
 

--- a/tests/EndToEnd/general/plugin-screens/PluginSettingsGeneralCest.php
+++ b/tests/EndToEnd/general/plugin-screens/PluginSettingsGeneralCest.php
@@ -47,8 +47,8 @@ class PluginSettingsGeneralCest
 		$I->seeInSource('<label for="no_css">');
 
 		// Confirm that the UTM parameters exist for the documentation links.
-		$I->seeInSource('<a href="https://help.kit.com/en/articles/2502591-the-convertkit-wordpress-plugin?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" class="convertkit-docs" target="_blank">Help</a>');
-		$I->seeInSource('<a href="https://help.kit.com/en/articles/2502591-the-convertkit-wordpress-plugin?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" target="_blank">plugin documentation</a>');
+		$I->seeInSource('<a href="https://help.kit.com/en/articles/2502591-how-to-set-up-the-kit-plugin-on-your-wordpress-website?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" class="convertkit-docs" target="_blank">Help</a>');
+		$I->seeInSource('<a href="https://help.kit.com/en/articles/2502591-how-to-set-up-the-kit-plugin-on-your-wordpress-website?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" target="_blank">plugin documentation</a>');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Updates documentation links in the Plugin to reflect changes:

- https://help.kit.com/en/articles/2502591-getting-started-the-wordpress-plugin redirects to https://help.kit.com/en/articles/2502591-how-to-set-up-the-kit-plugin-on-your-wordpress-website, so replaced these links with the new one (https://help.kit.com/en/articles/2502591-how-to-set-up-the-kit-plugin-on-your-wordpress-website)
- Broadcasts has its own documentation: https://help.kit.com/en/articles/9669096-publish-broadcasts-as-wordpress-posts-and-vice-versa
- Member Content has its own documentation: https://help.kit.com/en/articles/7896769-how-to-customize-your-kit-subscribers-experience-on-your-wordpress-website

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)