### PR TITLE
Improve Intercom Integration

### DIFF
--- a/admin/section/class-convertkit-admin-section-base.php
+++ b/admin/section/class-convertkit-admin-section-base.php
@@ -89,6 +89,11 @@ abstract class ConvertKit_Admin_Section_Base {
 			$this->tab_text = $this->title;
 		}
 
+		// Output the Intercom messenger if we're on the Plugin's settings screen.
+		if ( $this->on_settings_screen( $this->name ) ) {
+			add_action( 'admin_footer', array( $this, 'output_intercom' ) );
+		}
+
 		// Register the settings section.
 		$this->register_section();
 

--- a/admin/section/class-convertkit-admin-section-broadcasts.php
+++ b/admin/section/class-convertkit-admin-section-broadcasts.php
@@ -48,7 +48,6 @@ class ConvertKit_Admin_Section_Broadcasts extends ConvertKit_Admin_Section_Base 
 		if ( $this->on_settings_screen( $this->name ) ) {
 			add_filter( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );
 			add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
-			add_action( 'admin_footer', array( $this, 'output_intercom' ) );
 		}
 
 		// Enqueue scripts and CSS.

--- a/admin/section/class-convertkit-admin-section-general.php
+++ b/admin/section/class-convertkit-admin-section-general.php
@@ -85,7 +85,6 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 		if ( $this->on_settings_screen( $this->name ) ) {
 			add_filter( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );
 			add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
-			add_action( 'admin_footer', array( $this, 'output_intercom' ) );
 		}
 
 		// Enqueue scripts and CSS.

--- a/admin/section/class-convertkit-admin-section-oauth.php
+++ b/admin/section/class-convertkit-admin-section-oauth.php
@@ -35,7 +35,6 @@ class ConvertKit_Admin_Section_OAuth extends ConvertKit_Admin_Section_Base {
 		// Maybe output notices for this settings screen, and the Intercom messenger.
 		if ( $this->on_settings_screen( 'general' ) ) {
 			add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
-			add_action( 'admin_footer', array( $this, 'output_intercom' ) );
 		}
 
 		parent::__construct();

--- a/admin/section/class-convertkit-admin-section-oauth.php
+++ b/admin/section/class-convertkit-admin-section-oauth.php
@@ -35,6 +35,10 @@ class ConvertKit_Admin_Section_OAuth extends ConvertKit_Admin_Section_Base {
 		// Maybe output notices for this settings screen, and the Intercom messenger.
 		if ( $this->on_settings_screen( 'general' ) ) {
 			add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
+
+			// OAuth is a special case, as it'll register as the 'general' screen - so the Intercom
+			// call in ConvertKit_Admin_Section_Base's construct won't work.
+			add_action( 'admin_footer', array( $this, 'output_intercom' ) );
 		}
 
 		parent::__construct();

--- a/admin/section/class-convertkit-admin-section-restrict-content.php
+++ b/admin/section/class-convertkit-admin-section-restrict-content.php
@@ -59,11 +59,6 @@ class ConvertKit_Admin_Section_Restrict_Content extends ConvertKit_Admin_Section
 		// Enqueue scripts.
 		add_action( 'convertkit_admin_settings_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 
-		// Output the Intercom messenger.
-		if ( $this->on_settings_screen( $this->name ) ) {
-			add_action( 'admin_footer', array( $this, 'output_intercom' ) );
-		}
-
 		parent::__construct();
 
 	}

--- a/admin/section/class-convertkit-admin-section-tools.php
+++ b/admin/section/class-convertkit-admin-section-tools.php
@@ -32,7 +32,6 @@ class ConvertKit_Admin_Section_Tools extends ConvertKit_Admin_Section_Base {
 		if ( $this->on_settings_screen( $this->name ) ) {
 			add_filter( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );
 			add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
-			add_action( 'admin_footer', array( $this, 'output_intercom' ) );
 		}
 
 		parent::__construct();

--- a/tests/EndToEnd/general/plugin-screens/PluginIntercomCest.php
+++ b/tests/EndToEnd/general/plugin-screens/PluginIntercomCest.php
@@ -64,6 +64,18 @@ class PluginIntercomCest
 
 		// Confirm the Intercom script is loaded.
 		$this->_seeIntercomScript($I);
+
+		// Go to the Plugin's Form Entries screen.
+		$I->loadKitSettingsFormEntriesScreen($I);
+
+		// Confirm the Intercom script is loaded.
+		$this->_seeIntercomScript($I);
+
+		// Load a non-Plugin settings screen.
+		$I->amOnAdminPage('options-permalink.php');
+
+		// Confirm the Intercom script is not loaded.
+		$this->_dontSeeIntercomScript($I);
 	}
 
 	/**
@@ -109,6 +121,11 @@ class PluginIntercomCest
 		$I->waitForElementVisible('.intercom-lightweight-app-launcher-icon');
 		$I->click('.intercom-lightweight-app-launcher-icon');
 		$I->waitForElementVisible('iframe[data-intercom-frame="true"]');
+	}
+
+	private function _dontSeeIntercomScript(EndToEndTester $I)
+	{
+		$I->dontSeeElementInDOM('.intercom-lightweight-app-launcher-icon');
 	}
 
 	/**

--- a/tests/EndToEnd/general/plugin-screens/PluginIntercomCest.php
+++ b/tests/EndToEnd/general/plugin-screens/PluginIntercomCest.php
@@ -123,6 +123,13 @@ class PluginIntercomCest
 		$I->waitForElementVisible('iframe[data-intercom-frame="true"]');
 	}
 
+	/**
+	 * Assert that the Intercom script is not loaded.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
 	private function _dontSeeIntercomScript(EndToEndTester $I)
 	{
 		$I->dontSeeElementInDOM('.intercom-lightweight-app-launcher-icon');


### PR DESCRIPTION
## Summary

Load Intercom's script in the `ConvertKit_Admin_Section_Base` class, as all settings classes use this. There's no need to repeat this filter hook call all settings screens.

## Testing

Updated tests to include Form Entries settings screen, and confirm Intercom does not load on a non-Plugin screen.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)