### PR TITLE
Form Builder: Display asterisk for required fields

### DIFF
--- a/includes/blocks/class-convertkit-block-form-builder-field.php
+++ b/includes/blocks/class-convertkit-block-form-builder-field.php
@@ -279,6 +279,9 @@ class ConvertKit_Block_Form_Builder_Field extends ConvertKit_Block {
 		$css_classes = $this->get_css_classes( array( 'wp-block-convertkit-form-builder-field', 'convertkit-form-builder-field' ) );
 		$css_styles  = $this->get_css_styles( $atts );
 
+		// Determine if the field is required.
+		$field_required = $this->field_required ? true : ( $atts['required'] ? true : false );
+
 		// Build input / textarea.
 		switch ( $this->field_type ) {
 			case 'textarea':
@@ -286,7 +289,7 @@ class ConvertKit_Block_Form_Builder_Field extends ConvertKit_Block {
 					'<textarea id="%s" name="convertkit[%s]" %s></textarea>',
 					esc_attr( sanitize_title( $this->field_id ) ),
 					esc_attr( $this->field_name ),
-					$this->field_required ? ' required' : ( $atts['required'] ? ' required' : '' )
+					$field_required ? ' required' : ''
 				);
 				break;
 			default:
@@ -295,18 +298,19 @@ class ConvertKit_Block_Form_Builder_Field extends ConvertKit_Block {
 					esc_attr( $this->field_type ),
 					esc_attr( sanitize_title( $this->field_id ) ),
 					esc_attr( $this->field_name ),
-					$this->field_required ? ' required' : ( $atts['required'] ? ' required' : '' )
+					$field_required ? ' required' : ''
 				);
 				break;
 		}
 
 		// Build field HTML.
 		$html = sprintf(
-			'<div class="%s" style="%s"><label for="%s">%s</label>%s</div>',
+			'<div class="%s" style="%s"><label for="%s">%s%s</label>%s</div>',
 			implode( ' ', map_deep( $css_classes, 'sanitize_html_class' ) ),
 			implode( ';', map_deep( $css_styles, 'esc_attr' ) ),
 			esc_attr( sanitize_title( $this->field_id ) ),
 			esc_html( $atts['label'] ),
+			( $field_required ? ' <span class="convertkit-form-builder-field-required">*</span>' : '' ),
 			$field
 		);
 

--- a/resources/frontend/css/form-builder.css
+++ b/resources/frontend/css/form-builder.css
@@ -10,6 +10,9 @@
 	box-sizing: border-box;
 	font-family: inherit;
 }
+.wp-block-convertkit-form-builder-field label span.convertkit-form-builder-field-required {
+	color: red;
+}
 form .convertkit-form-builder-subscribed-message {
 	width: 100%;
 	margin: 0 0 20px 0;

--- a/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormBuilderCest.php
+++ b/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormBuilderCest.php
@@ -1149,6 +1149,11 @@ class PageBlockFormBuilderCest
 		// Check label exists with correct text.
 		$I->seeElementInDOM($container . ' label[for="' . $fieldID . '"]');
 		$I->assertEquals($label, $I->grabTextFrom($container . ' label[for="' . $fieldID . '"]'));
+
+		// Check the required asterisk is displayed.
+		if ($required) {
+			$I->seeElementInDOM($container . ' label[for="' . $fieldID . '"] span.convertkit-form-builder-field-required');
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Displays an asterisk when a field is marked as required in the Form Builder block

<img width="1052" height="551" alt="Screenshot 2025-09-08 at 10 31 36" src="https://github.com/user-attachments/assets/8195f4e2-5245-471f-a5db-0a4258fa12f7" />

## Testing

Updated existing tests to check asterisk element is displayed

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)