### PR TITLE
Improve HTML Parser

### DIFF
--- a/includes/class-convertkit-html-parser.php
+++ b/includes/class-convertkit-html-parser.php
@@ -67,9 +67,14 @@ class ConvertKit_HTML_Parser {
 	 */
 	public function get_body_html() {
 
-		// Return modified content in the <body> tag.
-		preg_match( '/<body[^>]*>(.*?)<\/body>/is', $this->html->saveHTML(), $matches );
-		return $matches[1] ?? '';
+		$body = $this->html->getElementsByTagName( 'body' )->item( 0 );
+
+		$html = '';
+		foreach ( $body->childNodes as $child ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$html .= $this->html->saveHTML( $child );
+		}
+
+		return $html;
 
 	}
 


### PR DESCRIPTION
## Summary

Improves https://github.com/Kit/convertkit-wordpress/pull/879 by using DOMDocument to extract the <body> HTML, instead of regex.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)