### PR TITLE
Form Entries: Filter by API Result

### DIFF
--- a/admin/section/class-convertkit-admin-section-form-entries.php
+++ b/admin/section/class-convertkit-admin-section-form-entries.php
@@ -141,6 +141,16 @@ class ConvertKit_Admin_Section_Form_Entries extends ConvertKit_Admin_Section_Bas
 		$table->add_bulk_action( 'export', __( 'Export', 'convertkit' ) );
 		$table->add_bulk_action( 'delete', __( 'Delete', 'convertkit' ) );
 
+		// Add filters to table.
+		$table->add_filter(
+			'api_result',
+			__( 'All Results', 'convertkit' ),
+			array(
+				'success' => __( 'Success', 'convertkit' ),
+				'error'   => __( 'Error', 'convertkit' ),
+			)
+		);
+
 		// Add columns to table.
 		$table->add_column( 'cb', __( 'Select', 'convertkit' ), false );
 		$table->add_column( 'post_id', __( 'Post ID', 'convertkit' ), false );
@@ -157,6 +167,7 @@ class ConvertKit_Admin_Section_Form_Entries extends ConvertKit_Admin_Section_Bas
 		// Add form entries to table.
 		$entries = $form_entries->search(
 			$table->get_search(),
+			$table->get_filter( 'api_result' ),
 			$table->get_order_by( 'created_at' ),
 			$table->get_order( 'desc' ),
 			$table->get_pagenum(),
@@ -165,7 +176,7 @@ class ConvertKit_Admin_Section_Form_Entries extends ConvertKit_Admin_Section_Bas
 		$table->add_items( $entries );
 
 		// Set total entries and items per page options key.
-		$table->set_total_items( $form_entries->total( $table->get_search() ) );
+		$table->set_total_items( $form_entries->total( $table->get_search(), $table->get_filter( 'api_result' ) ) );
 		$table->set_items_per_page_screen_options_key( 'convertkit_form_entries_per_page' );
 
 		// Display search term.

--- a/resources/backend/css/settings.css
+++ b/resources/backend/css/settings.css
@@ -207,7 +207,7 @@ body.settings_page__wp_convertkit_settings .wrap .search-box input[type=search] 
 body.settings_page__wp_convertkit_settings .wrap .tablenav.top {
 	margin-bottom: 10px;
 }
-body.settings_page__wp_convertkit_settings .wrap .tablenav input.button.action {
+body.settings_page__wp_convertkit_settings .wrap .tablenav input.button {
 	height: 20px;
 	line-height: 20px;
 }

--- a/tests/EndToEnd/general/plugin-screens/PluginSettingsFormEntriesCest.php
+++ b/tests/EndToEnd/general/plugin-screens/PluginSettingsFormEntriesCest.php
@@ -334,6 +334,46 @@ class PluginSettingsFormEntriesCest
 	}
 
 	/**
+	 * Test the Form Entries table with an API result filter and search.
+	 *
+	 * @since   3.0.1
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormEntriesTableWithAPIResultFilterAndSearch(EndToEndTester $I)
+	{
+		// Setup Plugin.
+		$I->setupKitPlugin($I);
+		$I->setupKitPluginResources($I);
+
+		// Enter some entries into the Form Entries table.
+		$items = $this->insertFormEntriesToDatabase($I);
+
+		// Load the Form Entries screen.
+		$I->loadKitSettingsFormEntriesScreen($I);
+
+		// Search by name and filter by API result.
+		$I->fillField('#convertkit-search', 'First 0');
+		$I->selectOption('filters[api_result]', 'Success');
+		$I->click('#filter_action');
+
+		// Confirm that the search term is displayed.
+		$I->waitForElementVisible('span.subtitle.left');
+		$I->assertEquals('Search results for "First 0"', $I->grabTextFrom('span.subtitle.left'));
+
+		// Confirm the table displays the filtered results.
+		$I->see('1 item');
+		$I->assertNotContains(
+			'error',
+			$I->grabMultiple('td.column-api_result')
+		);
+		$I->assertContains(
+			'success',
+			$I->grabMultiple('td.column-api_result')
+		);
+	}
+
+	/**
 	 * Test the Form Entries table with an API result filter and pagination.
 	 *
 	 * @since   3.0.1


### PR DESCRIPTION
## Summary

Adds an option to filter Form Entries by API result (success or error), which can be used to then export a CSV file of any entries that failed to be sent to the API (unlikely, but useful should creators then need to manually import a few missing entries on kit.com)

<img width="912" height="816" alt="Screenshot 2025-09-09 at 11 48 36" src="https://github.com/user-attachments/assets/f655fe35-d6ce-48c8-a380-010638d9c7d4" />

## Testing

- `testFormEntriesTableWithAPIResultFilter`: Test the Form Entries table with an API result filter.
- `testFormEntriesTableWithAPIResultFilterAndSearch`: Test the Form Entries table with an API result filter and search.
- `testFormEntriesTableWithAPIResultFilterAndPagination`: Test the Form Entries table with an API result filter and pagination.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)