### PR TITLE
Member Content: Improve login form layout on mobile

### DIFF
--- a/resources/frontend/css/restrict-content.css
+++ b/resources/frontend/css/restrict-content.css
@@ -227,11 +227,24 @@ form.convertkit-restrict-content-form div#convertkit-subscriber-code-container i
 
 /* Responsive */
 @media screen and (max-width: 730px) {
+	#convertkit-restrict-content {
+		padding: 20px;
+	}
 	#convertkit-restrict-content .convertkit-restrict-content-actions {
 		padding: 10px;
 	}
 	#convertkit-restrict-content input[type=email], #convertkit-restrict-content input[type=text], #convertkit-restrict-content input#convertkit_subscriber_code {
 		width: 100%;
+	}
+	form.convertkit-restrict-content-form div#convertkit-restrict-content-email-field {
+		grid-template-areas:
+			"email email"
+			"button button";
+		max-width: 100%;
+		height: auto;
+	}
+	form.convertkit-restrict-content-form div#convertkit-restrict-content-email-field input[type=submit] {
+		margin-top: 10px;
 	}
 	#convertkit-restrict-content-modal {
 		width: 90%;


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://linear.app/kit/issue/WP-60/wp-p3-subscribers-only-form-displaying-oddly-on-mobile) by improving the input field and button layout on smaller screens.

Before:
<img width="428" height="574" alt="Screenshot 2025-09-15 at 11 03 27" src="https://github.com/user-attachments/assets/db42cb41-4745-4959-8c75-7c0f951a9ac0" />

After:
<img width="427" height="580" alt="Screenshot 2025-09-15 at 11 03 54" src="https://github.com/user-attachments/assets/4cad68e0-a02f-492d-a418-e7eeb8379565" />

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)