### PR TITLE
Form Builder: Fix Typo

### DIFF
--- a/includes/blocks/class-convertkit-block-form-builder.php
+++ b/includes/blocks/class-convertkit-block-form-builder.php
@@ -292,7 +292,7 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 
 		return array(
 			'title'                   => __( 'Kit Form Builder', 'convertkit' ),
-			'description'             => __( 'Build a subcription form with Kit.', 'convertkit' ),
+			'description'             => __( 'Build a subscription form with Kit.', 'convertkit' ),
 			'icon'                    => 'resources/backend/images/block-icon-form-builder.svg',
 			'category'                => 'convertkit',
 			'keywords'                => array(

--- a/languages/convertkit.pot
+++ b/languages/convertkit.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-09-11T05:00:40+00:00\n"
+"POT-Creation-Date: 2025-09-16T14:20:51+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: convertkit\n"
@@ -1268,7 +1268,7 @@ msgid "Kit Form Builder"
 msgstr ""
 
 #: includes/blocks/class-convertkit-block-form-builder.php:295
-msgid "Build a subcription form with Kit."
+msgid "Build a subscription form with Kit."
 msgstr ""
 
 #: includes/blocks/class-convertkit-block-form-builder.php:301


### PR DESCRIPTION
## Summary

Fix a typo in the Form Builder's description:
<img width="352" height="160" alt="Kit Form Builder block typo" src="https://github.com/user-attachments/assets/42a0fc66-9cc5-4ef9-ae50-4bafca32b37e" />

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)