### PR TITLE
Add JS Coding Standards: Backend

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,10 @@ module.exports = {
 		convertkit_quicktags: 'readonly',
 		convertkit_shortcodes: 'readonly',
 	},
+	ignorePatterns: [
+		'resources/backend/js/gutenberg.js',
+		'resources/backend/js/gutenberg-block-formatters.js',
+	],
 	rules: {
 		// Turn off specific rules
 		camelcase: 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,6 @@ module.exports = {
 		convertkit_quicktags: 'readonly',
 		convertkit_shortcodes: 'readonly',
 	},
-	ignorePatterns: ['resources/backend/'],
 	rules: {
 		// Turn off specific rules
 		camelcase: 'off',

--- a/resources/backend/js/bulk-edit.js
+++ b/resources/backend/js/bulk-edit.js
@@ -1,7 +1,6 @@
 /**
  * Bulk Edit
  *
- * @package ConvertKit
  * @author ConvertKit
  */
 
@@ -13,21 +12,18 @@
  *
  * @since 	1.9.8.0
  */
-document.addEventListener(
-	'DOMContentLoaded',
-	function () {
+document.addEventListener('DOMContentLoaded', function () {
+	const convertKitBulkEditWrapper = document.querySelector(
+			'tr#bulk-edit .inline-edit-wrapper fieldset.inline-edit-col-right'
+		),
+		convertKitBulkEdit = document.querySelector('#convertkit-bulk-edit');
 
-		const convertKitBulkEditWrapper = document.querySelector( 'tr#bulk-edit .inline-edit-wrapper fieldset.inline-edit-col-right' ),
-			convertKitBulkEdit          = document.querySelector( '#convertkit-bulk-edit' );
+	if (convertKitBulkEditWrapper) {
+		// Move Bulk Edit fields from footer into the hidden bulk-edit table row,
+		// if a bulk-edit table row exists (it won't exist if searching returns no pages).
+		convertKitBulkEditWrapper.appendChild(convertKitBulkEdit);
 
-		if ( convertKitBulkEditWrapper ) {
-			// Move Bulk Edit fields from footer into the hidden bulk-edit table row,
-			// if a bulk-edit table row exists (it won't exist if searching returns no pages).
-			convertKitBulkEditWrapper.appendChild( convertKitBulkEdit );
-
-			// Show the Bulk Edit fields, as they are now contained in the inline-edit row which WordPress will show/hide as necessary.
-			convertKitBulkEdit.style.display = 'block';
-		}
-
+		// Show the Bulk Edit fields, as they are now contained in the inline-edit row which WordPress will show/hide as necessary.
+		convertKitBulkEdit.style.display = 'block';
 	}
-);
+});

--- a/resources/backend/js/editor.js
+++ b/resources/backend/js/editor.js
@@ -3,118 +3,96 @@
  *
  * @since   1.9.6
  *
- * @package ConvertKit
  * @author ConvertKit
  */
 
+/* eslint-disable no-unused-vars */
 /**
  * Registers the given block as a TinyMCE Plugin, with a button in
  * the Visual Editor toolbar.
  *
  * @since 	1.9.6
  *
- * @param 	object 	block 	Block
+ * @param {Object} block Block
  */
-function convertKitTinyMCERegisterPlugin( block ) {
-
+function convertKitTinyMCERegisterPlugin(block) {
 	tinymce.PluginManager.add(
 		'convertkit_' + block.name,
-		function ( editor, url ) {
-
+		function (editor, url) {
 			// Add Button to Visual Editor Toolbar.
-			editor.addButton(
-				'convertkit_' + block.name,
-				{
-					title: 	block.title,
-					image: 	url + '../../../../' + block.icon,
-					cmd: 	'convertkit_' + block.name,
-				}
-			);
+			editor.addButton('convertkit_' + block.name, {
+				title: block.title,
+				image: url + '../../../../' + block.icon,
+				cmd: 'convertkit_' + block.name,
+			});
 
 			// Load View when button clicked.
-			editor.addCommand(
-				'convertkit_' + block.name,
-				function () {
+			editor.addCommand('convertkit_' + block.name, function () {
+				// Close any existing QuickTags modal.
+				convertKitQuickTagsModal.close();
 
-					// Close any existing QuickTags modal.
-					convertKitQuickTagsModal.close();
+				// Open the TinyMCE Modal.
+				editor.windowManager.open({
+					id: 'convertkit-modal-body',
+					title: block.title,
+					width: block.modal.width,
 
-					// Open the TinyMCE Modal.
-					editor.windowManager.open(
+					// Set modal height up to a maximum of 580px.
+					// Content will overflow-y to show a scrollbar where necessary.
+					height: block.modal.height < 580 ? block.modal.height : 580,
+					inline: 1,
+					buttons: [
 						{
-							id: 	'convertkit-modal-body',
-							title: 	block.title,
-							width: 	block.modal.width,
-
-							// Set modal height up to a maximum of 580px.
-							// Content will overflow-y to show a scrollbar where necessary.
-							height: ( block.modal.height < 580 ? block.modal.height : 580 ),
-							inline: 1,
-							buttons: [
-								{
-									text: 'Cancel',
-									classes: 'cancel'
-							},
-								{
-									text: 'Insert',
-									subtype: 'primary',
-									classes: 'insert'
-							}
-							]
-						}
-					);
-
-					// Perform an AJAX call to load the modal's view.
-					fetch(
-						ajaxurl,
+							text: 'Cancel',
+							classes: 'cancel',
+						},
 						{
-							method: 'POST',
-							headers: {
-								'Content-Type': 'application/x-www-form-urlencoded',
-							},
-							body: new URLSearchParams(
-								{
-									'action': 		'convertkit_admin_tinymce_output_modal',
-									'nonce':  		convertkit_admin_tinymce.nonce,
-									'editor_type':  'tinymce',
-									'shortcode': 	block.name
-								}
-							),
-						}
-					)
-					.then(
-						function ( response ) {
-							return response.text();
-						}
-					)
-					.then(
-						function ( result ) {
-							// Inject HTML into modal.
-							document.querySelector( '#convertkit-modal-body-body' ).innerHTML = result;
+							text: 'Insert',
+							subtype: 'primary',
+							classes: 'insert',
+						},
+					],
+				});
 
-							// Initialize tabbed interface.
-							convertKitTabsInit();
+				// Perform an AJAX call to load the modal's view.
+				fetch(ajaxurl, {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/x-www-form-urlencoded',
+					},
+					body: new URLSearchParams({
+						action: 'convertkit_admin_tinymce_output_modal',
+						nonce: convertkit_admin_tinymce.nonce,
+						editor_type: 'tinymce',
+						shortcode: block.name,
+					}),
+				})
+					.then(function (response) {
+						return response.text();
+					})
+					.then(function (result) {
+						// Inject HTML into modal.
+						document.querySelector(
+							'#convertkit-modal-body-body'
+						).innerHTML = result;
 
-							// Listen for color input changes.
-							convertKitColorInputInit();
+						// Initialize tabbed interface.
+						convertKitTabsInit();
 
-							// Bind refresh resource event listeners.
-							convertKitRefreshResourcesInitEventListeners();
-						}
-					)
-					.catch(
-						function ( error ) {
-							console.error( error );
-						}
-					);
+						// Listen for color input changes.
+						convertKitColorInputInit();
 
-				}
-			);
-
+						// Bind refresh resource event listeners.
+						convertKitRefreshResourcesInitEventListeners();
+					})
+					.catch(function (error) {
+						console.error(error);
+					});
+			});
 		}
 	);
-
 }
+/* eslint-enable no-unused-vars */
 
 /**
  * Listens for changes to input[type=color] inputs within a TinyMCE or QuickTags modal,
@@ -126,16 +104,11 @@ function convertKitTinyMCERegisterPlugin( block ) {
  * @since 	2.4.3
  */
 function convertKitColorInputInit() {
-
-	document.querySelectorAll( '.convertkit-option input[type=color]' ).forEach(
-		function ( colorPicker ) {
-			colorPicker.addEventListener(
-				'change',
-				function ( event ) {
-					event.target.dataset.value = event.target.value;
-				}
-			);
-		}
-	);
-
+	document
+		.querySelectorAll('.convertkit-option input[type=color]')
+		.forEach(function (colorPicker) {
+			colorPicker.addEventListener('change', function (event) {
+				event.target.dataset.value = event.target.value;
+			});
+		});
 }

--- a/resources/backend/js/gutenberg-block-form.js
+++ b/resources/backend/js/gutenberg-block-form.js
@@ -3,56 +3,71 @@
  *
  * @since   1.9.6.5
  *
- * @package ConvertKit
  * @author ConvertKit
  */
 
+/* eslint-disable no-unused-vars */
 /**
  * Custom callback function to render the ConvertKit Form Block preview in the Gutenberg Editor.
  *
  * @since 	1.9.6.5
  *
- * @param 	object 	block 	Block
- * @param 	obejct  props 	Block properties
+ * @param {Object} block Block.
+ * @param {Object} props Block properties.
  */
-function convertKitGutenbergFormBlockRenderPreview( block, props ) {
-
+function convertKitGutenbergFormBlockRenderPreview(block, props) {
+	// eslint-disable-line no-unused-vars
 	// Get selected form.
-	var form = block.fields.form.data.forms[ props.attributes.form ];
+	const form = block.fields.form.data.forms[props.attributes.form];
 
 	// If no Form has been selected for display, return a prompt to tell the editor
 	// what to do.
-	if ( typeof form === 'undefined' ) {
-		return convertKitGutenbergDisplayBlockNotice( block.name, block.gutenberg_help_description );
+	if (typeof form === 'undefined') {
+		return convertKitGutenbergDisplayBlockNotice(
+			block.name,
+			block.gutenberg_help_description
+		);
 	}
 
 	// If the Form is a <script> embed, use the SandBox because the Gutenberg editor
 	// will not execute inline scripts.
-	if ( typeof form.uid !== 'undefined' ) {
+	if (typeof form.uid !== 'undefined') {
 		// Determine the Form's format (inline, sticky bar etc).
 		// This isn't available in API responses prior to Feb 2022, so check the Form object contains this property.
-		var format    = ( ( typeof form.format !== 'undefined' ) ? form.format : 'inline' ),
-			html      = '<script async data-uid="' + form.uid + '" src="' + form.embed_js + '"></script>',
-			className = [ 'convertkit-' + block.name ];
+		const format =
+			typeof form.format !== 'undefined' ? form.format : 'inline';
+		let html =
+			'<script async data-uid="' +
+			form.uid +
+			'" src="' +
+			form.embed_js +
+			'"></script>';
+		const className = ['convertkit-' + block.name];
 
 		// If the format isn't inline, define the Gutenberg Block preview's HTML to explain why the Form won't be
 		// rendered in the editor i.e because it is a Sticky Bar that is displayed at the top/bottom of the document.
 		// Also add a CSS class to the block in the editor, so that resources/backend/css/gutenberg-block-form.css
 		// can apply styling/branding to the block.
-		switch ( format ) {
+		switch (format) {
 			case 'modal':
-				html = block.i18n.gutenberg_form_modal.replace( '%s', form.name );
-				className.push( 'convertkit-no-content' );
+				html = block.i18n.gutenberg_form_modal.replace('%s', form.name);
+				className.push('convertkit-no-content');
 				break;
 
 			case 'slide in':
-				html = block.i18n.gutenberg_form_slide_in.replace( '%s', form.name );
-				className.push( 'convertkit-no-content' );
+				html = block.i18n.gutenberg_form_slide_in.replace(
+					'%s',
+					form.name
+				);
+				className.push('convertkit-no-content');
 				break;
 
 			case 'sticky bar':
-				html = block.i18n.gutenberg_form_sticky_bar.replace( '%s', form.name );
-				className.push( 'convertkit-no-content' );
+				html = block.i18n.gutenberg_form_sticky_bar.replace(
+					'%s',
+					form.name
+				);
+				className.push('convertkit-no-content');
 				break;
 		}
 
@@ -60,32 +75,27 @@ function convertKitGutenbergFormBlockRenderPreview( block, props ) {
 		return wp.element.createElement(
 			'div',
 			{
-				className: className.join( ' ' )
+				className: className.join(' '),
 			},
-			wp.components.SandBox(
-				{
-					html: html,
-					title: block.name,
-					styles: [
+			wp.components.SandBox({
+				html,
+				title: block.name,
+				styles: [
 					'body{font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif; text-align:center;} form{margin: 0 auto;}',
-					],
-				}
-			)
+				],
+			})
 		);
 	}
 
 	// This is a Legacy Form.
 	// Use the block's PHP's render() function by calling the ServerSideRender component.
-	return wp.element.createElement(
-		wp.serverSideRender,
-		{
-			block: 'convertkit/' + block.name,
-			attributes: props.attributes,
+	return wp.element.createElement(wp.serverSideRender, {
+		block: 'convertkit/' + block.name,
+		attributes: props.attributes,
 
-			// This is only output in the Gutenberg editor, so must be slightly different from the inner class name used to
-			// apply styles with i.e. convertkit-block.name.
-			className: 'convertkit-ssr-' + block.name,
-		}
-	);
-
+		// This is only output in the Gutenberg editor, so must be slightly different from the inner class name used to
+		// apply styles with i.e. convertkit-block.name.
+		className: 'convertkit-ssr-' + block.name,
+	});
 }
+/* eslint-enable no-unused-vars */

--- a/resources/backend/js/gutenberg-block-formatters.js
+++ b/resources/backend/js/gutenberg-block-formatters.js
@@ -3,21 +3,23 @@
  *
  * @since   2.2.0
  *
- * @package ConvertKit
  * @author ConvertKit
+ */
+
+/**
+ * @typedef {import('@wordpress/element').WPElement} WPElement
  */
 
 // Register Gutenberg Block Toolbar formatters if the Gutenberg Editor is loaded on screen.
 // This prevents JS errors if this script is accidentally enqueued on a non-
 // Gutenberg editor screen, or the Classic Editor Plugin is active.
-if ( typeof wp !== 'undefined' &&
-	typeof wp.blockEditor !== 'undefined' ) {
-
+if (typeof wp !== 'undefined' && typeof wp.blockEditor !== 'undefined') {
 	// Register each ConvertKit formatter in Gutenberg.
-	for ( const formatter in convertkit_block_formatters ) {
-		convertKitGutenbergRegisterBlockFormatter( convertkit_block_formatters[ formatter ] );
+	for (const formatter in convertkit_block_formatters) {
+		convertKitGutenbergRegisterBlockFormatter(
+			convertkit_block_formatters[formatter]
+		);
 	}
-
 }
 
 /**
@@ -25,34 +27,21 @@ if ( typeof wp !== 'undefined' &&
  *
  * @since   2.2.0
  *
- * @param   object  formatter   Block formatter.
+ * @param {Object} formatter Block formatter.
  */
-function convertKitGutenbergRegisterBlockFormatter( formatter ) {
-
-	( function ( editor, richText, element, components ) {
-
+function convertKitGutenbergRegisterBlockFormatter(formatter) {
+	(function (editor, richText, element, components) {
 		// Define the Gutenberg/React components to use.
-		const {
-			Fragment,
-			useState,
-			createElement
-		} = element;
+		const { Fragment, useState, createElement } = element;
 		const {
 			registerFormatType,
 			toggleFormat,
 			applyFormat,
 			useAnchorRef,
-			useAnchor
+			useAnchor,
 		} = richText;
-		const {
-			BlockControls,
-			RichTextToolbarButton,
-		} = editor;
-		const {
-			Button,
-			Popover,
-			SelectControl
-		} = components;
+		const { RichTextToolbarButton } = editor;
+		const { Popover, SelectControl } = components;
 
 		/**
 		 * Returns the icon to display in the block toolbar for this formatter, depending
@@ -60,28 +49,24 @@ function convertKitGutenbergRegisterBlockFormatter( formatter ) {
 		 *
 		 * @since   2.2.0
 		 *
-		 * @return  element|string
+		 * @return  {WPElement|string} Either a WordPress element (RawHTML) or a dashicon string.
 		 */
 		const getIcon = function () {
-
 			// Return a fallback default icon if none is specified for this block formatter.
-			if ( typeof formatter.gutenberg_icon === 'undefined' ) {
+			if (typeof formatter.gutenberg_icon === 'undefined') {
 				return 'dashicons-tablet';
 			}
 
 			// Return HTML element if the icon is an SVG string.
-			if ( formatter.gutenberg_icon.search( 'svg' ) >= 0 ) {
-				return element.RawHTML(
-					{
-						children: formatter.gutenberg_icon
-					}
-				);
+			if (formatter.gutenberg_icon.search('svg') >= 0) {
+				return element.RawHTML({
+					children: formatter.gutenberg_icon,
+				});
 			}
 
 			// Just return the string, as it's a dashicon CSS class.
 			return formatter.gutenberg_icon;
-
-		}
+		};
 
 		/**
 		 * Returns an object of this formatter's attributes if this formatter
@@ -92,41 +77,42 @@ function convertKitGutenbergRegisterBlockFormatter( formatter ) {
 		 *
 		 * @since   2.2.0
 		 *
-		 * @param   object  activeFormats   All active formatters applied to the selected text.
-		 * @return  object
+		 * @param {Object} activeFormats All active formatters applied to the selected text.
+		 * @return {Object} Attributes.
 		 */
-		const getAttributes = function ( activeFormats ) {
-
+		const getAttributes = function (activeFormats) {
 			// Define the attribute object.
-			let attributes = {};
-			for ( let attribute in formatter.attributes ) {
-				attributes[ attribute ] = '';
+			const attributes = {};
+			for (const attribute in formatter.attributes) {
+				attributes[attribute] = '';
 			}
 
 			// Return if no active formats have been applied to the selected text.
-			if ( typeof activeFormats === 'undefined' ) {
+			if (typeof activeFormats === 'undefined') {
 				return attributes;
 			}
 
 			// Return if this formatter has not been used on the selected text.
-			const formats = activeFormats.filter( format => 'convertkit/' + formatter.name === format['type'] );
-			if ( formats.length === 0 ) {
+			const formats = activeFormats.filter(
+				(format) => 'convertkit/' + formatter.name === format.type
+			);
+			if (formats.length === 0) {
 				return attributes;
 			}
 
 			// This formatter has been applied to the selected text.
 			// Build the object of attributes and return.
-			for ( let attribute in formatter.attributes ) {
-				if ( typeof formats[0].unregisteredAttributes !== 'undefined' ) {
-					attributes[ attribute ] = formats[0].unregisteredAttributes[ attribute ];
-				} else if ( typeof formats[0].attributes !== 'undefined' ) {
-					attributes[ attribute ] = formats[0].attributes[ attribute ];
+			for (const attribute in formatter.attributes) {
+				if (typeof formats[0].unregisteredAttributes !== 'undefined') {
+					attributes[attribute] =
+						formats[0].unregisteredAttributes[attribute];
+				} else if (typeof formats[0].attributes !== 'undefined') {
+					attributes[attribute] = formats[0].attributes[attribute];
 				}
 			}
 
 			return attributes;
-
-		}
+		};
 
 		/**
 		 * Updates the block formatter's attributes when a field in the
@@ -134,50 +120,42 @@ function convertKitGutenbergRegisterBlockFormatter( formatter ) {
 		 *
 		 * @since   2.2.0
 		 *
-		 * @param   object  props         Block formatter properties.
-		 * @param   array   field         Field definition.
-		 * @param   string  newValue      New value
+		 * @param {Object} props    Block formatter properties.
+		 * @param {Object} field    Field definition.
+		 * @param {string} newValue New value.
 		 */
-		const setAttributes = function ( props, field, newValue ) {
-
+		const setAttributes = function (props, field, newValue) {
 			// Define properties and functions to use.
 			const { onChange, value } = props;
 
 			// If no value exists, remove the formatter.
-			if ( newValue === '' ) {
+			if (newValue === '') {
 				return onChange(
-					toggleFormat(
-						value,
-						{
-							type: 'convertkit/' + formatter.name
-						}
-					)
+					toggleFormat(value, {
+						type: 'convertkit/' + formatter.name,
+					})
 				);
 			}
 
 			// Build object of new attributes.
-			let attributes = {};
-			for ( let attribute in formatter.attributes ) {
+			const attributes = {};
+			for (const attribute in formatter.attributes) {
 				// If 'None' selected, blank the attribute's value.
-				if ( newValue === '' ) {
-					attributes[ attribute ] = '';
+				if (newValue === '') {
+					attributes[attribute] = '';
 				} else {
-					attributes[ attribute ] = field.data[ newValue ][ attribute ];
+					attributes[attribute] = field.data[newValue][attribute];
 				}
 			}
 
 			// Apply formatter with new attributes.
 			return onChange(
-				applyFormat(
-					value,
-					{
-						type: 'convertkit/' + formatter.name,
-						attributes: attributes
-					}
-				)
+				applyFormat(value, {
+					type: 'convertkit/' + formatter.name,
+					attributes,
+				})
 			);
-
-		}
+		};
 
 		/**
 		 * Return an array of field elements to display in the popover modal when
@@ -185,81 +163,68 @@ function convertKitGutenbergRegisterBlockFormatter( formatter ) {
 		 *
 		 * @since   2.2.0
 		 *
-		 * @param   object  props           Block formatter properties.
-		 * @param   object  setShowPopover  Function to toggle showing/hiding the popover.
-		 * @param   object  attributes      Field attributes.
-		 * @return  array                   Field elements
+		 * @param {Object}   props          Block formatter properties.
+		 * @param {Function} setShowPopover Function to toggle showing/hiding the popover.
+		 * @param {Object}   attributes     Field attributes.
+		 * @return  {Array}                   Field elements
 		 */
-		const getFields = function ( props, setShowPopover, attributes ) {
-
+		const getFields = function (props, setShowPopover, attributes) {
 			// Define array of field elements.
-			let elements = [];
+			const elements = [];
 
 			// Return if no fields exist.
-			if ( formatter.fields.length === 0 ) {
+			if (formatter.fields.length === 0) {
 				return elements;
 			}
 
 			// Iterate through the formatter's fields, adding a field element for each.
-			for ( let fieldName in formatter.fields ) {
-				const field = formatter.fields[ fieldName ];
+			for (const fieldName in formatter.fields) {
+				const field = formatter.fields[fieldName];
 
 				// Build options for <select> input.
-				let fieldOptions = [
+				const fieldOptions = [
 					{
 						label: '(None)',
-						value: ''
-				}
+						value: '',
+					},
 				];
-				for ( let fieldValue in field.values ) {
-					fieldOptions.push(
-						{
-							label: field.values[ fieldValue ],
-							value: fieldValue
-						}
-					);
+				for (const fieldValue in field.values) {
+					fieldOptions.push({
+						label: field.values[fieldValue],
+						value: fieldValue,
+					});
 				}
 
 				// Sort field's options alphabetically by label.
-				fieldOptions.sort(
-					function ( x, y ) {
-
-						let a = x.label.toUpperCase(),
-						b     = y.label.toUpperCase();
-						return a.localeCompare( b );
-
-					}
-				);
+				fieldOptions.sort(function (x, y) {
+					const a = x.label.toUpperCase(),
+						b = y.label.toUpperCase();
+					return a.localeCompare(b);
+				});
 
 				// Add field to array.
 				elements.push(
-					createElement(
-						SelectControl,
-						{
-							key:        'convertkit_' + formatter.name + '_' + fieldName,
-							id:         'convertkit-' + formatter.name + '-' + fieldName,
-							label:      field.label,
-							value:      attributes[ fieldName ],
-							help:       field.description,
-							options:    fieldOptions,
-							onChange:   function ( newValue ) {
+					createElement(SelectControl, {
+						key: 'convertkit_' + formatter.name + '_' + fieldName,
+						id: 'convertkit-' + formatter.name + '-' + fieldName,
+						label: field.label,
+						value: attributes[fieldName],
+						help: field.description,
+						options: fieldOptions,
+						onChange(newValue) {
+							// Hide popover.
+							setShowPopover(false);
 
-								// Hide popover.
-								setShowPopover( false );
-
-								// Update and apply attributes to the selected text.
-								setAttributes( props, field, newValue );
-
-							}
-						}
-					)
+							// Update and apply attributes to the selected text.
+							setAttributes(props, field, newValue);
+						},
+					})
 				);
 			}
 
 			// Return elements.
 			return elements;
-
-		}
+		};
 
 		/**
 		 * Display modal when the formatter's button is clicked, and save
@@ -267,92 +232,95 @@ function convertKitGutenbergRegisterBlockFormatter( formatter ) {
 		 *
 		 * @since   2.2.0
 		 *
-		 * @param   object  props   Block formatter properties.
-		 * @return  object          Block formatter button and modal elements
+		 * @param {Object} props Block formatter properties.
+		 * @return  {Object}          Block formatter button and modal elements
 		 */
-		const editFormatType = function ( props ) {
-
+		const EditFormatType = function (props) {
 			// Get props.
 			const { contentRef, isActive, value } = props;
-			const { activeFormats }               = value;
+			const { activeFormats } = value;
 			let anchorRef;
 
 			// Get anchor reference to the text.
-			if ( typeof useAnchor === 'undefined' ) {
+			if (typeof useAnchor === 'undefined') {
 				// Use WordPress 6.0 and lower useAnchorRef(), as useAnchor() isn't available.
-				anchorRef = useAnchorRef( { ref: contentRef, value } );
+				anchorRef = useAnchorRef({ ref: contentRef, value }); // eslint-disable-line react-hooks/rules-of-hooks
 			} else {
 				// Use WordPress 6.1+ useAnchor(), as useAnchorRef() is deprecated in 6.2+.
-				anchorRef = useAnchor( { editableContentElement: contentRef.current, value } );
+				// eslint-disable-next-line react-hooks/rules-of-hooks
+				anchorRef = useAnchor({
+					editableContentElement: contentRef.current,
+					value,
+				});
 			}
 
 			// State to show popover.
-			const [ showPopover, setShowPopover ] = useState( false );
+			const [showPopover, setShowPopover] = useState(false);
 
 			// Get attributes.
-			let attributes = getAttributes( activeFormats );
+			const attributes = getAttributes(activeFormats);
 
 			// Define fields to display in the popover modal.
-			let popoverModalElements = getFields( props, setShowPopover, attributes );
-
-			// Return block toolbar button and its modal.
-			return (
-				createElement(
-					Fragment,
-					{
-						key:  'convertkit_' + formatter.name + '_rich_text_toolbar_fragment'
-					},
-					// Register the button in the rich text toolbar.
-					createElement(
-						RichTextToolbarButton,
-						{
-							key:      'convertkit_' + formatter.name + '_rich_text_toolbar_button',
-							icon:     getIcon( formatter ),
-							title:    formatter.title,
-							isActive: isActive,
-							onClick:  function () {
-								setShowPopover( true );
-							}
-						},
-					),
-					// Popover which displays fields when the button is active.
-					showPopover && ( createElement(
-						Popover,
-						{
-							key:        'convertkit_' + formatter.name + '_popover',
-							className:  'convertkit-popover',
-							anchor:     anchorRef,
-							onClose:    function () {
-								setShowPopover( false );
-							}
-						},
-						popoverModalElements
-					) )
-				)
+			const popoverModalElements = getFields(
+				props,
+				setShowPopover,
+				attributes
 			);
 
-		}
+			// Return block toolbar button and its modal.
+			return createElement(
+				Fragment,
+				{
+					key:
+						'convertkit_' +
+						formatter.name +
+						'_rich_text_toolbar_fragment',
+				},
+				// Register the button in the rich text toolbar.
+				createElement(RichTextToolbarButton, {
+					key:
+						'convertkit_' +
+						formatter.name +
+						'_rich_text_toolbar_button',
+					icon: getIcon(formatter),
+					title: formatter.title,
+					isActive,
+					onClick() {
+						setShowPopover(true);
+					},
+				}),
+				// Popover which displays fields when the button is active.
+				showPopover &&
+					createElement(
+						Popover,
+						{
+							key: 'convertkit_' + formatter.name + '_popover',
+							className: 'convertkit-popover',
+							anchor: anchorRef,
+							onClose() {
+								setShowPopover(false);
+							},
+						},
+						popoverModalElements
+					)
+			);
+		};
 
 		// Register Format Type.
-		registerFormatType(
-			'convertkit/' + formatter.name,
-			{
-				title:      formatter.title,
+		registerFormatType('convertkit/' + formatter.name, {
+			title: formatter.title,
 
-				// The tagName and className combination allow Gutenberg to uniquely identify
-				// whether this formatter has been used on the selected text.
-				tagName:    formatter.tag,
-				className:  'convertkit-' + formatter.name,
-				attributes: formatter.attributes,
-				edit:       editFormatType,
-			}
-		);
-
-	} (
+			// The tagName and className combination allow Gutenberg to uniquely identify
+			// whether this formatter has been used on the selected text.
+			tagName: formatter.tag,
+			className: 'convertkit-' + formatter.name,
+			attributes: formatter.attributes,
+			edit: EditFormatType,
+		});
+	})(
 		window.wp.blockEditor,
 		window.wp.richText,
 		window.wp.element,
 		window.wp.components
-	) );
-
+	);
 }

--- a/resources/backend/js/gutenberg-block-formatters.js
+++ b/resources/backend/js/gutenberg-block-formatters.js
@@ -3,23 +3,21 @@
  *
  * @since   2.2.0
  *
+ * @package ConvertKit
  * @author ConvertKit
- */
-
-/**
- * @typedef {import('@wordpress/element').WPElement} WPElement
  */
 
 // Register Gutenberg Block Toolbar formatters if the Gutenberg Editor is loaded on screen.
 // This prevents JS errors if this script is accidentally enqueued on a non-
 // Gutenberg editor screen, or the Classic Editor Plugin is active.
-if (typeof wp !== 'undefined' && typeof wp.blockEditor !== 'undefined') {
+if ( typeof wp !== 'undefined' &&
+	typeof wp.blockEditor !== 'undefined' ) {
+
 	// Register each ConvertKit formatter in Gutenberg.
-	for (const formatter in convertkit_block_formatters) {
-		convertKitGutenbergRegisterBlockFormatter(
-			convertkit_block_formatters[formatter]
-		);
+	for ( const formatter in convertkit_block_formatters ) {
+		convertKitGutenbergRegisterBlockFormatter( convertkit_block_formatters[ formatter ] );
 	}
+
 }
 
 /**
@@ -27,21 +25,34 @@ if (typeof wp !== 'undefined' && typeof wp.blockEditor !== 'undefined') {
  *
  * @since   2.2.0
  *
- * @param {Object} formatter Block formatter.
+ * @param   object  formatter   Block formatter.
  */
-function convertKitGutenbergRegisterBlockFormatter(formatter) {
-	(function (editor, richText, element, components) {
+function convertKitGutenbergRegisterBlockFormatter( formatter ) {
+
+	( function ( editor, richText, element, components ) {
+
 		// Define the Gutenberg/React components to use.
-		const { Fragment, useState, createElement } = element;
+		const {
+			Fragment,
+			useState,
+			createElement
+		} = element;
 		const {
 			registerFormatType,
 			toggleFormat,
 			applyFormat,
 			useAnchorRef,
-			useAnchor,
+			useAnchor
 		} = richText;
-		const { RichTextToolbarButton } = editor;
-		const { Popover, SelectControl } = components;
+		const {
+			BlockControls,
+			RichTextToolbarButton,
+		} = editor;
+		const {
+			Button,
+			Popover,
+			SelectControl
+		} = components;
 
 		/**
 		 * Returns the icon to display in the block toolbar for this formatter, depending
@@ -49,24 +60,28 @@ function convertKitGutenbergRegisterBlockFormatter(formatter) {
 		 *
 		 * @since   2.2.0
 		 *
-		 * @return  {WPElement|string} Either a WordPress element (RawHTML) or a dashicon string.
+		 * @return  element|string
 		 */
 		const getIcon = function () {
+
 			// Return a fallback default icon if none is specified for this block formatter.
-			if (typeof formatter.gutenberg_icon === 'undefined') {
+			if ( typeof formatter.gutenberg_icon === 'undefined' ) {
 				return 'dashicons-tablet';
 			}
 
 			// Return HTML element if the icon is an SVG string.
-			if (formatter.gutenberg_icon.search('svg') >= 0) {
-				return element.RawHTML({
-					children: formatter.gutenberg_icon,
-				});
+			if ( formatter.gutenberg_icon.search( 'svg' ) >= 0 ) {
+				return element.RawHTML(
+					{
+						children: formatter.gutenberg_icon
+					}
+				);
 			}
 
 			// Just return the string, as it's a dashicon CSS class.
 			return formatter.gutenberg_icon;
-		};
+
+		}
 
 		/**
 		 * Returns an object of this formatter's attributes if this formatter
@@ -77,42 +92,41 @@ function convertKitGutenbergRegisterBlockFormatter(formatter) {
 		 *
 		 * @since   2.2.0
 		 *
-		 * @param {Object} activeFormats All active formatters applied to the selected text.
-		 * @return {Object} Attributes.
+		 * @param   object  activeFormats   All active formatters applied to the selected text.
+		 * @return  object
 		 */
-		const getAttributes = function (activeFormats) {
+		const getAttributes = function ( activeFormats ) {
+
 			// Define the attribute object.
-			const attributes = {};
-			for (const attribute in formatter.attributes) {
-				attributes[attribute] = '';
+			let attributes = {};
+			for ( let attribute in formatter.attributes ) {
+				attributes[ attribute ] = '';
 			}
 
 			// Return if no active formats have been applied to the selected text.
-			if (typeof activeFormats === 'undefined') {
+			if ( typeof activeFormats === 'undefined' ) {
 				return attributes;
 			}
 
 			// Return if this formatter has not been used on the selected text.
-			const formats = activeFormats.filter(
-				(format) => 'convertkit/' + formatter.name === format.type
-			);
-			if (formats.length === 0) {
+			const formats = activeFormats.filter( format => 'convertkit/' + formatter.name === format['type'] );
+			if ( formats.length === 0 ) {
 				return attributes;
 			}
 
 			// This formatter has been applied to the selected text.
 			// Build the object of attributes and return.
-			for (const attribute in formatter.attributes) {
-				if (typeof formats[0].unregisteredAttributes !== 'undefined') {
-					attributes[attribute] =
-						formats[0].unregisteredAttributes[attribute];
-				} else if (typeof formats[0].attributes !== 'undefined') {
-					attributes[attribute] = formats[0].attributes[attribute];
+			for ( let attribute in formatter.attributes ) {
+				if ( typeof formats[0].unregisteredAttributes !== 'undefined' ) {
+					attributes[ attribute ] = formats[0].unregisteredAttributes[ attribute ];
+				} else if ( typeof formats[0].attributes !== 'undefined' ) {
+					attributes[ attribute ] = formats[0].attributes[ attribute ];
 				}
 			}
 
 			return attributes;
-		};
+
+		}
 
 		/**
 		 * Updates the block formatter's attributes when a field in the
@@ -120,42 +134,50 @@ function convertKitGutenbergRegisterBlockFormatter(formatter) {
 		 *
 		 * @since   2.2.0
 		 *
-		 * @param {Object} props    Block formatter properties.
-		 * @param {Object} field    Field definition.
-		 * @param {string} newValue New value.
+		 * @param   object  props         Block formatter properties.
+		 * @param   array   field         Field definition.
+		 * @param   string  newValue      New value
 		 */
-		const setAttributes = function (props, field, newValue) {
+		const setAttributes = function ( props, field, newValue ) {
+
 			// Define properties and functions to use.
 			const { onChange, value } = props;
 
 			// If no value exists, remove the formatter.
-			if (newValue === '') {
+			if ( newValue === '' ) {
 				return onChange(
-					toggleFormat(value, {
-						type: 'convertkit/' + formatter.name,
-					})
+					toggleFormat(
+						value,
+						{
+							type: 'convertkit/' + formatter.name
+						}
+					)
 				);
 			}
 
 			// Build object of new attributes.
-			const attributes = {};
-			for (const attribute in formatter.attributes) {
+			let attributes = {};
+			for ( let attribute in formatter.attributes ) {
 				// If 'None' selected, blank the attribute's value.
-				if (newValue === '') {
-					attributes[attribute] = '';
+				if ( newValue === '' ) {
+					attributes[ attribute ] = '';
 				} else {
-					attributes[attribute] = field.data[newValue][attribute];
+					attributes[ attribute ] = field.data[ newValue ][ attribute ];
 				}
 			}
 
 			// Apply formatter with new attributes.
 			return onChange(
-				applyFormat(value, {
-					type: 'convertkit/' + formatter.name,
-					attributes,
-				})
+				applyFormat(
+					value,
+					{
+						type: 'convertkit/' + formatter.name,
+						attributes: attributes
+					}
+				)
 			);
-		};
+
+		}
 
 		/**
 		 * Return an array of field elements to display in the popover modal when
@@ -163,68 +185,81 @@ function convertKitGutenbergRegisterBlockFormatter(formatter) {
 		 *
 		 * @since   2.2.0
 		 *
-		 * @param {Object}   props          Block formatter properties.
-		 * @param {Function} setShowPopover Function to toggle showing/hiding the popover.
-		 * @param {Object}   attributes     Field attributes.
-		 * @return  {Array}                   Field elements
+		 * @param   object  props           Block formatter properties.
+		 * @param   object  setShowPopover  Function to toggle showing/hiding the popover.
+		 * @param   object  attributes      Field attributes.
+		 * @return  array                   Field elements
 		 */
-		const getFields = function (props, setShowPopover, attributes) {
+		const getFields = function ( props, setShowPopover, attributes ) {
+
 			// Define array of field elements.
-			const elements = [];
+			let elements = [];
 
 			// Return if no fields exist.
-			if (formatter.fields.length === 0) {
+			if ( formatter.fields.length === 0 ) {
 				return elements;
 			}
 
 			// Iterate through the formatter's fields, adding a field element for each.
-			for (const fieldName in formatter.fields) {
-				const field = formatter.fields[fieldName];
+			for ( let fieldName in formatter.fields ) {
+				const field = formatter.fields[ fieldName ];
 
 				// Build options for <select> input.
-				const fieldOptions = [
+				let fieldOptions = [
 					{
 						label: '(None)',
-						value: '',
-					},
+						value: ''
+				}
 				];
-				for (const fieldValue in field.values) {
-					fieldOptions.push({
-						label: field.values[fieldValue],
-						value: fieldValue,
-					});
+				for ( let fieldValue in field.values ) {
+					fieldOptions.push(
+						{
+							label: field.values[ fieldValue ],
+							value: fieldValue
+						}
+					);
 				}
 
 				// Sort field's options alphabetically by label.
-				fieldOptions.sort(function (x, y) {
-					const a = x.label.toUpperCase(),
-						b = y.label.toUpperCase();
-					return a.localeCompare(b);
-				});
+				fieldOptions.sort(
+					function ( x, y ) {
+
+						let a = x.label.toUpperCase(),
+						b     = y.label.toUpperCase();
+						return a.localeCompare( b );
+
+					}
+				);
 
 				// Add field to array.
 				elements.push(
-					createElement(SelectControl, {
-						key: 'convertkit_' + formatter.name + '_' + fieldName,
-						id: 'convertkit-' + formatter.name + '-' + fieldName,
-						label: field.label,
-						value: attributes[fieldName],
-						help: field.description,
-						options: fieldOptions,
-						onChange(newValue) {
-							// Hide popover.
-							setShowPopover(false);
+					createElement(
+						SelectControl,
+						{
+							key:        'convertkit_' + formatter.name + '_' + fieldName,
+							id:         'convertkit-' + formatter.name + '-' + fieldName,
+							label:      field.label,
+							value:      attributes[ fieldName ],
+							help:       field.description,
+							options:    fieldOptions,
+							onChange:   function ( newValue ) {
 
-							// Update and apply attributes to the selected text.
-							setAttributes(props, field, newValue);
-						},
-					})
+								// Hide popover.
+								setShowPopover( false );
+
+								// Update and apply attributes to the selected text.
+								setAttributes( props, field, newValue );
+
+							}
+						}
+					)
 				);
 			}
 
 			// Return elements.
 			return elements;
-		};
+
+		}
 
 		/**
 		 * Display modal when the formatter's button is clicked, and save
@@ -232,95 +267,92 @@ function convertKitGutenbergRegisterBlockFormatter(formatter) {
 		 *
 		 * @since   2.2.0
 		 *
-		 * @param {Object} props Block formatter properties.
-		 * @return  {Object}          Block formatter button and modal elements
+		 * @param   object  props   Block formatter properties.
+		 * @return  object          Block formatter button and modal elements
 		 */
-		const EditFormatType = function (props) {
+		const editFormatType = function ( props ) {
+
 			// Get props.
 			const { contentRef, isActive, value } = props;
-			const { activeFormats } = value;
+			const { activeFormats }               = value;
 			let anchorRef;
 
 			// Get anchor reference to the text.
-			if (typeof useAnchor === 'undefined') {
+			if ( typeof useAnchor === 'undefined' ) {
 				// Use WordPress 6.0 and lower useAnchorRef(), as useAnchor() isn't available.
-				anchorRef = useAnchorRef({ ref: contentRef, value }); // eslint-disable-line react-hooks/rules-of-hooks
+				anchorRef = useAnchorRef( { ref: contentRef, value } );
 			} else {
 				// Use WordPress 6.1+ useAnchor(), as useAnchorRef() is deprecated in 6.2+.
-				// eslint-disable-next-line react-hooks/rules-of-hooks
-				anchorRef = useAnchor({
-					editableContentElement: contentRef.current,
-					value,
-				});
+				anchorRef = useAnchor( { editableContentElement: contentRef.current, value } );
 			}
 
 			// State to show popover.
-			const [showPopover, setShowPopover] = useState(false);
+			const [ showPopover, setShowPopover ] = useState( false );
 
 			// Get attributes.
-			const attributes = getAttributes(activeFormats);
+			let attributes = getAttributes( activeFormats );
 
 			// Define fields to display in the popover modal.
-			const popoverModalElements = getFields(
-				props,
-				setShowPopover,
-				attributes
-			);
+			let popoverModalElements = getFields( props, setShowPopover, attributes );
 
 			// Return block toolbar button and its modal.
-			return createElement(
-				Fragment,
-				{
-					key:
-						'convertkit_' +
-						formatter.name +
-						'_rich_text_toolbar_fragment',
-				},
-				// Register the button in the rich text toolbar.
-				createElement(RichTextToolbarButton, {
-					key:
-						'convertkit_' +
-						formatter.name +
-						'_rich_text_toolbar_button',
-					icon: getIcon(formatter),
-					title: formatter.title,
-					isActive,
-					onClick() {
-						setShowPopover(true);
+			return (
+				createElement(
+					Fragment,
+					{
+						key:  'convertkit_' + formatter.name + '_rich_text_toolbar_fragment'
 					},
-				}),
-				// Popover which displays fields when the button is active.
-				showPopover &&
+					// Register the button in the rich text toolbar.
 					createElement(
+						RichTextToolbarButton,
+						{
+							key:      'convertkit_' + formatter.name + '_rich_text_toolbar_button',
+							icon:     getIcon( formatter ),
+							title:    formatter.title,
+							isActive: isActive,
+							onClick:  function () {
+								setShowPopover( true );
+							}
+						},
+					),
+					// Popover which displays fields when the button is active.
+					showPopover && ( createElement(
 						Popover,
 						{
-							key: 'convertkit_' + formatter.name + '_popover',
-							className: 'convertkit-popover',
-							anchor: anchorRef,
-							onClose() {
-								setShowPopover(false);
-							},
+							key:        'convertkit_' + formatter.name + '_popover',
+							className:  'convertkit-popover',
+							anchor:     anchorRef,
+							onClose:    function () {
+								setShowPopover( false );
+							}
 						},
 						popoverModalElements
-					)
+					) )
+				)
 			);
-		};
+
+		}
 
 		// Register Format Type.
-		registerFormatType('convertkit/' + formatter.name, {
-			title: formatter.title,
+		registerFormatType(
+			'convertkit/' + formatter.name,
+			{
+				title:      formatter.title,
 
-			// The tagName and className combination allow Gutenberg to uniquely identify
-			// whether this formatter has been used on the selected text.
-			tagName: formatter.tag,
-			className: 'convertkit-' + formatter.name,
-			attributes: formatter.attributes,
-			edit: EditFormatType,
-		});
-	})(
+				// The tagName and className combination allow Gutenberg to uniquely identify
+				// whether this formatter has been used on the selected text.
+				tagName:    formatter.tag,
+				className:  'convertkit-' + formatter.name,
+				attributes: formatter.attributes,
+				edit:       editFormatType,
+			}
+		);
+
+	} (
 		window.wp.blockEditor,
 		window.wp.richText,
 		window.wp.element,
 		window.wp.components
-	);
+	) );
+
 }

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -3,28 +3,26 @@
  *
  * @since   1.9.6.5
  *
+ * @package ConvertKit
  * @author ConvertKit
- */
-
-/**
- * @typedef {import('@wordpress/element').WPElement} WPElement
  */
 
 // Register Gutenberg Blocks if the Gutenberg Editor is loaded on screen.
 // This prevents JS errors if this script is accidentally enqueued on a non-
 // Gutenberg editor screen, or the Classic Editor Plugin is active.
-if (typeof wp !== 'undefined' && typeof wp.blockEditor !== 'undefined') {
+if ( typeof wp !== 'undefined' &&
+	typeof wp.blockEditor !== 'undefined' ) {
+
 	// Register each ConvertKit Block in Gutenberg.
-	for (const block in convertkit_blocks) {
-		convertKitGutenbergRegisterBlock(convertkit_blocks[block]);
+	for ( const block in convertkit_blocks ) {
+		convertKitGutenbergRegisterBlock( convertkit_blocks[ block ] );
 	}
 
 	// Register ConvertKit Pre-publish actions in Gutenberg.
-	if (typeof convertkit_pre_publish_actions !== 'undefined') {
-		convertKitGutenbergRegisterPrePublishActions(
-			convertkit_pre_publish_actions
-		);
+	if ( typeof convertkit_pre_publish_actions !== 'undefined' ) {
+		convertKitGutenbergRegisterPrePublishActions( convertkit_pre_publish_actions );
 	}
+
 }
 
 /**
@@ -32,15 +30,23 @@ if (typeof wp !== 'undefined' && typeof wp.blockEditor !== 'undefined') {
  *
  * @since 	1.9.6.5
  *
- * @param {Object} block Block.
+ * @param 	object 	block 	Block
  */
-function convertKitGutenbergRegisterBlock(block) {
-	(function (blocks, editor, element, components) {
+function convertKitGutenbergRegisterBlock( block ) {
+
+	( function ( blocks, editor, element, components ) {
+
 		// Define some constants for the various items we'll use.
-		const el = element.createElement;
+		const el                    = element.createElement;
 		const { registerBlockType } = blocks;
-		const { InspectorControls, InnerBlocks } = editor;
-		const { Fragment, useState } = element;
+		const {
+			InspectorControls,
+			InnerBlocks
+		}                           = editor;
+		const {
+			Fragment,
+			useState
+		}                           = element;
 		const {
 			Button,
 			Icon,
@@ -49,10 +55,11 @@ function convertKitGutenbergRegisterBlock(block) {
 			ToggleControl,
 			Flex,
 			FlexItem,
+			Panel,
 			PanelBody,
 			PanelRow,
-			ProgressBar,
-		} = components;
+			ProgressBar
+		}                           = components;
 
 		/**
 		 * Returns the icon to display for this block, depending
@@ -60,24 +67,28 @@ function convertKitGutenbergRegisterBlock(block) {
 		 *
 		 * @since   2.2.0
 		 *
-		 * @return  {WPElement|string} Either a WordPress element (RawHTML) or a dashicon string.
+		 * @return  element|string
 		 */
 		const getIcon = function () {
+
 			// Return a fallback default icon if none is specified for this block.
-			if (typeof block.gutenberg_icon === 'undefined') {
+			if ( typeof block.gutenberg_icon === 'undefined' ) {
 				return 'dashicons-tablet';
 			}
 
 			// Return HTML element if the icon is an SVG string.
-			if (block.gutenberg_icon.search('svg') >= 0) {
-				return element.RawHTML({
-					children: block.gutenberg_icon,
-				});
+			if ( block.gutenberg_icon.search( 'svg' ) >= 0 ) {
+				return element.RawHTML(
+					{
+						children: block.gutenberg_icon
+					}
+				);
 			}
 
 			// Just return the string, as it's a dashicon CSS class.
 			return block.gutenberg_icon;
-		};
+
+		}
 
 		/**
 		 * Return a field element for the block sidebar, which is displayed in a panel's row
@@ -85,95 +96,113 @@ function convertKitGutenbergRegisterBlock(block) {
 		 *
 		 * @since   2.2.0
 		 *
-		 * @param {Object} props     Block properties.
-		 * @param {Object} field     Field attributes.
-		 * @param {string} attribute Attribute name to store the field's data in.
-		 * @return {Object}            Field element.
+		 * @param   object  props           Block properties.
+		 * @param   object  field      		Field attributes.
+		 * @param 	string 	attribute 		Attribute name to store the field's data in.
+		 * @return  array                   Field element
 		 */
-		const getField = function (props, field, attribute) {
+		const getField = function ( props, field, attribute ) {
+
 			// Define some field properties shared across all field types.
-			const fieldProperties = {
-				id:
-					'convertkit_' +
-					block.name.replace(/-/g, '_') +
-					'_' +
-					attribute,
-				label: field.label,
-				help: field.description,
-				value: props.attributes[attribute],
-				onChange(value) {
-					if (field.type === 'number') {
+			let fieldProperties = {
+				id:  		'convertkit_' + block.name.replace( /-/g, '_' ) + '_' + attribute,
+				label: 		field.label,
+				help: 		field.description,
+				value: 		props.attributes[ attribute ],
+				onChange: 	function ( value ) {
+					if ( field.type === 'number' ) {
 						// If value is a blank string i.e. no attribute value was provided,
 						// cast it to the field's minimum number setting.
 						// This prevents WordPress' block renderer API returning a 400 error
 						// because a blank value will be passed as a string, when WordPress
 						// expects it to be a numerical value.
-						if (value === '') {
+						if ( value === '' ) {
 							value = field.min;
 						}
 
 						// Cast value to integer if a value exists.
-						if (value.length > 0) {
-							value = Number(value);
+						if ( value.length > 0 ) {
+							value = Number( value );
 						}
 					}
 
-					const newValue = {};
-					newValue[attribute] = value;
-					props.setAttributes(newValue);
-				},
+					let newValue          = {};
+					newValue[ attribute ] = value;
+					props.setAttributes( newValue );
+				}
 			};
 
-			const fieldOptions = [];
+			let fieldOptions = [];
 
 			// Define additional Field Properties and the Field Element,
 			// depending on the Field Type (select, textarea, text etc).
-			switch (field.type) {
+			switch ( field.type ) {
+
 				case 'select':
 					// Build options for <select> input.
-					fieldOptions.push({
-						label: '(None)',
-						value: '',
-					});
-					for (const value of Object.keys(field.values)) {
-						fieldOptions.push({
-							label: field.values[value],
-							value,
-						});
+					fieldOptions.push(
+						{
+							label: '(None)',
+							value: '',
+						}
+					);
+					for ( const value of Object.keys( field.values ) ) {
+						fieldOptions.push(
+							{
+								label: field.values[ value ],
+								value: value
+							}
+						);
 					}
 
 					// Sort field's options alphabetically by label.
-					fieldOptions.sort(function (x, y) {
-						const a = x.label.toUpperCase(),
-							b = y.label.toUpperCase();
-						return a.localeCompare(b);
-					});
+					fieldOptions.sort(
+						function ( x, y ) {
+
+							let a = x.label.toUpperCase(),
+							b     = y.label.toUpperCase();
+							return a.localeCompare( b );
+
+						}
+					);
 
 					// Assign options to field.
 					fieldProperties.options = fieldOptions;
 
 					// Return field element.
-					return el(SelectControl, fieldProperties);
+					return el(
+						SelectControl,
+						fieldProperties
+					);
+					break;
 
 				case 'resource':
 					// Build options for <select> input.
-					fieldOptions.push({
-						label: '(None)',
-						value: '',
-					});
-					for (const value of Object.keys(field.values)) {
-						fieldOptions.push({
-							label: field.values[value],
-							value,
-						});
+					fieldOptions.push(
+						{
+							label: '(None)',
+							value: '',
+						}
+					);
+					for ( const value of Object.keys( field.values ) ) {
+						fieldOptions.push(
+							{
+								label: field.values[ value ],
+								value: value
+							}
+						);
 					}
 
 					// Sort field's options alphabetically by label.
-					fieldOptions.sort(function (x, y) {
-						const a = x.label.toUpperCase(),
-							b = y.label.toUpperCase();
-						return a.localeCompare(b);
-					});
+					fieldOptions.sort(
+						function ( x, y ) {
+
+							let a = x.label.toUpperCase(),
+							b     = y.label.toUpperCase();
+							return a.localeCompare( b );
+
+						}
+					);
 
 					// Assign options to field.
 					fieldProperties.options = fieldOptions;
@@ -187,34 +216,55 @@ function convertKitGutenbergRegisterBlock(block) {
 							el(
 								FlexItem,
 								{},
-								el(SelectControl, fieldProperties)
+								el(
+									SelectControl,
+									fieldProperties
+								)
 							),
-							el(FlexItem, {}, inlineRefreshButton(props)),
+							el(
+								FlexItem,
+								{},
+								inlineRefreshButton( props )
+							)
 						]
 					);
+					break;
 
 				case 'toggle':
 					// Define field properties.
-					fieldProperties.checked = props.attributes[attribute];
+					fieldProperties.checked = props.attributes[ attribute ];
 
 					// Return field element.
-					return el(ToggleControl, fieldProperties);
+					return el(
+						ToggleControl,
+						fieldProperties
+					);
+					break;
 
 				case 'number':
 					// Define field properties.
 					fieldProperties.type = field.type;
-					fieldProperties.min = field.min;
-					fieldProperties.max = field.max;
+					fieldProperties.min  = field.min;
+					fieldProperties.max  = field.max;
 					fieldProperties.step = field.step;
 
 					// Return field element.
-					return el(TextControl, fieldProperties);
+					return el(
+						TextControl,
+						fieldProperties
+					);
+					break;
 
 				default:
 					// Return field element.
-					return el(TextControl, fieldProperties);
+					return el(
+						TextControl,
+						fieldProperties
+					);
+					break;
 			}
-		};
+
+		}
 
 		/**
 		 * Return an array of rows to display in the given block sidebar's panel when
@@ -222,21 +272,22 @@ function convertKitGutenbergRegisterBlock(block) {
 		 *
 		 * @since   2.2.0
 		 *
-		 * @param {Object} props Block properties.
-		 * @param {string} panel Panel name.
-		 * @return {Array}        Panel rows.
+		 * @param   object  props   Block properties.
+		 * @param   string  panel 	Panel name.
+		 * @return  array           Panel rows
 		 */
-		const getPanelRows = function (props, panel) {
+		const getPanelRows = function ( props, panel ) {
+
 			// Build Inspector Control Panel Rows, one for each Field.
-			const rows = [];
-			for (const i in block.panels[panel].fields) {
-				const attribute = block.panels[panel].fields[i], // e.g. 'term'.
-					field = block.fields[attribute]; // field array.
+			let rows = [];
+			for ( let i in block.panels[ panel ].fields ) {
+				const attribute = block.panels[ panel ].fields[ i ], // e.g. 'term'.
+					field       = block.fields[ attribute ]; // field array.
 
 				// If this field doesn't exist as an attribute in the block's get_attributes(),
 				// this is a non-Gutenberg field (such as a color picker for shortcodes),
 				// which should be ignored.
-				if (typeof block.attributes[attribute] === 'undefined') {
+				if ( typeof block.attributes[ attribute ] === 'undefined' ) {
 					continue;
 				}
 
@@ -244,15 +295,16 @@ function convertKitGutenbergRegisterBlock(block) {
 					el(
 						PanelRow,
 						{
-							key: attribute,
+							key: attribute
 						},
-						getField(props, field, attribute)
+						getField( props, field, attribute )
 					)
 				);
 			}
 
 			return rows;
-		};
+
+		}
 
 		/**
 		 * Return an array of panels to display in the block's sidebar when the block
@@ -260,21 +312,22 @@ function convertKitGutenbergRegisterBlock(block) {
 		 *
 		 * @since   2.2.0
 		 *
-		 * @param {Object} props Block formatter properties.
-		 * @return {Array} 	      Block sidebar panels.
+		 * @param   object  props 	Block formatter properties.
+		 * @return 	array 			Block sidebar panels.
 		 */
-		const getPanels = function (props) {
-			const panels = [];
-			let initialOpen = true;
+		const getPanels = function ( props ) {
+
+			let panels      = [],
+				initialOpen = true;
 
 			// Build Inspector Control Panels.
-			for (const panel in block.panels) {
-				const panelRows = getPanelRows(props, panel);
+			for ( const panel in block.panels ) {
+				let panelRows = getPanelRows( props, panel );
 
 				// If no panel rows exist (e.g. this is a shortcode only panel,
 				// for styles, which Gutenberg registers in its own styles tab),
 				// don't add this panel.
-				if (!panelRows.length) {
+				if ( ! panelRows.length ) {
 					continue;
 				}
 
@@ -282,9 +335,9 @@ function convertKitGutenbergRegisterBlock(block) {
 					el(
 						PanelBody,
 						{
-							title: block.panels[panel].label,
+							title: block.panels[ panel ].label,
 							key: panel,
-							initialOpen,
+							initialOpen: initialOpen
 						},
 						panelRows
 					)
@@ -295,7 +348,8 @@ function convertKitGutenbergRegisterBlock(block) {
 			}
 
 			return panels;
-		};
+
+		}
 
 		/**
 		 * Display settings sidebar when the block is being edited, and save
@@ -303,102 +357,93 @@ function convertKitGutenbergRegisterBlock(block) {
 		 *
 		 * @since   2.2.0
 		 *
-		 * @param {Object} props Block properties.
-		 * @return {Object}       Block settings sidebar elements.
+		 * @param   object  props   Block properties.
+		 * @return  object          Block settings sidebar elements
 		 */
-		const editBlock = function (props) {
+		const editBlock = function ( props ) {
+
 			// If requesting an example of how this block looks (which is requested
 			// when the user adds a new block and hovers over this block's icon),
 			// show the preview image.
-			if (props.attributes.is_gutenberg_example === true) {
+			if ( props.attributes.is_gutenberg_example === true ) {
 				return (
 					Fragment,
 					{},
-					el('img', {
-						src: block.gutenberg_example_image,
-					})
+					el(
+						'img',
+						{
+							src: block.gutenberg_example_image,
+						}
+					)
 				);
 			}
 
-			// If no access token has been defined in the Plugin, or no resources exist in Kit
-			// for this block, show a message in the block to tell the user what to do.
-			if (!block.has_access_token || !block.has_resources) {
-				return DisplayNoticeWithLink(props);
-			}
-
 			// Build Inspector Control Panels, which will appear in the Sidebar when editing the Block.
-			const panels = getPanels(props);
+			let panels = getPanels( props );
 
 			// Generate Block Preview.
 			let preview = '';
+
+			// If no access token has been defined in the Plugin, or no resources exist in Kit
+			// for this block, show a message in the block to tell the user what to do.
+			if ( ! block.has_access_token || ! block.has_resources ) {
+				return displayNoticeWithLink( props );
+			}
 
 			// If a custom callback function to render this block's preview in the Gutenberg Editor
 			// has been defined, use it.
 			// This doesn't affect the output for this block on the frontend site, which will always
 			// use the block's PHP's render() function.
-			if (
-				typeof block.gutenberg_preview_render_callback !== 'undefined'
-			) {
-				preview = window[block.gutenberg_preview_render_callback](
-					block,
-					props
-				);
-				return editBlockWithPanelsAndPreview(panels, preview);
+			if ( typeof block.gutenberg_preview_render_callback !== 'undefined' ) {
+				preview = window[ block.gutenberg_preview_render_callback ]( block, props );
+				return editBlockWithPanelsAndPreview( panels, preview );
 			}
 
 			// If no settings have been defined for this block, render the block with a notice
 			// with instructions on how to configure the block.
-			if (
-				typeof block.gutenberg_help_description_attribute !==
-					'undefined' &&
-				props.attributes[block.gutenberg_help_description_attribute] ===
-					''
-			) {
-				preview = convertKitGutenbergDisplayBlockNotice(
-					block.name,
-					block.gutenberg_help_description
-				);
-				return editBlockWithPanelsAndPreview(panels, preview);
+			if ( typeof block.gutenberg_help_description_attribute !== 'undefined' && props.attributes[ block.gutenberg_help_description_attribute ] === '' ) {
+				preview = convertKitGutenbergDisplayBlockNotice( block.name, block.gutenberg_help_description );
+				return editBlockWithPanelsAndPreview( panels, preview );
 			}
 
 			// If no render_callback is defined, render the block.
-			if (typeof block.gutenberg_template !== 'undefined') {
+			if ( typeof block.gutenberg_template !== 'undefined' ) {
 				// Build template for the new block.
 				const template = [];
 				for (const templateBlockName in block.gutenberg_template) {
-					if (
-						block.gutenberg_template.hasOwnProperty(
-							templateBlockName
-						)
-					) {
-						template.push([
-							templateBlockName,
-							block.gutenberg_template[templateBlockName],
-						]);
+					if (block.gutenberg_template.hasOwnProperty( templateBlockName )) {
+						template.push( [templateBlockName, block.gutenberg_template[templateBlockName]] );
 					}
 				}
 
 				preview = el(
 					'div',
 					{},
-					el(InnerBlocks, {
-						template,
-					})
+					el(
+						InnerBlocks,
+						{
+							template: template
+						}
+					)
 				);
-				return editBlockWithPanelsAndPreview(panels, preview);
+				return editBlockWithPanelsAndPreview( panels, preview );
 			}
 
 			// Use the block's PHP's render() function by calling the ServerSideRender component.
-			preview = el(wp.serverSideRender, {
-				block: 'convertkit/' + block.name,
-				attributes: props.attributes,
+			preview = el(
+				wp.serverSideRender,
+				{
+					block: 'convertkit/' + block.name,
+					attributes: props.attributes,
 
-				// This is only output in the Gutenberg editor, so must be slightly different from the inner class name used to
-				// apply styles with i.e. convertkit-block.name.
-				className: 'convertkit-ssr-' + block.name,
-			});
-			return editBlockWithPanelsAndPreview(panels, preview);
-		};
+					// This is only output in the Gutenberg editor, so must be slightly different from the inner class name used to
+					// apply styles with i.e. convertkit-block.name.
+					className: 'convertkit-ssr-' + block.name,
+				}
+			);
+			return editBlockWithPanelsAndPreview( panels, preview );
+
+		}
 
 		/**
 		 * Display settings sidebar when the block is being edited, and save
@@ -406,38 +451,52 @@ function convertKitGutenbergRegisterBlock(block) {
 		 *
 		 * @since   3.0.0
 		 *
-		 * @param {Object} panels  Block panels.
-		 * @param {Object} preview Block preview.
-		 * @return {Object}         Block settings sidebar elements.
+		 * @param   object  props   Block properties.
+		 * @return  object          Block settings sidebar elements
 		 */
-		const editBlockWithPanelsAndPreview = function (panels, preview) {
-			return el(
-				// Sidebar Panel with Fields.
-				Fragment,
-				{},
-				el(InspectorControls, {}, panels),
-				// Block Preview.
-				preview
+		const editBlockWithPanelsAndPreview = function ( panels, preview ) {
+
+			return (
+				el(
+					// Sidebar Panel with Fields.
+					Fragment,
+					{},
+					el(
+						InspectorControls,
+						{},
+						panels
+					),
+					// Block Preview.
+					preview
+				)
 			);
-		};
+
+		}
 
 		/**
 		 * Save the block's content.
 		 *
 		 * @since   3.0.0
 		 *
-		 * @return {Object}       Block content.
+		 * @param   object  props   Block properties.
+		 * @return  object          Block content.
 		 */
-		const saveBlock = function () {
-			if (typeof block.gutenberg_template !== 'undefined') {
-				return el('div', {}, el(InnerBlocks.Content));
+		const saveBlock = function ( props ) {
+
+			if ( typeof block.gutenberg_template !== 'undefined' ) {
+				return el(
+					'div',
+					{},
+					el( InnerBlocks.Content )
+				);
 			}
 
 			// Deliberate; preview in the editor is determined by the return statement in `edit` above.
 			// On the frontend site, the block's render() PHP class is always called, so we dynamically
 			// fetch the content.
 			return null;
-		};
+
+		}
 
 		/**
 		 * Display a notice in the block with a clickable link to perform an action, and a refresh
@@ -446,31 +505,30 @@ function convertKitGutenbergRegisterBlock(block) {
 		 *
 		 * @since 	2.2.5
 		 *
-		 * @param {Object} props Block properties.
-		 * @return {Object}       Notice.
+		 * @param   object  props   Block properties.
+		 * @return  object          Notice.
 		 */
-		const DisplayNoticeWithLink = function (props) {
+		const displayNoticeWithLink = function ( props ) {
+
 			// useState to toggle the refresh button's disabled state.
-			const [buttonDisabled, setButtonDisabled] = useState(false);
+			const [ buttonDisabled, setButtonDisabled ] = useState( false );
 
 			// Holds the array of elements to display in the notice component.
 			let elements;
 
 			// Define elements to display, based on whether the refresh button is disabled.
-			if (buttonDisabled) {
+			if ( buttonDisabled ) {
 				// Refresh button disabled; display a loading indicator and the button.
 				elements = [
-					loadingIndicator(props),
-					refreshButton(props, buttonDisabled, setButtonDisabled),
+					loadingIndicator( props ),
+					refreshButton( props, buttonDisabled, setButtonDisabled )
 				];
 			} else {
 				// Refresh button enabled; display the notice, link and button.
 				elements = [
-					!block.has_access_token
-						? block.no_access_token.notice
-						: block.no_resources.notice,
-					noticeLink(props, setButtonDisabled),
-					refreshButton(props, buttonDisabled, setButtonDisabled),
+					( ! block.has_access_token ? block.no_access_token.notice : block.no_resources.notice ),
+					noticeLink( props, setButtonDisabled ),
+					refreshButton( props, buttonDisabled, setButtonDisabled )
 				];
 			}
 
@@ -480,87 +538,90 @@ function convertKitGutenbergRegisterBlock(block) {
 				{
 					// convertkit-no-content class allows resources/backend/css/gutenberg.css
 					// to apply styling/branding to the block.
-					className:
-						'convertkit-' + block.name + ' convertkit-no-content',
+					className: 'convertkit-' + block.name + ' convertkit-no-content'
 				},
 				elements
 			);
-		};
+
+		}
 
 		/**
 		 * Returns an indeterminate progress bar element, to show that a block is loading / refreshing.
 		 *
 		 * @since 	2.2.6
 		 *
-		 * @param {Object} props Block properties.
-		 * @return {Object}       Progress Bar.
+		 * @param   object  props   			Block properties.
+		 * @return  object          			Progress Bar.
 		 */
-		const loadingIndicator = function (props) {
-			return el(ProgressBar, {
-				key: props.clientId + '-progress-bar',
-				className: 'convertkit-progress-bar',
-			});
-		};
+		const loadingIndicator = function ( props ) {
+
+			return el(
+				ProgressBar,
+				{
+					key: props.clientId + '-progress-bar',
+					className: 'convertkit-progress-bar'
+				}
+			);
+
+		}
 
 		/**
 		 * Returns a WordPress Icon element.
 		 *
 		 * @since 	2.7.7
 		 *
-		 * @param {string} iconName Icon Name.
-		 * @return {Object} 		 Icon.
+		 * @param   string 	iconName 	Icon Name.
+		 * @return  object 				Icon.
 		 */
-		const iconType = function (iconName) {
-			return el(Icon, {
-				icon: iconName,
-			});
-		};
+		const iconType = function ( iconName ) {
+
+			return el(
+				Icon,
+				{
+					icon: iconName
+				}
+			);
+
+		}
 
 		/**
-		 * Returns the notice link for the DisplayNoticeWithLink element.
+		 * Returns the notice link for the displayNoticeWithLink element.
 		 *
 		 * @since 	2.2.6
 		 *
-		 * @param {Object}   props             Block properties.
-		 * @param {Function} setButtonDisabled Function to enable or disable the refresh button.
-		 * @return {Object}          			Notice Link.
+		 * @param   object  props   			Block properties.
+		 * @param 	object 	setButtonDisabled 	Function to enable or disable the refresh button.
+		 * @return  object          			Notice Link.
 		 */
-		const noticeLink = function (props, setButtonDisabled) {
+		const noticeLink = function ( props, setButtonDisabled ) {
+
 			// Get the URL to set the button to.
-			const url = !block.has_access_token
-				? block.no_access_token.link
-				: block.no_resources.link;
+			let url = ( ! block.has_access_token ? block.no_access_token.link : block.no_resources.link );
 
 			return el(
 				Button,
 				{
 					key: props.clientId + '-notice-link',
-					className: !block.has_access_token
-						? 'convertkit-block-modal'
-						: '',
+					className: ( ! block.has_access_token ? 'convertkit-block-modal' : '' ),
 					variant: 'link',
-					onClick(e) {
+					onClick: function ( e ) {
+
 						e.preventDefault();
 
 						// Show popup window with setup wizard if we need to connect via OAuth.
-						if (!block.has_access_token) {
-							showConvertKitPopupWindow(
-								props,
-								url,
-								setButtonDisabled
-							);
+						if ( ! block.has_access_token ) {
+							showConvertKitPopupWindow( props, url, setButtonDisabled );
 							return;
 						}
 
 						// Allow the link to load, as it's likely a link to the Kit site.
-						window.open(url, '_blank');
-					},
+						window.open( url, '_blank' );
+					}
 				},
-				!block.has_access_token
-					? block.no_access_token.link_text
-					: block.no_resources.link_text
+				( ! block.has_access_token ? block.no_access_token.link_text : block.no_resources.link_text )
 			);
-		};
+
+		}
 
 		/**
 		 * Returns a refresh button, used to refresh a block when it has no API Keys
@@ -568,64 +629,76 @@ function convertKitGutenbergRegisterBlock(block) {
 		 *
 		 * @since 	2.2.6
 		 *
-		 * @param {Object}   props             Block properties.
-		 * @param {boolean}  buttonDisabled    Whether the refresh button is disabled (true) or enabled (false)
-		 * @param {Function} setButtonDisabled Function to enable or disable the refresh button.
-		 * @return {Object} 					Button.
+		 * @param 	object 	props 				Block properties.
+		 * @param 	bool 	buttonDisabled 		Whether the refresh button is disabled (true) or enabled (false)/
+		 * @param 	object 	setButtonDisabled 	Function to enable or disable the refresh button.
+		 * @return 	object 						Button.
 		 */
-		const refreshButton = function (
-			props,
-			buttonDisabled,
-			setButtonDisabled
-		) {
-			return el(Button, {
-				key: props.clientId + '-refresh-button',
-				className: 'convertkit-block-refresh',
-				disabled: buttonDisabled,
-				text: 'Refresh',
-				icon: iconType('update'),
-				variant: 'secondary',
-				onClick() {
-					// Refresh block definitions.
-					refreshBlocksDefinitions(props, setButtonDisabled);
-				},
-			});
-		};
+		const refreshButton = function ( props, buttonDisabled, setButtonDisabled ) {
+
+			return el(
+				Button,
+				{
+					key: props.clientId + '-refresh-button',
+					className: 'convertkit-block-refresh',
+					disabled: buttonDisabled,
+					text: 'Refresh',
+					icon: iconType( 'update' ),
+					variant: 'secondary',
+					onClick: function () {
+
+						// Refresh block definitions.
+						refreshBlocksDefinitions( props, setButtonDisabled );
+
+					}
+				}
+			);
+
+		}
 
 		/**
 		 * Returns an inline refresh button, used to refresh a block's resources.
 		 *
 		 * @since 	2.7.1
 		 *
-		 * @param {Object} props Block properties.
-		 * @return {Object} 	  Button.
+		 * @param 	object 	props 				Block properties.
+		 * @return 	object 						Button.
 		 */
-		const inlineRefreshButton = function (props) {
-			return el(BlockInlineRefreshButton, props);
-		};
+		const inlineRefreshButton = function ( props ) {
+
+			return el( blockInlineRefreshButton, props );
+
+		}
 
 		/**
 		 * Returns a refresh button.
 		 *
 		 * @since 	2.7.1
 		 *
-		 * @param {Object} props Block properties.
-		 * @return {Object} 	  Button.
+		 * @param 	object 	props 	Block properties.
+		 * @return 	object 	Button.
 		 */
-		const BlockInlineRefreshButton = function (props) {
-			const [buttonDisabled, setButtonDisabled] = useState(false);
+		const blockInlineRefreshButton = function ( props ) {
 
-			return el(Button, {
-				key: props.clientId + '-refresh-button',
-				className: 'button button-secondary convertkit-block-refresh',
-				disabled: buttonDisabled,
-				icon: iconType('update'),
-				onClick() {
-					// Refresh block definitions.
-					refreshBlocksDefinitions(props, setButtonDisabled);
-				},
-			});
-		};
+			const [ buttonDisabled, setButtonDisabled ] = useState( false );
+
+			return el(
+				Button,
+				{
+					key: props.clientId + '-refresh-button',
+					className: 'button button-secondary convertkit-block-refresh',
+					disabled: buttonDisabled,
+					icon: iconType( 'update' ),
+					onClick: function () {
+
+						// Refresh block definitions.
+						refreshBlocksDefinitions( props, setButtonDisabled );
+
+					}
+				}
+			);
+
+		}
 
 		/**
 		 * Displays a new window with a given width and height to display the given URL.
@@ -637,37 +710,27 @@ function convertKitGutenbergRegisterBlock(block) {
 		 *
 		 * @since 	2.2.6
 		 *
-		 * @param {Object}   props             Block properties.
-		 * @param {string}   url               URL to display in the popup window.
-		 * @param {Function} setButtonDisabled Function to enable or disable the refresh button.
+		 * @param 	object 	props 				Block properties.
+		 * @param 	object 	url 				URL to display in the popup window.
+		 * @param 	object 	setButtonDisabled 	Function to enable or disable the refresh button.
 		 */
-		const showConvertKitPopupWindow = function (
-			props,
-			url,
-			setButtonDisabled
-		) {
+		const showConvertKitPopupWindow = function ( props, url, setButtonDisabled ) {
+
 			// Define popup width, height and positioning.
-			const width = 640,
-				height = 750,
-				top = (window.screen.height - height) / 2,
-				left = (window.screen.width - width) / 2;
+			const 	width  = 640,
+					height = 750,
+					top    = ( window.screen.height - height ) / 2,
+					left   = ( window.screen.width - width ) / 2;
 
 			// Open popup.
 			const convertKitPopup = window.open(
 				url + '&convertkit-modal=1',
 				'convertkit_popup_window',
-				'toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=' +
-					width +
-					',height=' +
-					height +
-					',top=' +
-					top +
-					',left=' +
-					left
+				'toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=' + width + ',height=' + height + ',top=' + top + ',left=' + left
 			);
 
 			// Center popup and focus.
-			convertKitPopup.moveTo(left, top);
+			convertKitPopup.moveTo( left, top );
 			convertKitPopup.focus();
 
 			// Refresh the block when the popup is closed using self.close().
@@ -677,15 +740,19 @@ function convertKitGutenbergRegisterBlock(block) {
 			// document changes (e.g. as the user steps through a wizard), and doesn't fire when
 			// the window is closed.
 			// See https://stackoverflow.com/questions/9388380/capture-the-close-event-of-popup-window-in-javascript/48240128#48240128.
-			const convertKitPopupTimer = setInterval(function () {
-				if (convertKitPopup.closed) {
-					clearInterval(convertKitPopupTimer);
+			var convertKitPopupTimer = setInterval(
+				function () {
+					if ( convertKitPopup.closed ) {
+						clearInterval( convertKitPopupTimer );
 
-					// Refresh block.
-					refreshBlocksDefinitions(props, setButtonDisabled);
-				}
-			}, 1000);
-		};
+						// Refresh block.
+						refreshBlocksDefinitions( props, setButtonDisabled );
+					}
+				},
+				1000
+			);
+
+		}
 
 		/**
 		 * Refreshes this block's properties by:
@@ -695,147 +762,188 @@ function convertKitGutenbergRegisterBlock(block) {
 		 *
 		 * @since 	2.2.6
 		 *
-		 * @param {Object}   props             Block properties.
-		 * @param {Function} setButtonDisabled Function to enable or disable the refresh button.
+		 * @param   object  props   			Block properties.
+		 * @param 	object 	setButtonDisabled 	Function to enable or disable the refresh button.
+		 * @return  object          			Notice.
 		 */
-		const refreshBlocksDefinitions = function (props, setButtonDisabled) {
+		const refreshBlocksDefinitions = function ( props, setButtonDisabled ) {
+
 			// Define data for WordPress AJAX request.
-			const data = new FormData();
-			data.append('action', 'convertkit_get_blocks');
-			data.append('nonce', convertkit_gutenberg.get_blocks_nonce);
+			let data = new FormData();
+			data.append( 'action', 'convertkit_get_blocks' );
+			data.append( 'nonce', convertkit_gutenberg.get_blocks_nonce );
 
 			// Disable the button.
-			if (typeof setButtonDisabled !== 'undefined') {
-				setButtonDisabled(true);
+			if ( typeof setButtonDisabled !== 'undefined' ) {
+				setButtonDisabled( true );
 			}
 
 			// Send AJAX request.
-			fetch(ajaxurl, {
-				method: 'POST',
-				credentials: 'same-origin',
-				body: data,
-			})
-				.then(function (response) {
+			fetch(
+				ajaxurl,
+				{
+					method: 'POST',
+					credentials: 'same-origin',
+					body: data
+				}
+			)
+			.then(
+				function ( response ) {
+
 					// Convert response JSON string to object.
 					return response.json();
-				})
-				.then(function (response) {
+
+				}
+			)
+			.then(
+				function ( response ) {
+
 					// Update global ConvertKit Blocks object, so that any updated resources
 					// are reflected when adding new ConvertKit Blocks.
 					convertkit_blocks = response.data;
 
 					// Update this block's properties, so that has_access_token, has_resources
 					// and the resources properties are updated.
-					block = convertkit_blocks[block.name];
+					block = convertkit_blocks[ block.name ];
 
 					// Call setAttributes on props to trigger the editBlock() function, which will re-render
 					// the block, reflecting any changes to its properties.
-					props.setAttributes({
-						refresh: Date.now(),
-					});
+					props.setAttributes(
+						{
+							refresh: Date.now()
+						}
+					);
 
 					// Enable refresh button.
-					if (typeof setButtonDisabled !== 'undefined') {
-						setButtonDisabled(false);
+					if ( typeof setButtonDisabled !== 'undefined' ) {
+						setButtonDisabled( false );
 					}
-				})
-				.catch(function (error) {
+
+				}
+			)
+			.catch(
+				function ( error ) {
+
 					// Show an error in the Gutenberg editor.
-					wp.data
-						.dispatch('core/notices')
-						.createErrorNotice('ConvertKit: ' + error, {
-							id: 'convertkit-error',
-						});
+					wp.data.dispatch( 'core/notices' ).createErrorNotice(
+						'ConvertKit: ' + error,
+						{
+							id: 'convertkit-error'
+						}
+					);
 
 					// Enable refresh button.
-					setButtonDisabled(false);
-				});
-		};
+					setButtonDisabled( false );
+
+				}
+			);
+
+		}
 
 		// Register Block.
-		registerBlockType('convertkit/' + block.name, {
-			title: block.title,
-			description: block.description,
-			category: block.category,
-			icon: getIcon,
-			keywords: block.keywords,
-			attributes: block.attributes,
-			supports: block.supports,
-			example: {
-				attributes: {
-					is_gutenberg_example: true,
+		registerBlockType(
+			'convertkit/' + block.name,
+			{
+				title:      block.title,
+				description:block.description,
+				category:   block.category,
+				icon:       getIcon,
+				keywords: 	block.keywords,
+				attributes: block.attributes,
+				supports: 	block.supports,
+				example: 	{
+					attributes: {
+						is_gutenberg_example: true,
+					}
 				},
-			},
 
-			// Editor.
-			edit: editBlock,
+				// Editor.
+				edit: editBlock,
 
-			// Output.
-			save: saveBlock,
-		});
-	})(
+				// Output.
+				save: saveBlock
+			}
+		);
+
+	} (
 		window.wp.blocks,
 		window.wp.blockEditor,
 		window.wp.element,
 		window.wp.components
-	);
+	) );
+
 }
 
 /**
  * Registers pre-publish actions in Gutenberg's pre-publish checks panel.
  *
- * @since 2.4.0
+ * @since 	2.4.0
  *
- * @param {Object} actions Pre-publish actions.
+ * @param 	object 	actions 	Pre-publish actions.
  */
-function convertKitGutenbergRegisterPrePublishActions(actions) {
-	(function (plugins, editPost, element, components, data) {
-		const el = element.createElement;
-		const { ToggleControl } = components;
-		const { registerPlugin } = plugins;
-		const { PluginPrePublishPanel } = editPost;
+function convertKitGutenbergRegisterPrePublishActions( actions ) {
+
+	( function ( plugins, editPost, element, components, data ) {
+
+		// Define some constants for the various items we'll use.
+		const el                                 = element.createElement;
+		const { ToggleControl }                  = components;
+		const { registerPlugin }                 = plugins;
+		const { PluginPrePublishPanel }          = editPost;
 		const { useSelect, useDispatch, select } = data;
 
 		/**
-		 * Returns a PluginPrePublishPanel for this plugin, containing all
+		 * Returns a PluginPrePublishPanel for this Plugin, comprising of all
 		 * pre-publish actions.
 		 *
-		 * @since 2.4.0
-		 * @return {WPElement|null} Pre-publish panel element or null if not a post.
+		 * @since   2.4.0
+		 *
+		 * @return  PluginPrePublishPanel
 		 */
-		const RenderPanel = function () {
-			// --- Hooks must be called first ---
-			const { meta } = useSelect((wpSelect) => ({
-				meta: wpSelect('core/editor').getEditedPostAttribute('meta'),
-			}));
+		const renderPanel = function () {
 
-			const { editPost: wpEditPost } = useDispatch('core/editor');
-
-			const currentPostType = select('core/editor').getCurrentPostType();
-
-			// Bail early if not a 'post'
-			if (currentPostType !== 'post') {
-				return null;
+			// Bail if the Post Type isn't a Post.
+			if ( select( 'core/editor' ).getCurrentPostType() !== 'post' ) {
+				return;
 			}
 
-			// Build rows safely using .map()
-			const rows = Object.values(actions).map((action) => {
-				const key = '_convertkit_action_' + action.name;
+			// Build rows.
+			let rows = [];
+			for ( const [ name, action ] of Object.entries( actions ) ) {
 
-				return el(ToggleControl, {
-					key,
-					id: 'convertkit_action_' + action.name,
-					label: action.label,
-					help: action.description,
-					value: true,
-					checked: meta[key],
-					onChange(value) {
-						wpEditPost({ meta: { [key]: value } });
-					},
-				});
-			});
+				const key          = '_convertkit_action_' + action.name;
+				const { meta }     = useSelect(
+					function ( select ) {
+						return {
+							meta: select( 'core/editor' ).getEditedPostAttribute( 'meta' ),
+						};
+					}
+				);
+				const { editPost } = useDispatch( 'core/editor', [ meta[ key ] ] );
 
-			// Return the pre-publish panel with rows
+				// Add row.
+				rows.push(
+					el(
+						ToggleControl,
+						{
+							id:  		'convertkit_action_' + action.name,
+							label: 		action.label,
+							help: 		action.description,
+							value:      true,
+							checked: 	meta[ key ],
+							onChange: 	function ( value ) {
+								editPost(
+									{
+										meta: { [ key ]: value },
+									}
+								);
+							}
+						}
+					)
+				);
+			}
+
+			// Return actions in the pre-publish panel.
 			return el(
 				PluginPrePublishPanel,
 				{
@@ -845,19 +953,25 @@ function convertKitGutenbergRegisterPrePublishActions(actions) {
 				},
 				rows
 			);
-		};
 
-		// Register pre-publish actions
-		registerPlugin('convertkit-pre-publish-actions', {
-			render: RenderPanel,
-		});
-	})(
+		}
+
+		// Register pre-publish actions.
+		registerPlugin(
+			'convertkit-pre-publish-actions',
+			{
+				render: renderPanel
+			}
+		);
+
+	} (
 		window.wp.plugins,
 		window.wp.editPost,
 		window.wp.element,
 		window.wp.components,
 		window.wp.data
-	);
+	) );
+
 }
 
 /**
@@ -868,18 +982,20 @@ function convertKitGutenbergRegisterPrePublishActions(actions) {
  *
  * @since 	2.2.3
  *
- * @param {string} block_name Block Name.
- * @param {string} notice     Notice to display.
- * @return {Object} 		   HTMLElement
+ * @param 	string 	block_name 	Block Name.
+ * @param 	string 	notice 		Notice to display.
+ * @return 	object 				HTMLElement
  */
-function convertKitGutenbergDisplayBlockNotice(block_name, notice) {
+function convertKitGutenbergDisplayBlockNotice( block_name, notice ) {
+
 	return wp.element.createElement(
 		'div',
 		{
 			// convertkit-no-content class allows resources/backend/css/gutenberg.css
 			// to apply styling/branding to the block.
-			className: 'convertkit-' + block_name + ' convertkit-no-content',
+			className: 'convertkit-' + block_name + ' convertkit-no-content'
 		},
 		notice
 	);
+
 }

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -3,26 +3,28 @@
  *
  * @since   1.9.6.5
  *
- * @package ConvertKit
  * @author ConvertKit
+ */
+
+/**
+ * @typedef {import('@wordpress/element').WPElement} WPElement
  */
 
 // Register Gutenberg Blocks if the Gutenberg Editor is loaded on screen.
 // This prevents JS errors if this script is accidentally enqueued on a non-
 // Gutenberg editor screen, or the Classic Editor Plugin is active.
-if ( typeof wp !== 'undefined' &&
-	typeof wp.blockEditor !== 'undefined' ) {
-
+if (typeof wp !== 'undefined' && typeof wp.blockEditor !== 'undefined') {
 	// Register each ConvertKit Block in Gutenberg.
-	for ( const block in convertkit_blocks ) {
-		convertKitGutenbergRegisterBlock( convertkit_blocks[ block ] );
+	for (const block in convertkit_blocks) {
+		convertKitGutenbergRegisterBlock(convertkit_blocks[block]);
 	}
 
 	// Register ConvertKit Pre-publish actions in Gutenberg.
-	if ( typeof convertkit_pre_publish_actions !== 'undefined' ) {
-		convertKitGutenbergRegisterPrePublishActions( convertkit_pre_publish_actions );
+	if (typeof convertkit_pre_publish_actions !== 'undefined') {
+		convertKitGutenbergRegisterPrePublishActions(
+			convertkit_pre_publish_actions
+		);
 	}
-
 }
 
 /**
@@ -30,23 +32,15 @@ if ( typeof wp !== 'undefined' &&
  *
  * @since 	1.9.6.5
  *
- * @param 	object 	block 	Block
+ * @param {Object} block Block.
  */
-function convertKitGutenbergRegisterBlock( block ) {
-
-	( function ( blocks, editor, element, components ) {
-
+function convertKitGutenbergRegisterBlock(block) {
+	(function (blocks, editor, element, components) {
 		// Define some constants for the various items we'll use.
-		const el                    = element.createElement;
+		const el = element.createElement;
 		const { registerBlockType } = blocks;
-		const {
-			InspectorControls,
-			InnerBlocks
-		}                           = editor;
-		const {
-			Fragment,
-			useState
-		}                           = element;
+		const { InspectorControls, InnerBlocks } = editor;
+		const { Fragment, useState } = element;
 		const {
 			Button,
 			Icon,
@@ -55,11 +49,10 @@ function convertKitGutenbergRegisterBlock( block ) {
 			ToggleControl,
 			Flex,
 			FlexItem,
-			Panel,
 			PanelBody,
 			PanelRow,
-			ProgressBar
-		}                           = components;
+			ProgressBar,
+		} = components;
 
 		/**
 		 * Returns the icon to display for this block, depending
@@ -67,28 +60,24 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 *
 		 * @since   2.2.0
 		 *
-		 * @return  element|string
+		 * @return  {WPElement|string} Either a WordPress element (RawHTML) or a dashicon string.
 		 */
 		const getIcon = function () {
-
 			// Return a fallback default icon if none is specified for this block.
-			if ( typeof block.gutenberg_icon === 'undefined' ) {
+			if (typeof block.gutenberg_icon === 'undefined') {
 				return 'dashicons-tablet';
 			}
 
 			// Return HTML element if the icon is an SVG string.
-			if ( block.gutenberg_icon.search( 'svg' ) >= 0 ) {
-				return element.RawHTML(
-					{
-						children: block.gutenberg_icon
-					}
-				);
+			if (block.gutenberg_icon.search('svg') >= 0) {
+				return element.RawHTML({
+					children: block.gutenberg_icon,
+				});
 			}
 
 			// Just return the string, as it's a dashicon CSS class.
 			return block.gutenberg_icon;
-
-		}
+		};
 
 		/**
 		 * Return a field element for the block sidebar, which is displayed in a panel's row
@@ -96,113 +85,95 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 *
 		 * @since   2.2.0
 		 *
-		 * @param   object  props           Block properties.
-		 * @param   object  field      		Field attributes.
-		 * @param 	string 	attribute 		Attribute name to store the field's data in.
-		 * @return  array                   Field element
+		 * @param {Object} props     Block properties.
+		 * @param {Object} field     Field attributes.
+		 * @param {string} attribute Attribute name to store the field's data in.
+		 * @return {Object}            Field element.
 		 */
-		const getField = function ( props, field, attribute ) {
-
+		const getField = function (props, field, attribute) {
 			// Define some field properties shared across all field types.
-			let fieldProperties = {
-				id:  		'convertkit_' + block.name.replace( /-/g, '_' ) + '_' + attribute,
-				label: 		field.label,
-				help: 		field.description,
-				value: 		props.attributes[ attribute ],
-				onChange: 	function ( value ) {
-					if ( field.type === 'number' ) {
+			const fieldProperties = {
+				id:
+					'convertkit_' +
+					block.name.replace(/-/g, '_') +
+					'_' +
+					attribute,
+				label: field.label,
+				help: field.description,
+				value: props.attributes[attribute],
+				onChange(value) {
+					if (field.type === 'number') {
 						// If value is a blank string i.e. no attribute value was provided,
 						// cast it to the field's minimum number setting.
 						// This prevents WordPress' block renderer API returning a 400 error
 						// because a blank value will be passed as a string, when WordPress
 						// expects it to be a numerical value.
-						if ( value === '' ) {
+						if (value === '') {
 							value = field.min;
 						}
 
 						// Cast value to integer if a value exists.
-						if ( value.length > 0 ) {
-							value = Number( value );
+						if (value.length > 0) {
+							value = Number(value);
 						}
 					}
 
-					let newValue          = {};
-					newValue[ attribute ] = value;
-					props.setAttributes( newValue );
-				}
+					const newValue = {};
+					newValue[attribute] = value;
+					props.setAttributes(newValue);
+				},
 			};
 
-			let fieldOptions = [];
+			const fieldOptions = [];
 
 			// Define additional Field Properties and the Field Element,
 			// depending on the Field Type (select, textarea, text etc).
-			switch ( field.type ) {
-
+			switch (field.type) {
 				case 'select':
 					// Build options for <select> input.
-					fieldOptions.push(
-						{
-							label: '(None)',
-							value: '',
-						}
-					);
-					for ( const value of Object.keys( field.values ) ) {
-						fieldOptions.push(
-							{
-								label: field.values[ value ],
-								value: value
-							}
-						);
+					fieldOptions.push({
+						label: '(None)',
+						value: '',
+					});
+					for (const value of Object.keys(field.values)) {
+						fieldOptions.push({
+							label: field.values[value],
+							value,
+						});
 					}
 
 					// Sort field's options alphabetically by label.
-					fieldOptions.sort(
-						function ( x, y ) {
-
-							let a = x.label.toUpperCase(),
-							b     = y.label.toUpperCase();
-							return a.localeCompare( b );
-
-						}
-					);
+					fieldOptions.sort(function (x, y) {
+						const a = x.label.toUpperCase(),
+							b = y.label.toUpperCase();
+						return a.localeCompare(b);
+					});
 
 					// Assign options to field.
 					fieldProperties.options = fieldOptions;
 
 					// Return field element.
-					return el(
-						SelectControl,
-						fieldProperties
-					);
-					break;
+					return el(SelectControl, fieldProperties);
 
 				case 'resource':
 					// Build options for <select> input.
-					fieldOptions.push(
-						{
-							label: '(None)',
-							value: '',
-						}
-					);
-					for ( const value of Object.keys( field.values ) ) {
-						fieldOptions.push(
-							{
-								label: field.values[ value ],
-								value: value
-							}
-						);
+					fieldOptions.push({
+						label: '(None)',
+						value: '',
+					});
+					for (const value of Object.keys(field.values)) {
+						fieldOptions.push({
+							label: field.values[value],
+							value,
+						});
 					}
 
 					// Sort field's options alphabetically by label.
-					fieldOptions.sort(
-						function ( x, y ) {
-
-							let a = x.label.toUpperCase(),
-							b     = y.label.toUpperCase();
-							return a.localeCompare( b );
-
-						}
-					);
+					fieldOptions.sort(function (x, y) {
+						const a = x.label.toUpperCase(),
+							b = y.label.toUpperCase();
+						return a.localeCompare(b);
+					});
 
 					// Assign options to field.
 					fieldProperties.options = fieldOptions;
@@ -216,55 +187,34 @@ function convertKitGutenbergRegisterBlock( block ) {
 							el(
 								FlexItem,
 								{},
-								el(
-									SelectControl,
-									fieldProperties
-								)
+								el(SelectControl, fieldProperties)
 							),
-							el(
-								FlexItem,
-								{},
-								inlineRefreshButton( props )
-							)
+							el(FlexItem, {}, inlineRefreshButton(props)),
 						]
 					);
-					break;
 
 				case 'toggle':
 					// Define field properties.
-					fieldProperties.checked = props.attributes[ attribute ];
+					fieldProperties.checked = props.attributes[attribute];
 
 					// Return field element.
-					return el(
-						ToggleControl,
-						fieldProperties
-					);
-					break;
+					return el(ToggleControl, fieldProperties);
 
 				case 'number':
 					// Define field properties.
 					fieldProperties.type = field.type;
-					fieldProperties.min  = field.min;
-					fieldProperties.max  = field.max;
+					fieldProperties.min = field.min;
+					fieldProperties.max = field.max;
 					fieldProperties.step = field.step;
 
 					// Return field element.
-					return el(
-						TextControl,
-						fieldProperties
-					);
-					break;
+					return el(TextControl, fieldProperties);
 
 				default:
 					// Return field element.
-					return el(
-						TextControl,
-						fieldProperties
-					);
-					break;
+					return el(TextControl, fieldProperties);
 			}
-
-		}
+		};
 
 		/**
 		 * Return an array of rows to display in the given block sidebar's panel when
@@ -272,22 +222,21 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 *
 		 * @since   2.2.0
 		 *
-		 * @param   object  props   Block properties.
-		 * @param   string  panel 	Panel name.
-		 * @return  array           Panel rows
+		 * @param {Object} props Block properties.
+		 * @param {string} panel Panel name.
+		 * @return {Array}        Panel rows.
 		 */
-		const getPanelRows = function ( props, panel ) {
-
+		const getPanelRows = function (props, panel) {
 			// Build Inspector Control Panel Rows, one for each Field.
-			let rows = [];
-			for ( let i in block.panels[ panel ].fields ) {
-				const attribute = block.panels[ panel ].fields[ i ], // e.g. 'term'.
-					field       = block.fields[ attribute ]; // field array.
+			const rows = [];
+			for (const i in block.panels[panel].fields) {
+				const attribute = block.panels[panel].fields[i], // e.g. 'term'.
+					field = block.fields[attribute]; // field array.
 
 				// If this field doesn't exist as an attribute in the block's get_attributes(),
 				// this is a non-Gutenberg field (such as a color picker for shortcodes),
 				// which should be ignored.
-				if ( typeof block.attributes[ attribute ] === 'undefined' ) {
+				if (typeof block.attributes[attribute] === 'undefined') {
 					continue;
 				}
 
@@ -295,16 +244,15 @@ function convertKitGutenbergRegisterBlock( block ) {
 					el(
 						PanelRow,
 						{
-							key: attribute
+							key: attribute,
 						},
-						getField( props, field, attribute )
+						getField(props, field, attribute)
 					)
 				);
 			}
 
 			return rows;
-
-		}
+		};
 
 		/**
 		 * Return an array of panels to display in the block's sidebar when the block
@@ -312,22 +260,21 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 *
 		 * @since   2.2.0
 		 *
-		 * @param   object  props 	Block formatter properties.
-		 * @return 	array 			Block sidebar panels.
+		 * @param {Object} props Block formatter properties.
+		 * @return {Array} 	      Block sidebar panels.
 		 */
-		const getPanels = function ( props ) {
-
-			let panels      = [],
-				initialOpen = true;
+		const getPanels = function (props) {
+			const panels = [];
+			let initialOpen = true;
 
 			// Build Inspector Control Panels.
-			for ( const panel in block.panels ) {
-				let panelRows = getPanelRows( props, panel );
+			for (const panel in block.panels) {
+				const panelRows = getPanelRows(props, panel);
 
 				// If no panel rows exist (e.g. this is a shortcode only panel,
 				// for styles, which Gutenberg registers in its own styles tab),
 				// don't add this panel.
-				if ( ! panelRows.length ) {
+				if (!panelRows.length) {
 					continue;
 				}
 
@@ -335,9 +282,9 @@ function convertKitGutenbergRegisterBlock( block ) {
 					el(
 						PanelBody,
 						{
-							title: block.panels[ panel ].label,
+							title: block.panels[panel].label,
 							key: panel,
-							initialOpen: initialOpen
+							initialOpen,
 						},
 						panelRows
 					)
@@ -348,8 +295,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 			}
 
 			return panels;
-
-		}
+		};
 
 		/**
 		 * Display settings sidebar when the block is being edited, and save
@@ -357,93 +303,102 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 *
 		 * @since   2.2.0
 		 *
-		 * @param   object  props   Block properties.
-		 * @return  object          Block settings sidebar elements
+		 * @param {Object} props Block properties.
+		 * @return {Object}       Block settings sidebar elements.
 		 */
-		const editBlock = function ( props ) {
-
+		const editBlock = function (props) {
 			// If requesting an example of how this block looks (which is requested
 			// when the user adds a new block and hovers over this block's icon),
 			// show the preview image.
-			if ( props.attributes.is_gutenberg_example === true ) {
+			if (props.attributes.is_gutenberg_example === true) {
 				return (
 					Fragment,
 					{},
-					el(
-						'img',
-						{
-							src: block.gutenberg_example_image,
-						}
-					)
+					el('img', {
+						src: block.gutenberg_example_image,
+					})
 				);
 			}
 
+			// If no access token has been defined in the Plugin, or no resources exist in Kit
+			// for this block, show a message in the block to tell the user what to do.
+			if (!block.has_access_token || !block.has_resources) {
+				return DisplayNoticeWithLink(props);
+			}
+
 			// Build Inspector Control Panels, which will appear in the Sidebar when editing the Block.
-			let panels = getPanels( props );
+			const panels = getPanels(props);
 
 			// Generate Block Preview.
 			let preview = '';
-
-			// If no access token has been defined in the Plugin, or no resources exist in Kit
-			// for this block, show a message in the block to tell the user what to do.
-			if ( ! block.has_access_token || ! block.has_resources ) {
-				return displayNoticeWithLink( props );
-			}
 
 			// If a custom callback function to render this block's preview in the Gutenberg Editor
 			// has been defined, use it.
 			// This doesn't affect the output for this block on the frontend site, which will always
 			// use the block's PHP's render() function.
-			if ( typeof block.gutenberg_preview_render_callback !== 'undefined' ) {
-				preview = window[ block.gutenberg_preview_render_callback ]( block, props );
-				return editBlockWithPanelsAndPreview( panels, preview );
+			if (
+				typeof block.gutenberg_preview_render_callback !== 'undefined'
+			) {
+				preview = window[block.gutenberg_preview_render_callback](
+					block,
+					props
+				);
+				return editBlockWithPanelsAndPreview(panels, preview);
 			}
 
 			// If no settings have been defined for this block, render the block with a notice
 			// with instructions on how to configure the block.
-			if ( typeof block.gutenberg_help_description_attribute !== 'undefined' && props.attributes[ block.gutenberg_help_description_attribute ] === '' ) {
-				preview = convertKitGutenbergDisplayBlockNotice( block.name, block.gutenberg_help_description );
-				return editBlockWithPanelsAndPreview( panels, preview );
+			if (
+				typeof block.gutenberg_help_description_attribute !==
+					'undefined' &&
+				props.attributes[block.gutenberg_help_description_attribute] ===
+					''
+			) {
+				preview = convertKitGutenbergDisplayBlockNotice(
+					block.name,
+					block.gutenberg_help_description
+				);
+				return editBlockWithPanelsAndPreview(panels, preview);
 			}
 
 			// If no render_callback is defined, render the block.
-			if ( typeof block.gutenberg_template !== 'undefined' ) {
+			if (typeof block.gutenberg_template !== 'undefined') {
 				// Build template for the new block.
 				const template = [];
 				for (const templateBlockName in block.gutenberg_template) {
-					if (block.gutenberg_template.hasOwnProperty( templateBlockName )) {
-						template.push( [templateBlockName, block.gutenberg_template[templateBlockName]] );
+					if (
+						block.gutenberg_template.hasOwnProperty(
+							templateBlockName
+						)
+					) {
+						template.push([
+							templateBlockName,
+							block.gutenberg_template[templateBlockName],
+						]);
 					}
 				}
 
 				preview = el(
 					'div',
 					{},
-					el(
-						InnerBlocks,
-						{
-							template: template
-						}
-					)
+					el(InnerBlocks, {
+						template,
+					})
 				);
-				return editBlockWithPanelsAndPreview( panels, preview );
+				return editBlockWithPanelsAndPreview(panels, preview);
 			}
 
 			// Use the block's PHP's render() function by calling the ServerSideRender component.
-			preview = el(
-				wp.serverSideRender,
-				{
-					block: 'convertkit/' + block.name,
-					attributes: props.attributes,
+			preview = el(wp.serverSideRender, {
+				block: 'convertkit/' + block.name,
+				attributes: props.attributes,
 
-					// This is only output in the Gutenberg editor, so must be slightly different from the inner class name used to
-					// apply styles with i.e. convertkit-block.name.
-					className: 'convertkit-ssr-' + block.name,
-				}
-			);
-			return editBlockWithPanelsAndPreview( panels, preview );
-
-		}
+				// This is only output in the Gutenberg editor, so must be slightly different from the inner class name used to
+				// apply styles with i.e. convertkit-block.name.
+				className: 'convertkit-ssr-' + block.name,
+			});
+			return editBlockWithPanelsAndPreview(panels, preview);
+		};
 
 		/**
 		 * Display settings sidebar when the block is being edited, and save
@@ -451,52 +406,38 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 *
 		 * @since   3.0.0
 		 *
-		 * @param   object  props   Block properties.
-		 * @return  object          Block settings sidebar elements
+		 * @param {Object} panels  Block panels.
+		 * @param {Object} preview Block preview.
+		 * @return {Object}         Block settings sidebar elements.
 		 */
-		const editBlockWithPanelsAndPreview = function ( panels, preview ) {
-
-			return (
-				el(
-					// Sidebar Panel with Fields.
-					Fragment,
-					{},
-					el(
-						InspectorControls,
-						{},
-						panels
-					),
-					// Block Preview.
-					preview
-				)
+		const editBlockWithPanelsAndPreview = function (panels, preview) {
+			return el(
+				// Sidebar Panel with Fields.
+				Fragment,
+				{},
+				el(InspectorControls, {}, panels),
+				// Block Preview.
+				preview
 			);
-
-		}
+		};
 
 		/**
 		 * Save the block's content.
 		 *
 		 * @since   3.0.0
 		 *
-		 * @param   object  props   Block properties.
-		 * @return  object          Block content.
+		 * @return {Object}       Block content.
 		 */
-		const saveBlock = function ( props ) {
-
-			if ( typeof block.gutenberg_template !== 'undefined' ) {
-				return el(
-					'div',
-					{},
-					el( InnerBlocks.Content )
-				);
+		const saveBlock = function () {
+			if (typeof block.gutenberg_template !== 'undefined') {
+				return el('div', {}, el(InnerBlocks.Content));
 			}
 
 			// Deliberate; preview in the editor is determined by the return statement in `edit` above.
 			// On the frontend site, the block's render() PHP class is always called, so we dynamically
 			// fetch the content.
 			return null;
-
-		}
+		};
 
 		/**
 		 * Display a notice in the block with a clickable link to perform an action, and a refresh
@@ -505,30 +446,31 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 *
 		 * @since 	2.2.5
 		 *
-		 * @param   object  props   Block properties.
-		 * @return  object          Notice.
+		 * @param {Object} props Block properties.
+		 * @return {Object}       Notice.
 		 */
-		const displayNoticeWithLink = function ( props ) {
-
+		const DisplayNoticeWithLink = function (props) {
 			// useState to toggle the refresh button's disabled state.
-			const [ buttonDisabled, setButtonDisabled ] = useState( false );
+			const [buttonDisabled, setButtonDisabled] = useState(false);
 
 			// Holds the array of elements to display in the notice component.
 			let elements;
 
 			// Define elements to display, based on whether the refresh button is disabled.
-			if ( buttonDisabled ) {
+			if (buttonDisabled) {
 				// Refresh button disabled; display a loading indicator and the button.
 				elements = [
-					loadingIndicator( props ),
-					refreshButton( props, buttonDisabled, setButtonDisabled )
+					loadingIndicator(props),
+					refreshButton(props, buttonDisabled, setButtonDisabled),
 				];
 			} else {
 				// Refresh button enabled; display the notice, link and button.
 				elements = [
-					( ! block.has_access_token ? block.no_access_token.notice : block.no_resources.notice ),
-					noticeLink( props, setButtonDisabled ),
-					refreshButton( props, buttonDisabled, setButtonDisabled )
+					!block.has_access_token
+						? block.no_access_token.notice
+						: block.no_resources.notice,
+					noticeLink(props, setButtonDisabled),
+					refreshButton(props, buttonDisabled, setButtonDisabled),
 				];
 			}
 
@@ -538,90 +480,87 @@ function convertKitGutenbergRegisterBlock( block ) {
 				{
 					// convertkit-no-content class allows resources/backend/css/gutenberg.css
 					// to apply styling/branding to the block.
-					className: 'convertkit-' + block.name + ' convertkit-no-content'
+					className:
+						'convertkit-' + block.name + ' convertkit-no-content',
 				},
 				elements
 			);
-
-		}
+		};
 
 		/**
 		 * Returns an indeterminate progress bar element, to show that a block is loading / refreshing.
 		 *
 		 * @since 	2.2.6
 		 *
-		 * @param   object  props   			Block properties.
-		 * @return  object          			Progress Bar.
+		 * @param {Object} props Block properties.
+		 * @return {Object}       Progress Bar.
 		 */
-		const loadingIndicator = function ( props ) {
-
-			return el(
-				ProgressBar,
-				{
-					key: props.clientId + '-progress-bar',
-					className: 'convertkit-progress-bar'
-				}
-			);
-
-		}
+		const loadingIndicator = function (props) {
+			return el(ProgressBar, {
+				key: props.clientId + '-progress-bar',
+				className: 'convertkit-progress-bar',
+			});
+		};
 
 		/**
 		 * Returns a WordPress Icon element.
 		 *
 		 * @since 	2.7.7
 		 *
-		 * @param   string 	iconName 	Icon Name.
-		 * @return  object 				Icon.
+		 * @param {string} iconName Icon Name.
+		 * @return {Object} 		 Icon.
 		 */
-		const iconType = function ( iconName ) {
-
-			return el(
-				Icon,
-				{
-					icon: iconName
-				}
-			);
-
-		}
+		const iconType = function (iconName) {
+			return el(Icon, {
+				icon: iconName,
+			});
+		};
 
 		/**
-		 * Returns the notice link for the displayNoticeWithLink element.
+		 * Returns the notice link for the DisplayNoticeWithLink element.
 		 *
 		 * @since 	2.2.6
 		 *
-		 * @param   object  props   			Block properties.
-		 * @param 	object 	setButtonDisabled 	Function to enable or disable the refresh button.
-		 * @return  object          			Notice Link.
+		 * @param {Object}   props             Block properties.
+		 * @param {Function} setButtonDisabled Function to enable or disable the refresh button.
+		 * @return {Object}          			Notice Link.
 		 */
-		const noticeLink = function ( props, setButtonDisabled ) {
-
+		const noticeLink = function (props, setButtonDisabled) {
 			// Get the URL to set the button to.
-			let url = ( ! block.has_access_token ? block.no_access_token.link : block.no_resources.link );
+			const url = !block.has_access_token
+				? block.no_access_token.link
+				: block.no_resources.link;
 
 			return el(
 				Button,
 				{
 					key: props.clientId + '-notice-link',
-					className: ( ! block.has_access_token ? 'convertkit-block-modal' : '' ),
+					className: !block.has_access_token
+						? 'convertkit-block-modal'
+						: '',
 					variant: 'link',
-					onClick: function ( e ) {
-
+					onClick(e) {
 						e.preventDefault();
 
 						// Show popup window with setup wizard if we need to connect via OAuth.
-						if ( ! block.has_access_token ) {
-							showConvertKitPopupWindow( props, url, setButtonDisabled );
+						if (!block.has_access_token) {
+							showConvertKitPopupWindow(
+								props,
+								url,
+								setButtonDisabled
+							);
 							return;
 						}
 
 						// Allow the link to load, as it's likely a link to the Kit site.
-						window.open( url, '_blank' );
-					}
+						window.open(url, '_blank');
+					},
 				},
-				( ! block.has_access_token ? block.no_access_token.link_text : block.no_resources.link_text )
+				!block.has_access_token
+					? block.no_access_token.link_text
+					: block.no_resources.link_text
 			);
-
-		}
+		};
 
 		/**
 		 * Returns a refresh button, used to refresh a block when it has no API Keys
@@ -629,76 +568,64 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 *
 		 * @since 	2.2.6
 		 *
-		 * @param 	object 	props 				Block properties.
-		 * @param 	bool 	buttonDisabled 		Whether the refresh button is disabled (true) or enabled (false)/
-		 * @param 	object 	setButtonDisabled 	Function to enable or disable the refresh button.
-		 * @return 	object 						Button.
+		 * @param {Object}   props             Block properties.
+		 * @param {boolean}  buttonDisabled    Whether the refresh button is disabled (true) or enabled (false)
+		 * @param {Function} setButtonDisabled Function to enable or disable the refresh button.
+		 * @return {Object} 					Button.
 		 */
-		const refreshButton = function ( props, buttonDisabled, setButtonDisabled ) {
-
-			return el(
-				Button,
-				{
-					key: props.clientId + '-refresh-button',
-					className: 'convertkit-block-refresh',
-					disabled: buttonDisabled,
-					text: 'Refresh',
-					icon: iconType( 'update' ),
-					variant: 'secondary',
-					onClick: function () {
-
-						// Refresh block definitions.
-						refreshBlocksDefinitions( props, setButtonDisabled );
-
-					}
-				}
-			);
-
-		}
+		const refreshButton = function (
+			props,
+			buttonDisabled,
+			setButtonDisabled
+		) {
+			return el(Button, {
+				key: props.clientId + '-refresh-button',
+				className: 'convertkit-block-refresh',
+				disabled: buttonDisabled,
+				text: 'Refresh',
+				icon: iconType('update'),
+				variant: 'secondary',
+				onClick() {
+					// Refresh block definitions.
+					refreshBlocksDefinitions(props, setButtonDisabled);
+				},
+			});
+		};
 
 		/**
 		 * Returns an inline refresh button, used to refresh a block's resources.
 		 *
 		 * @since 	2.7.1
 		 *
-		 * @param 	object 	props 				Block properties.
-		 * @return 	object 						Button.
+		 * @param {Object} props Block properties.
+		 * @return {Object} 	  Button.
 		 */
-		const inlineRefreshButton = function ( props ) {
-
-			return el( blockInlineRefreshButton, props );
-
-		}
+		const inlineRefreshButton = function (props) {
+			return el(BlockInlineRefreshButton, props);
+		};
 
 		/**
 		 * Returns a refresh button.
 		 *
 		 * @since 	2.7.1
 		 *
-		 * @param 	object 	props 	Block properties.
-		 * @return 	object 	Button.
+		 * @param {Object} props Block properties.
+		 * @return {Object} 	  Button.
 		 */
-		const blockInlineRefreshButton = function ( props ) {
+		const BlockInlineRefreshButton = function (props) {
+			const [buttonDisabled, setButtonDisabled] = useState(false);
 
-			const [ buttonDisabled, setButtonDisabled ] = useState( false );
-
-			return el(
-				Button,
-				{
-					key: props.clientId + '-refresh-button',
-					className: 'button button-secondary convertkit-block-refresh',
-					disabled: buttonDisabled,
-					icon: iconType( 'update' ),
-					onClick: function () {
-
-						// Refresh block definitions.
-						refreshBlocksDefinitions( props, setButtonDisabled );
-
-					}
-				}
-			);
-
-		}
+			return el(Button, {
+				key: props.clientId + '-refresh-button',
+				className: 'button button-secondary convertkit-block-refresh',
+				disabled: buttonDisabled,
+				icon: iconType('update'),
+				onClick() {
+					// Refresh block definitions.
+					refreshBlocksDefinitions(props, setButtonDisabled);
+				},
+			});
+		};
 
 		/**
 		 * Displays a new window with a given width and height to display the given URL.
@@ -710,27 +637,37 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 *
 		 * @since 	2.2.6
 		 *
-		 * @param 	object 	props 				Block properties.
-		 * @param 	object 	url 				URL to display in the popup window.
-		 * @param 	object 	setButtonDisabled 	Function to enable or disable the refresh button.
+		 * @param {Object}   props             Block properties.
+		 * @param {string}   url               URL to display in the popup window.
+		 * @param {Function} setButtonDisabled Function to enable or disable the refresh button.
 		 */
-		const showConvertKitPopupWindow = function ( props, url, setButtonDisabled ) {
-
+		const showConvertKitPopupWindow = function (
+			props,
+			url,
+			setButtonDisabled
+		) {
 			// Define popup width, height and positioning.
-			const 	width  = 640,
-					height = 750,
-					top    = ( window.screen.height - height ) / 2,
-					left   = ( window.screen.width - width ) / 2;
+			const width = 640,
+				height = 750,
+				top = (window.screen.height - height) / 2,
+				left = (window.screen.width - width) / 2;
 
 			// Open popup.
 			const convertKitPopup = window.open(
 				url + '&convertkit-modal=1',
 				'convertkit_popup_window',
-				'toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=' + width + ',height=' + height + ',top=' + top + ',left=' + left
+				'toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=' +
+					width +
+					',height=' +
+					height +
+					',top=' +
+					top +
+					',left=' +
+					left
 			);
 
 			// Center popup and focus.
-			convertKitPopup.moveTo( left, top );
+			convertKitPopup.moveTo(left, top);
 			convertKitPopup.focus();
 
 			// Refresh the block when the popup is closed using self.close().
@@ -740,19 +677,15 @@ function convertKitGutenbergRegisterBlock( block ) {
 			// document changes (e.g. as the user steps through a wizard), and doesn't fire when
 			// the window is closed.
 			// See https://stackoverflow.com/questions/9388380/capture-the-close-event-of-popup-window-in-javascript/48240128#48240128.
-			var convertKitPopupTimer = setInterval(
-				function () {
-					if ( convertKitPopup.closed ) {
-						clearInterval( convertKitPopupTimer );
+			const convertKitPopupTimer = setInterval(function () {
+				if (convertKitPopup.closed) {
+					clearInterval(convertKitPopupTimer);
 
-						// Refresh block.
-						refreshBlocksDefinitions( props, setButtonDisabled );
-					}
-				},
-				1000
-			);
-
-		}
+					// Refresh block.
+					refreshBlocksDefinitions(props, setButtonDisabled);
+				}
+			}, 1000);
+		};
 
 		/**
 		 * Refreshes this block's properties by:
@@ -762,188 +695,147 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 *
 		 * @since 	2.2.6
 		 *
-		 * @param   object  props   			Block properties.
-		 * @param 	object 	setButtonDisabled 	Function to enable or disable the refresh button.
-		 * @return  object          			Notice.
+		 * @param {Object}   props             Block properties.
+		 * @param {Function} setButtonDisabled Function to enable or disable the refresh button.
 		 */
-		const refreshBlocksDefinitions = function ( props, setButtonDisabled ) {
-
+		const refreshBlocksDefinitions = function (props, setButtonDisabled) {
 			// Define data for WordPress AJAX request.
-			let data = new FormData();
-			data.append( 'action', 'convertkit_get_blocks' );
-			data.append( 'nonce', convertkit_gutenberg.get_blocks_nonce );
+			const data = new FormData();
+			data.append('action', 'convertkit_get_blocks');
+			data.append('nonce', convertkit_gutenberg.get_blocks_nonce);
 
 			// Disable the button.
-			if ( typeof setButtonDisabled !== 'undefined' ) {
-				setButtonDisabled( true );
+			if (typeof setButtonDisabled !== 'undefined') {
+				setButtonDisabled(true);
 			}
 
 			// Send AJAX request.
-			fetch(
-				ajaxurl,
-				{
-					method: 'POST',
-					credentials: 'same-origin',
-					body: data
-				}
-			)
-			.then(
-				function ( response ) {
-
+			fetch(ajaxurl, {
+				method: 'POST',
+				credentials: 'same-origin',
+				body: data,
+			})
+				.then(function (response) {
 					// Convert response JSON string to object.
 					return response.json();
-
-				}
-			)
-			.then(
-				function ( response ) {
-
+				})
+				.then(function (response) {
 					// Update global ConvertKit Blocks object, so that any updated resources
 					// are reflected when adding new ConvertKit Blocks.
 					convertkit_blocks = response.data;
 
 					// Update this block's properties, so that has_access_token, has_resources
 					// and the resources properties are updated.
-					block = convertkit_blocks[ block.name ];
+					block = convertkit_blocks[block.name];
 
 					// Call setAttributes on props to trigger the editBlock() function, which will re-render
 					// the block, reflecting any changes to its properties.
-					props.setAttributes(
-						{
-							refresh: Date.now()
-						}
-					);
+					props.setAttributes({
+						refresh: Date.now(),
+					});
 
 					// Enable refresh button.
-					if ( typeof setButtonDisabled !== 'undefined' ) {
-						setButtonDisabled( false );
+					if (typeof setButtonDisabled !== 'undefined') {
+						setButtonDisabled(false);
 					}
-
-				}
-			)
-			.catch(
-				function ( error ) {
-
+				})
+				.catch(function (error) {
 					// Show an error in the Gutenberg editor.
-					wp.data.dispatch( 'core/notices' ).createErrorNotice(
-						'ConvertKit: ' + error,
-						{
-							id: 'convertkit-error'
-						}
-					);
+					wp.data
+						.dispatch('core/notices')
+						.createErrorNotice('ConvertKit: ' + error, {
+							id: 'convertkit-error',
+						});
 
 					// Enable refresh button.
-					setButtonDisabled( false );
-
-				}
-			);
-
-		}
+					setButtonDisabled(false);
+				});
+		};
 
 		// Register Block.
-		registerBlockType(
-			'convertkit/' + block.name,
-			{
-				title:      block.title,
-				description:block.description,
-				category:   block.category,
-				icon:       getIcon,
-				keywords: 	block.keywords,
-				attributes: block.attributes,
-				supports: 	block.supports,
-				example: 	{
-					attributes: {
-						is_gutenberg_example: true,
-					}
+		registerBlockType('convertkit/' + block.name, {
+			title: block.title,
+			description: block.description,
+			category: block.category,
+			icon: getIcon,
+			keywords: block.keywords,
+			attributes: block.attributes,
+			supports: block.supports,
+			example: {
+				attributes: {
+					is_gutenberg_example: true,
 				},
+			},
 
-				// Editor.
-				edit: editBlock,
+			// Editor.
+			edit: editBlock,
 
-				// Output.
-				save: saveBlock
-			}
-		);
-
-	} (
+			// Output.
+			save: saveBlock,
+		});
+	})(
 		window.wp.blocks,
 		window.wp.blockEditor,
 		window.wp.element,
 		window.wp.components
-	) );
-
+	);
 }
 
 /**
  * Registers pre-publish actions in Gutenberg's pre-publish checks panel.
  *
- * @since 	2.4.0
+ * @since 2.4.0
  *
- * @param 	object 	actions 	Pre-publish actions.
+ * @param {Object} actions Pre-publish actions.
  */
-function convertKitGutenbergRegisterPrePublishActions( actions ) {
-
-	( function ( plugins, editPost, element, components, data ) {
-
-		// Define some constants for the various items we'll use.
-		const el                                 = element.createElement;
-		const { ToggleControl }                  = components;
-		const { registerPlugin }                 = plugins;
-		const { PluginPrePublishPanel }          = editPost;
+function convertKitGutenbergRegisterPrePublishActions(actions) {
+	(function (plugins, editPost, element, components, data) {
+		const el = element.createElement;
+		const { ToggleControl } = components;
+		const { registerPlugin } = plugins;
+		const { PluginPrePublishPanel } = editPost;
 		const { useSelect, useDispatch, select } = data;
 
 		/**
-		 * Returns a PluginPrePublishPanel for this Plugin, comprising of all
+		 * Returns a PluginPrePublishPanel for this plugin, containing all
 		 * pre-publish actions.
 		 *
-		 * @since   2.4.0
-		 *
-		 * @return  PluginPrePublishPanel
+		 * @since 2.4.0
+		 * @return {WPElement|null} Pre-publish panel element or null if not a post.
 		 */
-		const renderPanel = function () {
+		const RenderPanel = function () {
+			// --- Hooks must be called first ---
+			const { meta } = useSelect((wpSelect) => ({
+				meta: wpSelect('core/editor').getEditedPostAttribute('meta'),
+			}));
 
-			// Bail if the Post Type isn't a Post.
-			if ( select( 'core/editor' ).getCurrentPostType() !== 'post' ) {
-				return;
+			const { editPost: wpEditPost } = useDispatch('core/editor');
+
+			const currentPostType = select('core/editor').getCurrentPostType();
+
+			// Bail early if not a 'post'
+			if (currentPostType !== 'post') {
+				return null;
 			}
 
-			// Build rows.
-			let rows = [];
-			for ( const [ name, action ] of Object.entries( actions ) ) {
+			// Build rows safely using .map()
+			const rows = Object.values(actions).map((action) => {
+				const key = '_convertkit_action_' + action.name;
 
-				const key          = '_convertkit_action_' + action.name;
-				const { meta }     = useSelect(
-					function ( select ) {
-						return {
-							meta: select( 'core/editor' ).getEditedPostAttribute( 'meta' ),
-						};
-					}
-				);
-				const { editPost } = useDispatch( 'core/editor', [ meta[ key ] ] );
+				return el(ToggleControl, {
+					key,
+					id: 'convertkit_action_' + action.name,
+					label: action.label,
+					help: action.description,
+					value: true,
+					checked: meta[key],
+					onChange(value) {
+						wpEditPost({ meta: { [key]: value } });
+					},
+				});
+			});
 
-				// Add row.
-				rows.push(
-					el(
-						ToggleControl,
-						{
-							id:  		'convertkit_action_' + action.name,
-							label: 		action.label,
-							help: 		action.description,
-							value:      true,
-							checked: 	meta[ key ],
-							onChange: 	function ( value ) {
-								editPost(
-									{
-										meta: { [ key ]: value },
-									}
-								);
-							}
-						}
-					)
-				);
-			}
-
-			// Return actions in the pre-publish panel.
+			// Return the pre-publish panel with rows
 			return el(
 				PluginPrePublishPanel,
 				{
@@ -953,25 +845,19 @@ function convertKitGutenbergRegisterPrePublishActions( actions ) {
 				},
 				rows
 			);
+		};
 
-		}
-
-		// Register pre-publish actions.
-		registerPlugin(
-			'convertkit-pre-publish-actions',
-			{
-				render: renderPanel
-			}
-		);
-
-	} (
+		// Register pre-publish actions
+		registerPlugin('convertkit-pre-publish-actions', {
+			render: RenderPanel,
+		});
+	})(
 		window.wp.plugins,
 		window.wp.editPost,
 		window.wp.element,
 		window.wp.components,
 		window.wp.data
-	) );
-
+	);
 }
 
 /**
@@ -982,20 +868,18 @@ function convertKitGutenbergRegisterPrePublishActions( actions ) {
  *
  * @since 	2.2.3
  *
- * @param 	string 	block_name 	Block Name.
- * @param 	string 	notice 		Notice to display.
- * @return 	object 				HTMLElement
+ * @param {string} block_name Block Name.
+ * @param {string} notice     Notice to display.
+ * @return {Object} 		   HTMLElement
  */
-function convertKitGutenbergDisplayBlockNotice( block_name, notice ) {
-
+function convertKitGutenbergDisplayBlockNotice(block_name, notice) {
 	return wp.element.createElement(
 		'div',
 		{
 			// convertkit-no-content class allows resources/backend/css/gutenberg.css
 			// to apply styling/branding to the block.
-			className: 'convertkit-' + block_name + ' convertkit-no-content'
+			className: 'convertkit-' + block_name + ' convertkit-no-content',
 		},
 		notice
 	);
-
 }

--- a/resources/backend/js/modal.js
+++ b/resources/backend/js/modal.js
@@ -3,160 +3,173 @@
  *
  * @since   1.9.6
  *
- * @package ConvertKit
  * @author ConvertKit
  */
 
-document.addEventListener(
-	'DOMContentLoaded',
-	function () {
+document.addEventListener('DOMContentLoaded', function () {
+	// Cancel.
+	document.body.addEventListener('click', function (e) {
+		// Check if a cancel button was clicked.
+		if (
+			e.target.matches(
+				'#convertkit-modal-body div.mce-cancel button, #convertkit-modal-body div.mce-cancel button *, #convertkit-quicktags-modal .media-toolbar .media-toolbar-secondary button.cancel'
+			)
+		) {
+			// TinyMCE.
+			if (
+				typeof tinyMCE !== 'undefined' &&
+				tinyMCE.activeEditor &&
+				!tinyMCE.activeEditor.isHidden()
+			) {
+				tinymce.activeEditor.windowManager.close();
+				return;
+			}
 
-		// Cancel.
-		document.body.addEventListener(
-			'click',
-			function ( e ) {
+			// Text Editor.
+			// Close the QuickTags modal.
+			convertKitQuickTagsModal.close();
+		}
+	});
 
-				// Check if a cancel button was clicked.
-				if ( e.target.matches( '#convertkit-modal-body div.mce-cancel button, #convertkit-modal-body div.mce-cancel button *, #convertkit-quicktags-modal .media-toolbar .media-toolbar-secondary button.cancel' ) ) {
+	// Insert.
+	document.body.addEventListener('click', function (e) {
+		// Check if an insert button was clicked.
+		if (
+			e.target.matches(
+				'#convertkit-modal-body div.mce-insert button, #convertkit-modal-body div.mce-insert button *, #convertkit-quicktags-modal .media-toolbar .media-toolbar-primary button.button-primary'
+			) ||
+			e.target.matches(
+				'button.wp-convertkit-refresh-resources, span.dashicons-update'
+			)
+		) {
+			// Prevent default action.
+			e.preventDefault();
 
-					// TinyMCE.
-					if ( typeof tinyMCE !== 'undefined' && tinyMCE.activeEditor && ! tinyMCE.activeEditor.isHidden() ) {
-						tinymce.activeEditor.windowManager.close();
-						return;
+			// Don't close the modal if the refresh button was clicked.
+			if (
+				e.target.matches(
+					'button.wp-convertkit-refresh-resources, span.dashicons-update'
+				)
+			) {
+				return;
+			}
+
+			// Get containing form.
+			const form = document.querySelector(
+				'form.convertkit-tinymce-popup'
+			);
+
+			// Build Shortcode.
+			let shortcode =
+				'[' + form.querySelector('input[name="shortcode"]').value;
+			const shortcodeClose =
+				form.querySelector('input[name="close_shortcode"]').value ===
+				'1';
+
+			// Iterate through form fields.
+			form.querySelectorAll('input, select').forEach(function (element) {
+				// Skip if no data-shortcode attribute.
+				if (!element.dataset.shortcode) {
+					return;
+				}
+
+				let val = '';
+
+				// If this is a color picker, #000000 will be submitted by the browser as the value
+				// even if no value / color was selected.
+				// Check the data-value attribute instead.
+				switch (element.type) {
+					case 'color':
+						val = element.dataset.value;
+						break;
+					default:
+						val = element.value;
+						break;
+				}
+
+				// Skip if the value is empty.
+				if (!val) {
+					return;
+				}
+				if (val.length === 0) {
+					return;
+				}
+
+				// Get shortcode attribute.
+				const key = element.dataset.shortcode;
+				const trim = element.dataset.trim !== '0';
+
+				// Skip if the shortcode is empty.
+				if (!key.length) {
+					return;
+				}
+
+				// Trim the value, unless the shortcode attribute disables string trimming.
+				if (trim) {
+					val = val.trim();
+				}
+
+				// Append attribute and value to shortcode string.
+				shortcode += ' ' + key.trim() + '="' + val + '"';
+			});
+
+			// Close Shortcode.
+			shortcode += ']';
+
+			// If the shortcode includes a closing element, append it now.
+			if (shortcodeClose) {
+				shortcode +=
+					'[/' +
+					form.querySelector('input[name="shortcode"]').value +
+					']';
+			}
+
+			// Depending on the editor type, insert the shortcode.
+			switch (form.querySelector('input[name="editor_type"]').value) {
+				case 'tinymce':
+					// Sanity check that a Visual editor exists and is active.
+					if (
+						typeof tinyMCE !== 'undefined' &&
+						tinyMCE.activeEditor &&
+						!tinyMCE.activeEditor.isHidden()
+					) {
+						// Insert into editor.
+						tinyMCE.activeEditor.execCommand(
+							'mceReplaceContent',
+							false,
+							shortcode
+						);
+
+						// Close modal.
+						tinyMCE.activeEditor.windowManager.close();
 					}
+					break;
 
-					// Text Editor.
-					// Close the QuickTags modal.
+				case 'quicktags':
+					// Insert into editor.
+					QTags.insertContent(shortcode);
+
+					// Close modal.
 					convertKitQuickTagsModal.close();
-				}
+					break;
 			}
-		);
-
-		// Insert.
-		document.body.addEventListener(
-			'click',
-			function ( e ) {
-
-				// Check if an insert button was clicked.
-				if ( e.target.matches( '#convertkit-modal-body div.mce-insert button, #convertkit-modal-body div.mce-insert button *, #convertkit-quicktags-modal .media-toolbar .media-toolbar-primary button.button-primary' ) ||
-					e.target.matches( 'button.wp-convertkit-refresh-resources, span.dashicons-update' ) ) {
-
-					// Prevent default action.
-					e.preventDefault();
-
-					// Don't close the modal if the refresh button was clicked.
-					if ( e.target.matches( 'button.wp-convertkit-refresh-resources, span.dashicons-update' ) ) {
-						return;
-					}
-
-					// Get containing form.
-					const form = document.querySelector( 'form.convertkit-tinymce-popup' );
-
-					// Build Shortcode.
-					let shortcode        = '[' + form.querySelector( 'input[name="shortcode"]' ).value;
-					const shortcodeClose = form.querySelector( 'input[name="close_shortcode"]' ).value === '1';
-
-					// Iterate through form fields.
-					form.querySelectorAll( 'input, select' ).forEach(
-						function ( element ) {
-							// Skip if no data-shortcode attribute.
-							if ( ! element.dataset.shortcode ) {
-								return;
-							}
-
-							let val = '';
-
-							// If this is a color picker, #000000 will be submitted by the browser as the value
-							// even if no value / color was selected.
-							// Check the data-value attribute instead.
-							switch ( element.type ) {
-								case 'color':
-									val = element.dataset.value;
-									break;
-								default:
-									val = element.value;
-									break;
-							}
-
-							// Skip if the value is empty.
-							if ( ! val ) {
-								return;
-							}
-							if ( val.length === 0 ) {
-								return;
-							}
-
-							// Get shortcode attribute.
-							const key  = element.dataset.shortcode;
-							const trim = element.dataset.trim !== '0';
-
-							// Skip if the shortcode is empty.
-							if ( ! key.length ) {
-								return;
-							}
-
-							// Trim the value, unless the shortcode attribute disables string trimming.
-							if ( trim ) {
-								val = val.trim();
-							}
-
-							// Append attribute and value to shortcode string.
-							shortcode += ' ' + key.trim() + '="' + val + '"';
-						}
-					);
-
-					// Close Shortcode.
-					shortcode += ']';
-
-					// If the shortcode includes a closing element, append it now.
-					if ( shortcodeClose ) {
-						shortcode += '[/' + form.querySelector( 'input[name="shortcode"]' ).value + ']';
-					}
-
-					// Depending on the editor type, insert the shortcode.
-					switch ( form.querySelector( 'input[name="editor_type"]' ).value ) {
-						case 'tinymce':
-							// Sanity check that a Visual editor exists and is active.
-							if ( typeof tinyMCE !== 'undefined' && tinyMCE.activeEditor && ! tinyMCE.activeEditor.isHidden() ) {
-								// Insert into editor.
-								tinyMCE.activeEditor.execCommand( 'mceReplaceContent', false, shortcode );
-
-								// Close modal.
-								tinyMCE.activeEditor.windowManager.close();
-							}
-							break;
-
-						case 'quicktags':
-							// Insert into editor.
-							QTags.insertContent( shortcode );
-
-							// Close modal.
-							convertKitQuickTagsModal.close();
-							break;
-					}
-				}
-			}
-		);
-
-	}
-);
+		}
+	});
+});
 
 // QuickTags: Setup Backbone Modal and Template.
-if ( typeof wp !== 'undefined' && typeof wp.media !== 'undefined' ) {
-
+if (typeof wp !== 'undefined' && typeof wp.media !== 'undefined') {
 	// Declared globally, as used in this file and quicktags.js.
-	var convertKitQuickTagsModal          = new wp.media.view.Modal(
-		{
-			controller: { trigger: function () {} },
-			className: 'convertkit-quicktags-modal'
-		}
-	);
-	const convertKitQuickTagsModalContent = wp.Backbone.View.extend(
-		{
-			template: wp.template( 'convertkit-quicktags-modal' )
-		}
-	);
-	convertKitQuickTagsModal.content( new convertKitQuickTagsModalContent() );
+	// Setting this as const or let causes a JS error stating that `convertKitQuickTagsModal` is not defined globally.
+	// eslint-disable-next-line no-var
+	var convertKitQuickTagsModal = new wp.media.view.Modal({
+		controller: { trigger() {} },
+		className: 'convertkit-quicktags-modal',
+	});
+	const convertKitQuickTagsModalContent = wp.Backbone.View.extend({
+		template: wp.template('convertkit-quicktags-modal'),
+	});
+	convertKitQuickTagsModal.content(new convertKitQuickTagsModalContent());
 
 	/**
 	 * Resets the content of the convertKitQuickTagsModal when closing.
@@ -165,11 +178,7 @@ if ( typeof wp !== 'undefined' && typeof wp.media !== 'undefined' ) {
 	 * code picking up data from the QuickTags modal, not the TinyMCE one, due to this 'stale'
 	 * modal remaining in the DOM, resulting in e.g. the tabbed UI not loading correctly.
 	 */
-	convertKitQuickTagsModal.on(
-		'close',
-		function ( e ) {
-			this.content( new convertKitQuickTagsModalContent() );
-		}
-	);
-
+	convertKitQuickTagsModal.on('close', function () {
+		this.content(new convertKitQuickTagsModalContent());
+	});
 }

--- a/resources/backend/js/preview-output.js
+++ b/resources/backend/js/preview-output.js
@@ -1,7 +1,6 @@
 /**
  * Preview Output Wizard
  *
- * @package ConvertKit
  * @author ConvertKit
  */
 
@@ -10,21 +9,14 @@
  *
  * @since 	1.9.8.5
  */
-jQuery( document ).ready(
-	function ( $ ) {
+jQuery(document).ready(function ($) {
+	// Appends a <select> field value to a link. Used for previews.
+	$('select.convertkit-preview-output-link')
+		.on('change', function () {
+			const target = $(this).data('target'),
+				link = $(this).data('link') + $(this).val();
 
-		// Appends a <select> field value to a link. Used for previews.
-		$( 'select.convertkit-preview-output-link' ).on(
-			'change',
-			function () {
-
-				var target = $( this ).data( 'target' ),
-				link       = $( this ).data( 'link' ) + $( this ).val();
-
-				$( target ).attr( 'href', link );
-
-			}
-		).trigger( 'change' );
-
-	}
-);
+			$(target).attr('href', link);
+		})
+		.trigger('change');
+});

--- a/resources/backend/js/quick-edit.js
+++ b/resources/backend/js/quick-edit.js
@@ -1,7 +1,6 @@
 /**
  * Quick Edit
  *
- * @package ConvertKit
  * @author ConvertKit
  */
 
@@ -18,54 +17,53 @@
  * @since 	1.9.8.0
  */
 
-document.addEventListener(
-	'DOMContentLoaded',
-	function () {
+document.addEventListener('DOMContentLoaded', function () {
+	const convertKitQuickEditWrapper = document.querySelector(
+			'tr#inline-edit .inline-edit-wrapper fieldset.inline-edit-col-left'
+		),
+		convertKitQuickEdit = document.querySelector('#convertkit-quick-edit'),
+		convertKitInlineEditPost = inlineEditPost.edit;
 
-		const convertKitQuickEditWrapper = document.querySelector( 'tr#inline-edit .inline-edit-wrapper fieldset.inline-edit-col-left' ),
-			convertKitQuickEdit          = document.querySelector( '#convertkit-quick-edit' ),
-			convertKitInlineEditPost     = inlineEditPost.edit;
+	if (convertKitQuickEditWrapper) {
+		// Move Quick Edit fields from footer into the hidden inline-edit table row.
+		convertKitQuickEditWrapper.appendChild(convertKitQuickEdit);
 
-		if ( convertKitQuickEditWrapper ) {
-			// Move Quick Edit fields from footer into the hidden inline-edit table row.
-			convertKitQuickEditWrapper.appendChild( convertKitQuickEdit );
+		// Show the Quick Edit fields, as they are now contained in the inline-edit row which WordPress will show/hide as necessary.
+		convertKitQuickEdit.style.display = 'block';
 
-			// Show the Quick Edit fields, as they are now contained in the inline-edit row which WordPress will show/hide as necessary.
-			convertKitQuickEdit.style.display = 'block';
+		// Extend WordPress' inline edit function to load the Plugin's Quick Edit fields.
+		inlineEditPost.edit = function (id) {
+			// Merge arguments from the original function.
+			convertKitInlineEditPost.apply(this, arguments);
 
-			// Extend WordPress' inline edit function to load the Plugin's Quick Edit fields.
-			inlineEditPost.edit = function ( id ) {
+			// Get Post ID.
+			if (typeof id === 'object') {
+				id = parseInt(this.getId(id));
+			}
 
-				// Merge arguments from the original function.
-				convertKitInlineEditPost.apply( this, arguments );
+			// Iterate through any ConvertKit inline data, assigning values to Quick Edit fields.
+			document
+				.querySelectorAll('#inline_' + id + ' .convertkit')
+				.forEach(function (element) {
+					// Get Quick Edit field.
+					const convertKitQuickEditField = document.querySelector(
+						'#convertkit-quick-edit select[name="wp-convertkit[' +
+							element.dataset.setting +
+							']"]'
+					);
 
-				// Get Post ID.
-				if (typeof id === 'object') {
-					id = parseInt( this.getId( id ) );
-				}
-
-				// Iterate through any ConvertKit inline data, assigning values to Quick Edit fields.
-				document.querySelectorAll( '#inline_' + id + ' .convertkit' ).forEach(
-					function ( element ) {
-						// Get Quick Edit field.
-						let convertKitQuickEditField = document.querySelector( '#convertkit-quick-edit select[name="wp-convertkit[' + element.dataset.setting + ']"]' );
-
-						// If the Quick Edit field doesn't exist for this setting, skip it.
-						// (e.g. we're editing a Post and this is a Landing Page setting, that isn't supported in Posts).
-						if ( convertKitQuickEditField === null ) {
-							return;
-						}
-
-						// Assign the setting's value to the setting's Quick Edit field.
-						convertKitQuickEditField.value = element.dataset.value;
+					// If the Quick Edit field doesn't exist for this setting, skip it.
+					// (e.g. we're editing a Post and this is a Landing Page setting, that isn't supported in Posts).
+					if (convertKitQuickEditField === null) {
+						return;
 					}
-				);
 
-				// Bind refresh resource event listeners.
-				convertKitRefreshResourcesInitEventListeners();
+					// Assign the setting's value to the setting's Quick Edit field.
+					convertKitQuickEditField.value = element.dataset.value;
+				});
 
-			};
-		}
-
+			// Bind refresh resource event listeners.
+			convertKitRefreshResourcesInitEventListeners();
+		};
 	}
-);
+});

--- a/resources/backend/js/quicktags.js
+++ b/resources/backend/js/quicktags.js
@@ -3,14 +3,11 @@
  *
  * @since   1.9.6
  *
- * @package ConvertKit
  * @author ConvertKit
  */
 
-for ( const block in convertkit_quicktags ) {
-
-	convertKitQuickTagRegister( convertkit_quicktags[ block ] );
-
+for (const block in convertkit_quicktags) {
+	convertKitQuickTagRegister(convertkit_quicktags[block]);
 }
 
 /**
@@ -19,75 +16,70 @@ for ( const block in convertkit_quicktags ) {
  *
  * @since 	1.9.6
  *
- * @param 	object 	block 	Block
+ * @param {Object} block Block.
  */
-function convertKitQuickTagRegister( block ) {
+function convertKitQuickTagRegister(block) {
+	QTags.addButton('convertkit-' + block.name, block.title, function () {
+		// Perform an AJAX call to load the modal's view.
+		fetch(ajaxurl, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams({
+				action: 'convertkit_admin_tinymce_output_modal',
+				nonce: convertkit_admin_tinymce.nonce,
+				editor_type: 'quicktags',
+				shortcode: block.name,
+			}),
+		})
+			.then(function (response) {
+				return response.text();
+			})
+			.then(function (result) {
+				// Show Modal.
+				convertKitQuickTagsModal.open();
 
-	QTags.addButton(
-		'convertkit-' + block.name,
-		block.title,
-		function () {
-
-			// Perform an AJAX call to load the modal's view.
-			fetch(
-				ajaxurl,
-				{
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/x-www-form-urlencoded',
-					},
-					body: new URLSearchParams(
-						{
-							'action': 		'convertkit_admin_tinymce_output_modal',
-							'nonce':  		convertkit_admin_tinymce.nonce,
-							'editor_type':  'quicktags',
-							'shortcode': 	block.name
-						}
+				// Get Modal.
+				const quicktagsModal = document.querySelector(
+						'div.convertkit-quicktags-modal div.media-modal.wp-core-ui'
 					),
-				}
-			)
-			.then(
-				function ( response ) {
-					return response.text();
-				}
-			)
-			.then(
-				function ( result ) {
-					// Show Modal.
-					convertKitQuickTagsModal.open();
+					quicktagsModalHeader = quicktagsModal.querySelector(
+						'div.media-frame-title'
+					),
+					quicktagsModalFooter = quicktagsModal.querySelector(
+						'div.media-frame-toolbar div.media-toolbar'
+					);
 
-					// Get Modal.
-					const quicktagsModal         = document.querySelector( 'div.convertkit-quicktags-modal div.media-modal.wp-core-ui' ),
-							quicktagsModalHeader = quicktagsModal.querySelector( 'div.media-frame-title' ),
-							quicktagsModalFooter = quicktagsModal.querySelector( 'div.media-frame-toolbar div.media-toolbar' );
+				// Resize Modal so it's not full screen.
+				quicktagsModal.style.width = block.modal.width + 'px';
+				quicktagsModal.style.height =
+					block.modal.height +
+					quicktagsModalHeader.offsetHeight +
+					quicktagsModalFooter.offsetHeight +
+					'px'; // Prevents a vertical scroll bar.
 
-					// Resize Modal so it's not full screen.
-					quicktagsModal.style.width  = block.modal.width + 'px';
-					quicktagsModal.style.height = block.modal.height + quicktagsModalHeader.offsetHeight + quicktagsModalFooter.offsetHeight + 'px'; // Prevents a vertical scroll bar.
+				// Set Title.
+				document.querySelector(
+					'#convertkit-quicktags-modal .media-frame-title h1'
+				).textContent = block.title;
 
-					// Set Title.
-					document.querySelector( '#convertkit-quicktags-modal .media-frame-title h1' ).textContent = block.title;
+				// Inject HTML into modal.
+				document.querySelector(
+					'#convertkit-quicktags-modal .media-frame-content'
+				).innerHTML = result;
 
-					// Inject HTML into modal.
-					document.querySelector( '#convertkit-quicktags-modal .media-frame-content' ).innerHTML = result;
+				// Initialize tabbed interface.
+				convertKitTabsInit();
 
-					// Initialize tabbed interface.
-					convertKitTabsInit();
+				// Listen for color input changes.
+				convertKitColorInputInit();
 
-					// Listen for color input changes.
-					convertKitColorInputInit();
-
-					// Bind refresh resource event listeners.
-					convertKitRefreshResourcesInitEventListeners();
-				}
-			)
-			.catch(
-				function ( error ) {
-					console.error( error );
-				}
-			);
-
-		}
-	);
-
+				// Bind refresh resource event listeners.
+				convertKitRefreshResourcesInitEventListeners();
+			})
+			.catch(function (error) {
+				console.error(error);
+			});
+	});
 }

--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -1,11 +1,13 @@
 /**
  * Refresh Resources
  *
- * @package ConvertKit
  * @author ConvertKit
  */
 
-document.addEventListener( 'DOMContentLoaded', convertKitRefreshResourcesInitEventListeners );
+document.addEventListener(
+	'DOMContentLoaded',
+	convertKitRefreshResourcesInitEventListeners
+);
 
 /**
  * Binds click event listeners to refresh resource buttons.
@@ -13,23 +15,19 @@ document.addEventListener( 'DOMContentLoaded', convertKitRefreshResourcesInitEve
  * @since 	2.4.4
  */
 function convertKitRefreshResourcesInitEventListeners() {
-
 	// Refreshes resources when the Refresh button is clicked.
-	document.querySelectorAll( 'button.wp-convertkit-refresh-resources' ).forEach(
-		function ( element ) {
-
+	document
+		.querySelectorAll('button.wp-convertkit-refresh-resources')
+		.forEach(function (element) {
 			element.addEventListener(
 				'click',
-				function ( e ) {
+				function (e) {
 					e.preventDefault();
-					convertKitRefreshResources( element );
+					convertKitRefreshResources(element);
 				},
 				false
 			);
-
-		},
-	);
-
+		});
 }
 
 /**
@@ -37,55 +35,43 @@ function convertKitRefreshResourcesInitEventListeners() {
  *
  * @since 	2.4.4
  *
- * @param 	DOMObject 	button
+ * @param {Object} button Button element.
  */
-function convertKitRefreshResources( button ) {
-
+function convertKitRefreshResources(button) {
 	// Remove any existing error notices that might be displayed.
 	convertKitRefreshResourcesRemoveNotices();
 
 	const resource = button.dataset.resource,
-			field  = button.dataset.field;
+		field = button.dataset.field;
 
 	// Disable button.
 	button.disabled = true;
 
 	// Perform AJAX request to refresh resource.
-	fetch(
-		convertkit_admin_refresh_resources.ajaxurl,
-		{
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/x-www-form-urlencoded'
-			},
-			body: new URLSearchParams(
-				{
-					action: 'convertkit_admin_refresh_resources',
-					nonce: convertkit_admin_refresh_resources.nonce,
-					resource: resource // e.g. forms, landing_pages, tags.
-				}
-			)
-		}
-	)
-	.then(
-		function ( response ) {
-
+	fetch(convertkit_admin_refresh_resources.ajaxurl, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/x-www-form-urlencoded',
+		},
+		body: new URLSearchParams({
+			action: 'convertkit_admin_refresh_resources',
+			nonce: convertkit_admin_refresh_resources.nonce,
+			resource, // e.g. forms, landing_pages, tags.
+		}),
+	})
+		.then(function (response) {
 			// Convert response JSON string to object.
 			return response.json();
-
-		}
-	)
-	.then(
-		function ( response ) {
-
-			if ( convertkit_admin_refresh_resources.debug ) {
-				console.log( response );
+		})
+		.then(function (response) {
+			if (convertkit_admin_refresh_resources.debug) {
+				console.log(response);
 			}
 
 			// Show an error if the request wasn't successful.
-			if ( ! response.success ) {
+			if (!response.success) {
 				// Show error notice.
-				convertKitRefreshResourcesOutputErrorNotice( response.data );
+				convertKitRefreshResourcesOutputErrorNotice(response.data);
 
 				// Enable button.
 				button.disabled = false;
@@ -93,114 +79,115 @@ function convertKitRefreshResources( button ) {
 				return;
 			}
 
-			const selectedOption = document.querySelector( field ).value;
+			const selectedOption = document.querySelector(field).value;
 
 			// Remove existing select options.
-			document.querySelectorAll( field + ' option' ).forEach(
-				function ( option ) {
+			document
+				.querySelectorAll(field + ' option')
+				.forEach(function (option) {
 					// Skip if data-preserve-on-refresh is specified, as this means we want to keep this specific option.
 					// This will be present on the 'None' and 'Default' options.
-					if ( option.dataset.preserveOnRefresh !== undefined ) {
-							return;
+					if (option.dataset.preserveOnRefresh !== undefined) {
+						return;
 					}
 
 					// Remove this option.
 					option.remove();
-				}
-			);
+				});
 
 			// Depending on the resource we're refreshing, populate the <select> options.
-			switch ( resource ) {
+			switch (resource) {
 				case 'restrict_content':
 					// Populate select `optgroup`` from response data, which comprises of Tags and Products.
 					// Tags.
-					response.data.tags.forEach(
-						function ( item ) {
-							document.querySelector( field + ' optgroup[data-resource=tags]' ).appendChild(
+					response.data.tags.forEach(function (item) {
+						document
+							.querySelector(
+								field + ' optgroup[data-resource=tags]'
+							)
+							.appendChild(
 								new Option(
 									item.name,
 									'tag_' + item.id,
 									false,
-									( selectedOption === 'tag_' + item.id )
+									selectedOption === 'tag_' + item.id
 								)
 							);
-						}
-					);
+					});
 
 					// Products.
-					response.data.products.forEach(
-						function ( item ) {
-							document.querySelector( field + ' optgroup[data-resource=products]' ).appendChild(
+					response.data.products.forEach(function (item) {
+						document
+							.querySelector(
+								field + ' optgroup[data-resource=products]'
+							)
+							.appendChild(
 								new Option(
 									item.name,
 									'product_' + item.id,
 									false,
-									( selectedOption === 'product_' + item.id )
+									selectedOption === 'product_' + item.id
 								)
 							);
-						}
-					);
+					});
 					break;
 
 				default:
 					// Populate select options from response data.
-					response.data.forEach(
-						function ( item ) {
+					response.data.forEach(function (item) {
+						// Define label.
+						let label = '';
+						switch (resource) {
+							case 'forms':
+								label =
+									item.name +
+									' [' +
+									(item.format !== ''
+										? item.format
+										: 'inline') +
+									']';
+								break;
 
-							// Define label.
-							let label = '';
-							switch ( resource ) {
-								case 'forms':
-									label = item.name + ' [' + ( item.format !== '' ? item.format : 'inline' ) + ']';
-									break;
+							default:
+								label = item.name;
+								break;
+						}
 
-								default:
-									label = item.name;
-									break;
-							}
-
-							// Add option.
-							document.querySelector( field ).add(
+						// Add option.
+						document
+							.querySelector(field)
+							.add(
 								new Option(
 									label,
 									item.id,
 									false,
-									( selectedOption == item.id ? true : false )
+									selectedOption === item.id ? true : false
 								)
 							);
-
-						}
-					);
+					});
 					break;
 			}
 
 			// Trigger a change event on the select field, to allow Select2 instances to repopulate their options.
-			document.querySelector( field ).dispatchEvent( new Event( 'change' ) );
+			document.querySelector(field).dispatchEvent(new Event('change'));
 
 			// Enable button.
 			button.disabled = false;
-
-		}
-	)
-	.catch(
-		function ( error ) {
-
-			if ( convertkit_admin_refresh_resources.debug ) {
-				console.error( error );
+		})
+		.catch(function (error) {
+			if (convertkit_admin_refresh_resources.debug) {
+				console.error(error);
 			}
 
 			// Remove any existing error notices that might be displayed.
 			convertKitRefreshResourcesRemoveNotices();
 
 			// Show error notice.
-			convertKitRefreshResourcesOutputErrorNotice( error );
+			convertKitRefreshResourcesOutputErrorNotice(error);
 
 			// Enable button.
 			button.disabled = false;
-
-		}
-	);
-
+		});
 }
 
 /**
@@ -209,21 +196,17 @@ function convertKitRefreshResources( button ) {
  * @since 	1.9.8.3
  */
 function convertKitRefreshResourcesRemoveNotices() {
-
 	// If we're editing a Page, Post or Custom Post Type in Gutenberg, use wp.data.dispatch to remove the error.
 	if (typeof wp !== 'undefined' && typeof wp.blockEditor !== 'undefined') {
 		// Gutenberg Editor.
-		wp.data.dispatch( 'core/notices' ).removeNotice( 'convertkit-error' );
+		wp.data.dispatch('core/notices').removeNotice('convertkit-error');
 		return;
 	}
 
 	// Classic Editor, WP_List_Table (Bulk/Quick edit) or Edit Term.
-	document.querySelectorAll( 'div.convertkit-error' ).forEach(
-		function ( div ) {
-			div.remove();
-		}
-	);
-
+	document.querySelectorAll('div.convertkit-error').forEach(function (div) {
+		div.remove();
+	});
 }
 
 /**
@@ -232,32 +215,37 @@ function convertKitRefreshResourcesRemoveNotices() {
  *
  * @since 	1.9.8.3
  *
- * @param 	string 	message 	Error message to display.
+ * @param {string} message Error message to display.
  */
-function convertKitRefreshResourcesOutputErrorNotice( message ) {
-
+function convertKitRefreshResourcesOutputErrorNotice(message) {
 	// Prefix the message with the Plugin name.
 	message = 'ConvertKit: ' + message;
 
 	// If we're editing a Page, Post or Custom Post Type in Gutenberg, use wp.data.dispatch to show the error.
-	if ( typeof wp !== 'undefined' && typeof wp.blockEditor !== 'undefined' ) {
+	if (typeof wp !== 'undefined' && typeof wp.blockEditor !== 'undefined') {
 		// Gutenberg Editor.
-		wp.data.dispatch( 'core/notices' ).createErrorNotice( message, { id: 'convertkit-error' } );
+		wp.data
+			.dispatch('core/notices')
+			.createErrorNotice(message, { id: 'convertkit-error' });
 		return;
 	}
 
 	// Classic Editor, WP_List_Table (Bulk/Quick edit) or Edit Term.
-	const notice = '<div id="message" class="error convertkit-error notice is-dismissible"><p>' + message + '</p></div>';
+	const notice =
+		'<div id="message" class="error convertkit-error notice is-dismissible"><p>' +
+		message +
+		'</p></div>';
 
 	// Append the WordPress style error notice, depending on the screen.
-	const insertLocation = document.querySelector( 'hr.wp-header-end' ) || document.querySelector( '#ajax-response' );
-	if ( insertLocation ) {
-		insertLocation.insertAdjacentHTML( 'afterend', notice );
+	const insertLocation =
+		document.querySelector('hr.wp-header-end') ||
+		document.querySelector('#ajax-response');
+	if (insertLocation) {
+		insertLocation.insertAdjacentHTML('afterend', notice);
 
 		// Notify WordPress that a new dismissible notification exists, triggering WordPress' makeNoticesDismissible() function,
 		// which adds a dismiss button and binds necessary events to hide the notification.
 		// We can't directly call makeNoticesDismissible(), as its minified function name will be different.
-		document.dispatchEvent( new Event( 'wp-updates-notice-added' ) );
+		document.dispatchEvent(new Event('wp-updates-notice-added'));
 	}
-
 }

--- a/resources/backend/js/select2.js
+++ b/resources/backend/js/select2.js
@@ -3,7 +3,6 @@
  *
  * @since   1.9.6.4
  *
- * @package ConvertKit
  * @author ConvertKit
  */
 
@@ -13,19 +12,11 @@
  * @since 	1.9.6.4
  */
 function convertKitSelect2Init() {
-
-	( function ( $ ) {
-
-		$( '.convertkit-select2' ).select2();
-
-	} )( jQuery );
-
+	(function ($) {
+		$('.convertkit-select2').select2();
+	})(jQuery);
 }
 
-jQuery( document ).ready(
-	function ( $ ) {
-
-		convertKitSelect2Init();
-
-	}
-);
+jQuery(document).ready(function () {
+	convertKitSelect2Init();
+});

--- a/resources/backend/js/settings-conditional-display.js
+++ b/resources/backend/js/settings-conditional-display.js
@@ -2,7 +2,6 @@
  * Displays or hides settings in the UI, depending on which settings are enabled
  * or disabled.
  *
- * @package ConvertKit
  * @author ConvertKit
  */
 
@@ -12,27 +11,19 @@
  *
  * @since 	2.2.4
  */
-document.addEventListener(
-	'DOMContentLoaded',
-	function () {
+document.addEventListener('DOMContentLoaded', function () {
+	// Update settings and refresh UI when a setting is changed.
+	const sourceInputs = document.querySelectorAll(
+		'.convertkit-conditional-display'
+	);
+	sourceInputs.forEach(function (input) {
+		input.addEventListener('change', function () {
+			convertKitConditionallyDisplaySettings(this);
+		});
 
-		// Update settings and refresh UI when a setting is changed.
-		const sourceInputs = document.querySelectorAll( '.convertkit-conditional-display' );
-		sourceInputs.forEach(
-			function ( input ) {
-				input.addEventListener(
-					'change',
-					function () {
-						convertKitConditionallyDisplaySettings( this );
-					}
-				);
-
-				convertKitConditionallyDisplaySettings( input );
-			}
-		);
-
-	}
-);
+		convertKitConditionallyDisplaySettings(input);
+	});
+});
 
 /**
  * Shows all table rows on a ConvertKit settings screen, and then hides
@@ -40,57 +31,59 @@ document.addEventListener(
  *
  * @since 	2.2.4
  *
- * @param 	object  input 	Element interacted with
+ * @param {Object} input Element interacted with.
  */
-function convertKitConditionallyDisplaySettings( input ) {
+function convertKitConditionallyDisplaySettings(input) {
+	const rows = document.querySelectorAll('table.form-table tr');
 
-	const rows = document.querySelectorAll( 'table.form-table tr' );
-
-	switch ( input.type ) {
+	switch (input.type) {
 		case 'checkbox':
 			// Show all rows.
-			rows.forEach( row => row.style.display = '' );
+			rows.forEach((row) => (row.style.display = ''));
 
 			// Don't do anything else if the checkbox is checked.
-			if ( input.checked ) {
+			if (input.checked) {
 				return;
 			}
 
 			// Iterate through the table rows, hiding any settings.
-			rows.forEach(
-				function ( row ) {
-					// Skip if this table row is for the setting we've just checked/unchecked.
-					if ( row.querySelector( `[id = "${input.id}"]` ) ) {
-						return;
-					}
-
-					// Hide this row if the input, select, link or span element within the row has the CSS class of the setting ID.
-					if ( row.querySelector( `input.${input.id}, select.${input.id}, a.${input.id}, span.${input.id}` ) ) {
-						row.style.display = 'none';
-					}
+			rows.forEach(function (row) {
+				// Skip if this table row is for the setting we've just checked/unchecked.
+				if (row.querySelector(`[id = "${input.id}"]`)) {
+					return;
 				}
-			);
+
+				// Hide this row if the input, select, link or span element within the row has the CSS class of the setting ID.
+				if (
+					row.querySelector(
+						`input.${input.id}, select.${input.id}, a.${input.id}, span.${input.id}`
+					)
+				) {
+					row.style.display = 'none';
+				}
+			});
 			break;
 
 		default:
 			// Iterate through the table rows, hiding any settings.
-			rows.forEach(
-				function ( row ) {
-					// Skip if this table row is for the setting we've just changed.
-					if ( row.querySelector( `[id = "${input.id}"]` ) ) {
-						return;
-					}
+			rows.forEach(function (row) {
+				// Skip if this table row is for the setting we've just changed.
+				if (row.querySelector(`[id = "${input.id}"]`)) {
+					return;
+				}
 
-					if ( row.querySelector( `input#${input.dataset.conditionalElement}` ) ) {
-						if ( input.value !== input.dataset.conditionalValue ) {
-							row.style.display = 'none';
-						} else {
-							row.style.display = '';
-						}
+				if (
+					row.querySelector(
+						`input#${input.dataset.conditionalElement}`
+					)
+				) {
+					if (input.value !== input.dataset.conditionalValue) {
+						row.style.display = 'none';
+					} else {
+						row.style.display = '';
 					}
 				}
-			);
+			});
 			break;
 	}
-
 }

--- a/resources/backend/js/setup-wizard.js
+++ b/resources/backend/js/setup-wizard.js
@@ -1,7 +1,6 @@
 /**
  * Setup Wizard
  *
- * @package ConvertKit
  * @author ConvertKit
  */
 
@@ -11,52 +10,31 @@
  *
  * @since 	1.9.8.4
  */
-document.addEventListener(
-	'DOMContentLoaded',
-	function () {
+document.addEventListener('DOMContentLoaded', function () {
+	// Redirect parent screen to a given URL after clicking a link that opens
+	// the href URL in a new tab.
+	document
+		.querySelectorAll('a.convertkit-redirect')
+		.forEach(function (element) {
+			element.addEventListener('click', function () {
+				// Delay the redirect, otherwise browsers will block opening the href attribute
+				// thinking it's a popup.
+				setTimeout(function () {
+					// Redirect the parent screen to the link's data-convertkit-redirect-url property.
+					window.location.href =
+						element.dataset.convertkitRedirectUrl;
+				}, 1000);
+			});
+		});
 
-		// Redirect parent screen to a given URL after clicking a link that opens
-		// the href URL in a new tab.
-		document.querySelectorAll( 'a.convertkit-redirect' ).forEach(
-			function ( element ) {
-
-				element.addEventListener(
-					'click',
-					function ( e ) {
-
-						// Delay the redirect, otherwise browsers will block opening the href attribute
-						// thinking it's a popup.
-						setTimeout(
-							function () {
-								// Redirect the parent screen to the link's data-convertkit-redirect-url property.
-								window.location.href = element.dataset.convertkitRedirectUrl;
-							},
-							1000
-						);
-
-					}
-				);
-
-			}
-		);
-
-		// Show a confirmation dialog for specific links.
-		document.querySelectorAll( 'a.convertkit-confirm' ).forEach(
-			function ( element ) {
-
-				element.addEventListener(
-					'click',
-					function ( e ) {
-
-						if ( ! confirm( element.dataset.message ) ) {
-							e.preventDefault();
-						}
-
-					}
-				);
-
-			}
-		);
-
-	}
-);
+	// Show a confirmation dialog for specific links.
+	document
+		.querySelectorAll('a.convertkit-confirm')
+		.forEach(function (element) {
+			element.addEventListener('click', function (e) {
+				if (!confirm(element.dataset.message)) {
+					e.preventDefault();
+				}
+			});
+		});
+});

--- a/resources/backend/js/tabs.js
+++ b/resources/backend/js/tabs.js
@@ -3,47 +3,59 @@
  *
  * @since   2.2.5
  *
- * @package ConvertKit
  * @author  ConvertKit
  */
 
+/* eslint-disable no-unused-vars */
 /**
  * Initializes tabbed interfaces.
  *
  * @since 2.2.5
  */
 function convertKitTabsInit() {
-
+	// eslint-disable-line no-unused-vars
 	// Safely call this function by destroying any previously initialized instances.
 	convertKitTabsDestroy();
 
 	// Iterate through all JS tab instances, initializing each one.
-	document.querySelectorAll( '.convertkit-js-tabs' ).forEach(
-		function ( navTabContainer ) {
-			const navTabPanelsContainer = navTabContainer.dataset.panelsContainer;
-			const navTabPanel           = navTabContainer.dataset.panel;
-			const navTabActive          = navTabContainer.dataset.active;
+	document
+		.querySelectorAll('.convertkit-js-tabs')
+		.forEach(function (navTabContainer) {
+			const navTabPanelsContainer =
+				navTabContainer.dataset.panelsContainer;
+			const navTabPanel = navTabContainer.dataset.panel;
+			const navTabActive = navTabContainer.dataset.active;
 
 			// Call update.
-			const activeTabElement = navTabContainer.querySelector( 'a.' + navTabActive );
-			convertKitTabsUpdate( navTabContainer, navTabPanelsContainer, navTabPanel, navTabActive, activeTabElement ? activeTabElement.getAttribute( 'href' ) : null );
+			const activeTabElement = navTabContainer.querySelector(
+				'a.' + navTabActive
+			);
+			convertKitTabsUpdate(
+				navTabContainer,
+				navTabPanelsContainer,
+				navTabPanel,
+				navTabActive,
+				activeTabElement ? activeTabElement.getAttribute('href') : null
+			);
 
 			// Register a listener when a tab is clicked.
-			navTabContainer.addEventListener(
-				'click',
-				function ( e ) {
-					if ( e.target.tagName === 'A' ) {
-						e.preventDefault();
+			navTabContainer.addEventListener('click', function (e) {
+				if (e.target.tagName === 'A') {
+					e.preventDefault();
 
-						// Update the UI to show the active tab and content associated with it.
-						convertKitTabsUpdate( navTabContainer, navTabPanelsContainer, navTabPanel, navTabActive, e.target.getAttribute( 'href' ) );
-					}
+					// Update the UI to show the active tab and content associated with it.
+					convertKitTabsUpdate(
+						navTabContainer,
+						navTabPanelsContainer,
+						navTabPanel,
+						navTabActive,
+						e.target.getAttribute('href')
+					);
 				}
-			);
-		}
-	);
-
+			});
+		});
 }
+/* eslint-enable no-unused-vars */
 
 /**
  * For the given active tab:
@@ -52,31 +64,45 @@ function convertKitTabsInit() {
  *
  * @since 1.0.0
  *
- * @param {Object} navTabContainer        <ul> Navigation Tab Container.
- * @param {string} navTabPanelsContainer  ID of element containing content panel, to display, which associate with the navigation tabs.
- * @param {string} navTabPanel            Class of elements containing content panels, to hide, which associate with the navigation tabs.
- * @param {string} navTabActive           Class to apply to the clicked activeTab element.
- * @param {string} activeTab              ID of <a> tab which has been selected / clicked.
+ * @param {Object} navTabContainer       <ul> Navigation Tab Container.
+ * @param {string} navTabPanelsContainer ID of element containing content panel, to display, which associate with the navigation tabs.
+ * @param {string} navTabPanel           Class of elements containing content panels, to hide, which associate with the navigation tabs.
+ * @param {string} navTabActive          Class to apply to the clicked activeTab element.
+ * @param {string} activeTab             ID of <a> tab which has been selected / clicked.
  */
-function convertKitTabsUpdate( navTabContainer, navTabPanelsContainer, navTabPanel, navTabActive, activeTab ) {
-
+function convertKitTabsUpdate(
+	navTabContainer,
+	navTabPanelsContainer,
+	navTabPanel,
+	navTabActive,
+	activeTab
+) {
 	// If we don't have an active tab at this point, we don't have any tabs, so bail.
-	if ( typeof activeTab === 'undefined' || activeTab === null || activeTab.length === 0 ) {
+	if (
+		typeof activeTab === 'undefined' ||
+		activeTab === null ||
+		activeTab.length === 0
+	) {
 		return;
 	}
 
 	// Deactivate all tabs in this container.
-	navTabContainer.querySelectorAll( 'a' ).forEach( tab => tab.classList.remove( navTabActive ) );
+	navTabContainer
+		.querySelectorAll('a')
+		.forEach((tab) => tab.classList.remove(navTabActive));
 
 	// Hide all panels in this container.
-	document.querySelectorAll( navTabPanelsContainer + ' ' + navTabPanel ).forEach( panel => panel.style.display = 'none' );
+	document
+		.querySelectorAll(navTabPanelsContainer + ' ' + navTabPanel)
+		.forEach((panel) => (panel.style.display = 'none'));
 
 	// Activate the clicked / selected tab in this container.
-	navTabContainer.querySelector( 'a[href="' + activeTab + '"]' ).classList.add( navTabActive );
+	navTabContainer
+		.querySelector('a[href="' + activeTab + '"]')
+		.classList.add(navTabActive);
 
 	// Show the active tab's panels in this container.
-	document.querySelector( activeTab ).style.display = 'block';
-
+	document.querySelector(activeTab).style.display = 'block';
 }
 
 /**
@@ -87,12 +113,12 @@ function convertKitTabsUpdate( navTabContainer, navTabPanelsContainer, navTabPan
  */
 function convertKitTabsDestroy() {
 	// Iterate through all JS tab instances, destroying each one.
-	document.querySelectorAll( '.convertkit-js-tabs' ).forEach(
-		function ( tabInstance ) {
+	document
+		.querySelectorAll('.convertkit-js-tabs')
+		.forEach(function (tabInstance) {
 			// Remove the click event listener.
-			tabInstance.removeEventListener( 'click', tabInstance.clickHandler );
+			tabInstance.removeEventListener('click', tabInstance.clickHandler);
 			// Remove the clickHandler property.
 			delete tabInstance.clickHandler;
-		}
-	);
+		});
 }

--- a/resources/backend/js/tinymce-broadcasts.js
+++ b/resources/backend/js/tinymce-broadcasts.js
@@ -3,8 +3,7 @@
  *
  * @since   1.9.6.9
  *
- * @package ConvertKit
  * @author ConvertKit
  */
 
-convertKitTinyMCERegisterPlugin( convertkit_shortcodes['broadcasts'] );
+convertKitTinyMCERegisterPlugin(convertkit_shortcodes.broadcasts);

--- a/resources/backend/js/tinymce-content.js
+++ b/resources/backend/js/tinymce-content.js
@@ -3,8 +3,7 @@
  *
  * @since   1.9.6
  *
- * @package ConvertKit
  * @author ConvertKit
  */
 
-convertKitTinyMCERegisterPlugin( convertkit_shortcodes['content'] );
+convertKitTinyMCERegisterPlugin(convertkit_shortcodes.content);

--- a/resources/backend/js/tinymce-form.js
+++ b/resources/backend/js/tinymce-form.js
@@ -3,8 +3,7 @@
  *
  * @since   1.9.6
  *
- * @package ConvertKit
  * @author ConvertKit
  */
 
-convertKitTinyMCERegisterPlugin( convertkit_shortcodes['form'] );
+convertKitTinyMCERegisterPlugin(convertkit_shortcodes.form);

--- a/resources/backend/js/tinymce-formtrigger.js
+++ b/resources/backend/js/tinymce-formtrigger.js
@@ -3,8 +3,7 @@
  *
  * @since   2.2.0
  *
- * @package ConvertKit
  * @author ConvertKit
  */
 
-convertKitTinyMCERegisterPlugin( convertkit_shortcodes['formtrigger'] );
+convertKitTinyMCERegisterPlugin(convertkit_shortcodes.formtrigger);

--- a/resources/backend/js/tinymce-product.js
+++ b/resources/backend/js/tinymce-product.js
@@ -3,8 +3,7 @@
  *
  * @since   1.9.8.5
  *
- * @package ConvertKit
  * @author ConvertKit
  */
 
-convertKitTinyMCERegisterPlugin( convertkit_shortcodes['product'] );
+convertKitTinyMCERegisterPlugin(convertkit_shortcodes.product);

--- a/resources/backend/js/wp-list-table-buttons.js
+++ b/resources/backend/js/wp-list-table-buttons.js
@@ -2,32 +2,25 @@
  * Moves any buttons added from the filter list in a WP_List_Table
  * to be displayed next to the "Add New" button.
  *
- * @package ConvertKit
  * @author ConvertKit
  */
 
-document.addEventListener(
-	'DOMContentLoaded',
-	function () {
+document.addEventListener('DOMContentLoaded', function () {
+	// Move any buttons from the filter list to display next to the Add New button.
+	document.querySelectorAll('ul.subsubsub span').forEach(function (span) {
+		// Ignore if not a ConvertKit Group Action.
+		if (!span.classList.contains('convertkit-action')) {
+			return;
+		}
 
-		// Move any buttons from the filter list to display next to the Add New button.
-		document.querySelectorAll( 'ul.subsubsub span' ).forEach(
-			function ( span ) {
-				// Ignore if not a ConvertKit Group Action.
-				if ( ! span.classList.contains( 'convertkit-action' ) ) {
-						return;
-				}
+		// Clone and move.
+		const clone = span.cloneNode(true);
+		clone.classList.remove('hidden');
+		document
+			.querySelector('a.page-title-action')
+			.insertAdjacentElement('afterend', clone);
 
-				// Clone and move.
-				let clone = span.cloneNode( true );
-				clone.classList.remove( 'hidden' );
-				document.querySelector( 'a.page-title-action' ).insertAdjacentElement( 'afterend', clone );
-
-				// Remove original.
-				span.parentElement.remove();
-
-			}
-		);
-
-	}
-);
+		// Remove original.
+		span.parentElement.remove();
+	});
+});


### PR DESCRIPTION
## Summary

Implement WordPress' recommended configuration for JS coding standards / linting on backend JS code:
https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/#installation
https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/#lint-js

Separate PRs to follow for Gutenberg backend JS coding standards, for ease of review.

## Testing

The GitHub action's coding-standards includes a new step to check JS coding standards.

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)