### PR TITLE
Improve JS Rules and Workflow

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,10 +13,15 @@ module.exports = {
 		convertkit_shortcodes: 'readonly',
 	},
 	rules: {
-		// Turn off specific rules
+		// Globals are not camelcase; in the future, we should update JS to meet camelcase standards.
 		camelcase: 'off',
+		// We don't yet manage dependencies, so some files report functions that are not defined, as they're in different files,
+		// despite being enqueued on the same page.
+		// In the future, we will use `wp-scripts build` to build single backend + frontend JS, which will fix this issue.
 		'no-undef': 'off',
+		// If debugging is enabled in the Plugin, we deliberately output to the console.
 		'no-console': 'off',
+		// We use a blocking confirm() dialog in the Plugin's Setup Wizard.
 		'no-alert': 'off',
 	},
 };

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -113,17 +113,17 @@ jobs:
         working-directory: ${{ env.PLUGIN_DIR }}
         run: composer update
 
-      # Installs WordPress scripts for CSS Coding Standards.
-      - name: Run npm install
-        working-directory: ${{ env.PLUGIN_DIR }}
-        run: npm install @wordpress/scripts --save-dev
-
       - name: Build PHP Autoloader
         working-directory: ${{ env.PLUGIN_DIR }}
         run: composer dump-autoload
 
+      # Installs WordPress scripts for CSS and JS Coding Standards.
+      - name: Run npm install
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: npm install
+
       # Run PHP Coding Standards on Tests.
-      - name: Run WordPress PHPCoding Standards on Tests
+      - name: Run WordPress PHP Coding Standards on Tests
         working-directory: ${{ env.PLUGIN_DIR }}
         if: ${{ matrix.php-versions == '8.1' || matrix.php-versions == '8.2' || matrix.php-versions == '8.3' || matrix.php-versions == '8.4' }}
         run: php vendor/bin/phpcs -q --standard=phpcs.tests.xml --report=checkstyle ./tests | cs2pr


### PR DESCRIPTION
## Summary

Explains why some JS standards are disabled, and updates the GitHub action to just call `npm install`, as `package.json` defines what will be installed.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)