### PR TITLE
Add Usage Tracking Checkbox

### DIFF
--- a/admin/section/class-convertkit-admin-section-general.php
+++ b/admin/section/class-convertkit-admin-section-general.php
@@ -472,6 +472,17 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 			)
 		);
 
+		add_settings_field(
+			'usage_tracking',
+			__( 'Usage Tracking', 'convertkit' ),
+			array( $this, 'usage_tracking_callback' ),
+			$this->settings_key,
+			$this->name . '-advanced',
+			array(
+				'label_for' => 'usage_tracking',
+			)
+		);
+
 	}
 
 	/**
@@ -976,6 +987,31 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 					esc_html__( 'For developers who require custom form designs through use of CSS, consider using the', 'convertkit' ),
 					esc_html__( 'or', 'convertkit' ),
 					esc_html__( 'integrations.', 'convertkit' )
+				),
+			)
+		);
+
+	}
+
+	/**
+	 * Renders the input for the Usage Tracking setting.
+	 *
+	 * @since   3.0.4
+	 */
+	public function usage_tracking_callback() {
+
+		// Output field.
+		$this->output_checkbox_field(
+			'usage_tracking',
+			'on',
+			$this->settings->usage_tracking(),
+			esc_html__( 'By allowing us to collect usage data, we can better understand which WordPress configurations, themes and plugins we should test.', 'convertkit' ),
+			array(
+				sprintf(
+					'%s <a href="%s" target="_blank">%s</a>',
+					esc_html__( 'Complete documentation on usage tracking can be found', 'convertkit' ),
+					$this->documentation_url(),
+					esc_html__( 'here', 'convertkit' )
 				),
 			)
 		);

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
@@ -262,8 +262,9 @@ class ConvertKit_Admin_Setup_Wizard_Plugin extends ConvertKit_Admin_Setup_Wizard
 				$settings = new ConvertKit_Settings();
 				$settings->save(
 					array(
-						'post_form' => ( isset( $_POST['post_form'] ) ? sanitize_text_field( wp_unslash( $_POST['post_form'] ) ) : '0' ),
-						'page_form' => ( isset( $_POST['page_form'] ) ? sanitize_text_field( wp_unslash( $_POST['page_form'] ) ) : '0' ),
+						'post_form'      => ( isset( $_POST['post_form'] ) ? sanitize_text_field( wp_unslash( $_POST['post_form'] ) ) : '0' ),
+						'page_form'      => ( isset( $_POST['page_form'] ) ? sanitize_text_field( wp_unslash( $_POST['page_form'] ) ) : '0' ),
+						'usage_tracking' => ( isset( $_POST['usage_tracking'] ) ? 'on' : '' ),
 					)
 				);
 				break;

--- a/includes/class-convertkit-settings.php
+++ b/includes/class-convertkit-settings.php
@@ -541,6 +541,19 @@ class ConvertKit_Settings {
 	}
 
 	/**
+	 * Returns whether usage tracking is enabled in the Plugin settings.
+	 *
+	 * @since   3.0.4
+	 *
+	 * @return  bool
+	 */
+	public function usage_tracking() {
+
+		return ( $this->settings['usage_tracking'] === 'on' ? true : false );
+
+	}
+
+	/**
 	 * The default settings, used when the ConvertKit Plugin Settings haven't been saved
 	 * e.g. on a new installation.
 	 *
@@ -574,6 +587,7 @@ class ConvertKit_Settings {
 			'debug'                              => '', // blank|on.
 			'no_scripts'                         => '', // blank|on.
 			'no_css'                             => '', // blank|on.
+			'usage_tracking'                     => '', // blank|on.
 		);
 
 		// Add Post Type Default Forms.

--- a/tests/EndToEnd/general/plugin-screens/PluginSettingsGeneralCest.php
+++ b/tests/EndToEnd/general/plugin-screens/PluginSettingsGeneralCest.php
@@ -45,6 +45,7 @@ class PluginSettingsGeneralCest
 		$I->seeInSource('<label for="debug">');
 		$I->seeInSource('<label for="no_scripts">');
 		$I->seeInSource('<label for="no_css">');
+		$I->seeInSource('<label for="usage_tracking">');
 
 		// Confirm that the UTM parameters exist for the documentation links.
 		$I->seeInSource('<a href="https://help.kit.com/en/articles/2502591-how-to-set-up-the-kit-plugin-on-your-wordpress-website?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" class="convertkit-docs" target="_blank">Help</a>');
@@ -771,6 +772,48 @@ class PluginSettingsGeneralCest
 
 	/**
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
+	 * when the Usage Tracking settings is unchecked, and that CSS is output
+	 * on the frontend web site.
+	 *
+	 * @since   3.0.4
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testEnableAndDisableUsageTrackingSetting(EndToEndTester $I)
+	{
+		// Setup Plugin.
+		$I->setupKitPlugin($I);
+
+		// Go to the Plugin's Settings Screen.
+		$I->loadKitSettingsGeneralScreen($I);
+
+		// Tick field.
+		$I->checkOption('#usage_tracking');
+
+		// Click the Save Changes button.
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check the field remains ticked.
+		$I->seeCheckboxIsChecked('#usage_tracking');
+
+		// Untick field.
+		$I->uncheckOption('#usage_tracking');
+
+		// Click the Save Changes button.
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check the field remains unticked.
+		$I->dontSeeCheckboxIsChecked('#usage_tracking');
+	}
+
+	/**
+	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
 	 * when using a Kit account with no resources, and that the applicable Form settings
 	 * fields do not display.
 	 *
@@ -808,6 +851,7 @@ class PluginSettingsGeneralCest
 		$I->checkOption('#debug');
 		$I->checkOption('#no_scripts');
 		$I->checkOption('#no_css');
+		$I->checkOption('#usage_tracking');
 
 		// Click the Save Changes button.
 		$I->click('Save Changes');
@@ -819,11 +863,13 @@ class PluginSettingsGeneralCest
 		$I->seeCheckboxIsChecked('#debug');
 		$I->seeCheckboxIsChecked('#no_scripts');
 		$I->seeCheckboxIsChecked('#no_css');
+		$I->seeCheckboxIsChecked('#usage_tracking');
 
 		// Untick fields.
 		$I->uncheckOption('#debug');
 		$I->uncheckOption('#no_scripts');
 		$I->uncheckOption('#no_css');
+		$I->uncheckOption('#usage_tracking');
 
 		// Click the Save Changes button.
 		$I->click('Save Changes');
@@ -835,6 +881,7 @@ class PluginSettingsGeneralCest
 		$I->dontSeeCheckboxIsChecked('#debug');
 		$I->dontSeeCheckboxIsChecked('#no_scripts');
 		$I->dontSeeCheckboxIsChecked('#no_css');
+		$I->dontSeeCheckboxIsChecked('#usage_tracking');
 	}
 
 	/**

--- a/tests/EndToEnd/general/plugin-screens/PluginSetupWizardCest.php
+++ b/tests/EndToEnd/general/plugin-screens/PluginSetupWizardCest.php
@@ -300,6 +300,89 @@ class PluginSetupWizardCest
 	}
 
 	/**
+	 * Test that the Setup Wizard > Usage Tracking setting is honored.
+	 *
+	 * @since   3.0.4
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testSetupWizardUsageTrackingSetting(EndToEndTester $I)
+	{
+		// Activate Plugin.
+		$this->_activatePlugin($I);
+
+		// Wait for the Plugin Setup Wizard screen to load.
+		$I->waitForElementVisible('body.convertkit');
+
+		// Define Plugin settings.
+		$I->setupKitPluginNoDefaultForms($I);
+
+		// Create a Page and a Post, so that preview links display.
+		$I->havePostInDatabase(
+			[
+				'post_title'  => 'Kit: Setup Wizard: Page',
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			]
+		);
+		$I->havePostInDatabase(
+			[
+				'post_title'  => 'Kit: Setup Wizard: Post',
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+			]
+		);
+
+		// Load Step 2/3.
+		$I->amOnAdminPage('options.php?page=convertkit-setup&step=2');
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen($I, 2, 'Display an email capture form');
+
+		// Uncheck Usage Tracking setting.
+		$I->uncheckOption('#wp-convertkit-usage-tracking');
+
+		// Click Finish Setup button.
+		$I->click('Finish Setup');
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen($I, 3, 'Setup complete');
+
+		// Click Plugin Settings.
+		$I->click('Plugin Settings');
+
+		// Confirm that Plugin Settings screen contains no errors.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Usage Tracking setting is unticked on the Plugin Settings screen.
+		$I->dontSeeCheckboxIsChecked('#usage_tracking');
+
+		// Load Step 2/3 on the Setup Wizard screen again.
+		$I->amOnAdminPage('options.php?page=convertkit-setup&step=2');
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen($I, 2, 'Display an email capture form');
+
+		// Check Usage Tracking setting.
+		$I->checkOption('#wp-convertkit-usage-tracking');
+
+		// Click Finish Setup button.
+		$I->click('Finish Setup');
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen($I, 3, 'Setup complete');
+
+		// Click Plugin Settings.
+		$I->click('Plugin Settings');
+
+		// Confirm that Plugin Settings screen contains no errors.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Usage Tracking setting is ticked on the Plugin Settings screen.
+		$I->seeCheckboxIsChecked('#usage_tracking');
+	}
+
+	/**
 	 * Test that the Setup Wizard > Form Configuration screen works as expected
 	 * when API credentials are supplied for a Kit account that contains
 	 * no forms.

--- a/tests/Support/Helper/KitPlugin.php
+++ b/tests/Support/Helper/KitPlugin.php
@@ -60,6 +60,7 @@ class KitPlugin extends \Codeception\Module
 	 *     @type string $recaptcha_site_key         reCAPTCHA Site Key (if specified, used instead of CONVERTKIT_API_RECAPTCHA_SITE_KEY).
 	 *     @type string $recaptcha_secret_key       reCAPTCHA Secret Key (if specified, used instead of CONVERTKIT_API_RECAPTCHA_SECRET_KEY).
 	 *     @type string $recaptcha_minimum_score    reCAPTCHA Minimum Score (if specified, used instead of 0.5).
+	 *     @type string $usage_tracking             Usage Tracking (if specified, used instead of on).
 	 * }
 	 */
 	public function setupKitPlugin($I, $options = false)
@@ -71,6 +72,7 @@ class KitPlugin extends \Codeception\Module
 			'debug'                              => 'on',
 			'no_scripts'                         => '',
 			'no_css'                             => '',
+			'usage_tracking'                     => '',
 			'post_form'                          => $_ENV['CONVERTKIT_API_FORM_ID'],
 			'page_form'                          => $_ENV['CONVERTKIT_API_FORM_ID'],
 			'product_form'                       => $_ENV['CONVERTKIT_API_FORM_ID'],

--- a/views/backend/setup-wizard/convertkit-setup/content-2.php
+++ b/views/backend/setup-wizard/convertkit-setup/content-2.php
@@ -134,5 +134,23 @@ if ( ! $this->forms->exist() ) {
 			?>
 		</p>
 	</div>
+
+	<div>
+		<label for="wp-convertkit-usage-tracking">
+			<?php esc_html_e( 'Usage tracking', 'convertkit' ); ?>
+		</label>
+
+		<input type="checkbox" name="usage_tracking" id="wp-convertkit-usage-tracking" value="on" checked />
+
+		<p class="description">
+			<?php
+			printf(
+				'%s <a href="https://help.kit.com/en/articles/2502591-how-to-set-up-the-kit-plugin-on-your-wordpress-website" target="_blank">%s</a>',
+				esc_html__( 'By allowing us to collect usage data, we can better understand which WordPress configurations, themes and plugins we should test. Complete documentation on usage tracking can be found', 'convertkit' ),
+				esc_html__( 'here', 'convertkit' )
+			);
+			?>
+		</p>
+	</div>
 	<?php
 }


### PR DESCRIPTION
## Summary

Adds a `Usage Tracking` checkbox to the Plugin settings and Setup Wizard screens, that creators may opt in to, so we can later track the Plugins and Themes installed on sites with the Kit Plugin installed, to help improve compatibility and migrations.

<img width="995" height="213" alt="Screenshot 2025-10-06 at 19 46 36" src="https://github.com/user-attachments/assets/178acb64-09a6-4b72-aace-e7bea11ef40d" />

We can't automatically collect this without consent:
https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/#7-plugins-may-not-track-users-without-their-consent

We don't have an API endpoint to track this on the `wordpress` namespace, but we can add one later, and then start collecting some data.

## Testing

- `testEnableAndDisableUsageTrackingSetting`: Test that no PHP errors or notices are displayed on the Plugin's Setting screen when the Usage Tracking settings is unchecked, and that CSS is output on the frontend web site.
- `testSetupWizardUsageTrackingSetting`: Test that the Setup Wizard > Usage Tracking setting is honored.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)