### PR TITLE
Form Builder: Subscribe to Form: Upgrade Test

### DIFF
--- a/tests/EndToEnd/general/other/UpgradePathsCest.php
+++ b/tests/EndToEnd/general/other/UpgradePathsCest.php
@@ -216,6 +216,58 @@ class UpgradePathsCest
 	}
 
 	/**
+	 * Tests that the form_id column is added to the form entries table when upgrading to 3.0.4 or later.
+	 *
+	 * @since   3.0.4
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testUpdateFormEntriesTableAddsFormIDColumn(EndToEndTester $I)
+	{
+		// Create the form entries table as if it were created in 3.0.3 or older,
+		// without the form_id column.
+		$I->importSql(
+			[
+				"CREATE TABLE IF NOT EXISTS wp_kit_form_entries (
+				`id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+				`post_id` int(11) NOT NULL,
+				`first_name` varchar(191) NOT NULL DEFAULT '',
+				`email` varchar(191) NOT NULL DEFAULT '',
+				`custom_fields` text,
+				`tag_id` int(11) NOT NULL,
+				`sequence_id` int(11) NOT NULL,
+				`created_at` datetime NOT NULL,
+				`updated_at` datetime NOT NULL,
+				`api_result` varchar(191) NOT NULL DEFAULT 'success',
+				`api_error` text,
+				PRIMARY KEY (`id`),
+				KEY `post_id` (`post_id`),
+				KEY `first_name` (`first_name`),
+				KEY `email` (`email`),
+				KEY `tag_id` (`tag_id`),
+				KEY `sequence_id` (`sequence_id`),
+				KEY `api_result` (`api_result`)
+			) AUTO_INCREMENT=1",
+			]
+		);
+
+		// Confirm the form entries table is created.
+		$I->seeTableInDatabase('wp_kit_form_entries');
+
+		// Setup Kit Plugin.
+		$I->setupKitPlugin($I);
+
+		// Define an installation version older than 3.0.3.
+		$I->haveOptionInDatabase('convertkit_version', '3.0.0');
+
+		// Activate the Plugin.
+		$I->activateKitPlugin($I, false);
+
+		// Confirm the form entries table now has the form_id column.
+		$I->seeColumnInDatabase('wp_kit_form_entries', 'form_id');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/Support/Helper/KitPlugin.php
+++ b/tests/Support/Helper/KitPlugin.php
@@ -1014,4 +1014,27 @@ class KitPlugin extends \Codeception\Module
 	{
 		$this->getModule(\lucatume\WPBrowser\Module\WPDb::class)->_getDbh()->query('TRUNCATE TABLE ' . $table);
 	}
+
+	/**
+	 * Helper method to assert that the given column exists in the given table.
+	 *
+	 * @since   3.0.4
+	 *
+	 * @param   string $table Table name.
+	 * @param   string $column Column name.
+	 */
+	public function seeColumnInDatabase(string $table, string $column): void
+	{
+		$wpDb = $this->getModule(\lucatume\WPBrowser\Module\WPDb::class);
+		$dbh  = $wpDb->_getDbh();
+
+		$stmt = $dbh->prepare("SHOW COLUMNS FROM {$table} LIKE ?");
+		$stmt->execute([ $column ]);
+		$result = $stmt->fetch();
+
+		$this->assertNotEmpty(
+			$result,
+			"Failed asserting that column '{$column}' exists in table '{$table}'."
+		);
+	}
 }


### PR DESCRIPTION
## Summary

Adds a test to confirm the `form_id` column is added to the `wp_kit_form_entries` table when upgrading from 3.0.3 or lower.

## Testing

`testUpdateFormEntriesTableAddsFormIDColumn`: Tests that the form_id column is added to the form entries table when upgrading to 3.0.4 or later.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)